### PR TITLE
Make asset copy task add to dist/ for dist-custom-elements target

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -14,14 +14,12 @@ export const config: Config = {
       copy: [
         {
           src: '../node_modules/@shoelace-style/shoelace/dist/assets/icons',
-          dest: 'assets/icons',
+          dest: 'dist/assets/icons',
           warn: true,
         },
       ],
     },
-    {
-      type: 'docs-readme',
-    },
+    // This target is used only for the development live server.
     {
       type: 'www',
       serviceWorker: null, // disable service workers


### PR DESCRIPTION
This prevents the assets folder from being copied to the project
root, where it can be accidentally committed to version control.
