### PR TITLE
Extract a component for the menubar

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,22 +8,47 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { OgmRecord } from "./utils/record";
 export { OgmRecord } from "./utils/record";
 export namespace Components {
+    interface OgmMenubar {
+        "record": OgmRecord;
+    }
     interface OgmMetadata {
         "fieldNames": string[];
         "record": OgmRecord;
     }
     interface OgmSidebar {
+        "open": boolean;
         "record": OgmRecord;
     }
     interface OgmViewer {
         "recordUrl": string;
     }
 }
+export interface OgmMenubarCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLOgmMenubarElement;
+}
 export interface OgmViewerCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOgmViewerElement;
 }
 declare global {
+    interface HTMLOgmMenubarElementEventMap {
+        "sidebarToggled": any;
+    }
+    interface HTMLOgmMenubarElement extends Components.OgmMenubar, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLOgmMenubarElementEventMap>(type: K, listener: (this: HTMLOgmMenubarElement, ev: OgmMenubarCustomEvent<HTMLOgmMenubarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLOgmMenubarElementEventMap>(type: K, listener: (this: HTMLOgmMenubarElement, ev: OgmMenubarCustomEvent<HTMLOgmMenubarElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLOgmMenubarElement: {
+        prototype: HTMLOgmMenubarElement;
+        new (): HTMLOgmMenubarElement;
+    };
     interface HTMLOgmMetadataElement extends Components.OgmMetadata, HTMLStencilElement {
     }
     var HTMLOgmMetadataElement: {
@@ -38,7 +63,6 @@ declare global {
     };
     interface HTMLOgmViewerElementEventMap {
         "recordLoaded": OgmRecord;
-        "sidebarToggled": boolean;
     }
     interface HTMLOgmViewerElement extends Components.OgmViewer, HTMLStencilElement {
         addEventListener<K extends keyof HTMLOgmViewerElementEventMap>(type: K, listener: (this: HTMLOgmViewerElement, ev: OgmViewerCustomEvent<HTMLOgmViewerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -55,25 +79,31 @@ declare global {
         new (): HTMLOgmViewerElement;
     };
     interface HTMLElementTagNameMap {
+        "ogm-menubar": HTMLOgmMenubarElement;
         "ogm-metadata": HTMLOgmMetadataElement;
         "ogm-sidebar": HTMLOgmSidebarElement;
         "ogm-viewer": HTMLOgmViewerElement;
     }
 }
 declare namespace LocalJSX {
+    interface OgmMenubar {
+        "onSidebarToggled"?: (event: OgmMenubarCustomEvent<any>) => void;
+        "record"?: OgmRecord;
+    }
     interface OgmMetadata {
         "fieldNames"?: string[];
         "record"?: OgmRecord;
     }
     interface OgmSidebar {
+        "open"?: boolean;
         "record"?: OgmRecord;
     }
     interface OgmViewer {
         "onRecordLoaded"?: (event: OgmViewerCustomEvent<OgmRecord>) => void;
-        "onSidebarToggled"?: (event: OgmViewerCustomEvent<boolean>) => void;
         "recordUrl"?: string;
     }
     interface IntrinsicElements {
+        "ogm-menubar": OgmMenubar;
         "ogm-metadata": OgmMetadata;
         "ogm-sidebar": OgmSidebar;
         "ogm-viewer": OgmViewer;
@@ -83,6 +113,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "ogm-menubar": LocalJSX.OgmMenubar & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;
             "ogm-metadata": LocalJSX.OgmMetadata & JSXBase.HTMLAttributes<HTMLOgmMetadataElement>;
             "ogm-sidebar": LocalJSX.OgmSidebar & JSXBase.HTMLAttributes<HTMLOgmSidebarElement>;
             "ogm-viewer": LocalJSX.OgmViewer & JSXBase.HTMLAttributes<HTMLOgmViewerElement>;

--- a/src/components/ogm-menubar/ogm-menubar.css
+++ b/src/components/ogm-menubar/ogm-menubar.css
@@ -1,0 +1,22 @@
+.menubar {
+  display: flex;
+  align-items: center;
+  padding: var(--sl-spacing-x-small);
+  background-color: var(--sl-panel-background-color);
+  border-top: calc(var(--sl-panel-border-width) * 2) solid var(--accent-color);
+  border-bottom: var(--sl-panel-border-width) solid var(--sl-panel-border-color);
+
+  /* shadow above map and sidebar */
+  position: relative;
+  z-index: 701;
+  box-shadow: 0 2px 6px 0px var(--sl-overlay-background-color);
+}
+
+.title {
+  font-size: var(--sl-font-size-large);
+}
+
+.menu-button {
+  font-size: var(--sl-font-size-x-large);
+  margin-right: var(--sl-spacing-x-small);
+}

--- a/src/components/ogm-menubar/ogm-menubar.tsx
+++ b/src/components/ogm-menubar/ogm-menubar.tsx
@@ -1,0 +1,29 @@
+import { Component, Element, Prop, EventEmitter, h, Event } from '@stencil/core';
+import type { OgmRecord } from '../../utils/record';
+
+import _SlIconButton from '@shoelace-style/shoelace/dist/components/icon-button/icon-button.component.js';
+import _SlTooltip from '@shoelace-style/shoelace/dist/components/tooltip/tooltip.component.js';
+
+@Component({
+  tag: 'ogm-menubar',
+  styleUrl: 'ogm-menubar.css',
+  shadow: true,
+})
+export class OgmMenubar {
+  @Element() el: HTMLElement;
+  @Prop() record: OgmRecord;
+  @Event() sidebarToggled: EventEmitter;
+
+  // Don't render anything if no record is loaded
+  render() {
+    if (!this.record) return;
+    return (
+      <div class="menubar">
+        <sl-tooltip content="Open sidebar">
+          <sl-icon-button name="list" label="Open sidebar" class="menu-button" onclick={() => this.sidebarToggled.emit()}></sl-icon-button>
+        </sl-tooltip>
+        <div class="title">{this.record.title}</div>
+      </div>
+    );
+  }
+}

--- a/src/components/ogm-menubar/test/ogm-menubar.spec.tsx
+++ b/src/components/ogm-menubar/test/ogm-menubar.spec.tsx
@@ -1,0 +1,38 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { OgmMenubar } from '../ogm-menubar';
+import { OgmRecord } from '../../../utils/record';
+
+describe('ogm-menubar', () => {
+  describe('with a record', () => {
+    it('renders the record title', async () => {
+      const record = new OgmRecord({
+        id: 'stanford-ff359cr8805',
+        dct_title_s: 'Coho Salmon Watersheds: San Francisco Bay Area, California, 2011',
+        dct_description_sm: [],
+        gbl_resourceType_sm: ['Polygon data'],
+        gbl_resourceClass_sm: ['Datasets'],
+        dct_accessRights_s: 'Public',
+        gbl_mdVersion_s: 'Aardvark',
+      });
+
+      const page = await newSpecPage({
+        components: [OgmMenubar],
+        template: () => <ogm-menubar record={record}></ogm-menubar>,
+      });
+
+      expect(page.body.innerHTML).toContain('Coho Salmon Watersheds: San Francisco Bay Area, California, 2011');
+    });
+  });
+
+  describe('without a record', () => {
+    it('does not render anything', async () => {
+      const page = await newSpecPage({
+        components: [OgmMenubar],
+        html: `<ogm-menubar></ogm-menubar>`,
+      });
+
+      expect(page.body).not.toContain('div class="menubar">');
+    });
+  });
+});

--- a/src/components/ogm-sidebar/ogm-sidebar.tsx
+++ b/src/components/ogm-sidebar/ogm-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Listen, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 
 import '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
 import '@shoelace-style/shoelace/dist/components/icon/icon.js';
@@ -7,7 +7,6 @@ import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';
 
 import type { OgmRecord } from '../../utils/record';
-import type SlDrawer from '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
 import type SlTabGroup from '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 
 @Component({
@@ -18,13 +17,12 @@ import type SlTabGroup from '@shoelace-style/shoelace/dist/components/tab-group/
 export class OgmSidebar {
   @Element() el: HTMLElement;
   @Prop() record: OgmRecord;
+  @Prop() open: boolean = false;
 
-  private drawer: SlDrawer;
   private tabs: SlTabGroup;
 
-  // Find the drawer and tab group elements after the component is loaded
+  // Find the tab group element after the component is loaded
   componentDidLoad() {
-    this.drawer = this.el.shadowRoot.querySelector('sl-drawer');
     this.tabs = this.el.shadowRoot.querySelector('sl-tab-group');
   }
 
@@ -34,17 +32,15 @@ export class OgmSidebar {
     if (activeTab) return activeTab.getAttribute('panel');
   }
 
-  // Open/close the sidebar; if open and no active tab, show the info tab
-  @Listen('sidebarToggled', { target: 'window' })
-  toggleDrawer() {
-    this.drawer.open = !this.drawer.open;
-    if (this.drawer.open && !this.activeTabPanel) this.tabs.show('information');
+  // If open and no active tab, show the info tab
+  componentDidUpdate() {
+    if (this.open && !this.activeTabPanel) this.tabs.show('information');
   }
 
   render() {
     return (
       <Host>
-        <sl-drawer label="Sidebar" placement="start" class="sidebar" contained no-header>
+        <sl-drawer label="Sidebar" placement="start" class="sidebar" contained no-header open={this.open}>
           <sl-tab-group placement="start">
             <sl-tab slot="nav" panel="information">
               <sl-icon name="info-circle-fill" label="Information"></sl-icon>

--- a/src/components/ogm-viewer/ogm-viewer.css
+++ b/src/components/ogm-viewer/ogm-viewer.css
@@ -1,3 +1,4 @@
+/* Import these here, at the top level */
 @import '~maplibre-gl/dist/maplibre-gl.css';
 @import '~@shoelace-style/shoelace/dist/themes/light.css';
 
@@ -12,38 +13,17 @@
   position: relative;
   font-family: var(--sl-font-sans);
   border: var(--sl-panel-border-width) solid var(--sl-panel-border-color);
+  width: 100%;
+  min-height: 400px;
 }
 
 .map-container {
   position: relative;
 }
 
-.menubar {
-  display: flex;
-  align-items: center;
-  padding: var(--sl-spacing-x-small);
-  background-color: var(--sl-panel-background-color);
-  border-top: calc(var(--sl-panel-border-width) * 2) solid var(--accent-color);
-  border-bottom: var(--sl-panel-border-width) solid var(--sl-panel-border-color);
-
-  /* shadow above map and sidebar */
-  position: relative;
-  z-index: 701;
-  box-shadow: 0 2px 6px 0px var(--sl-overlay-background-color);
-}
-
-.title {
-  font-size: var(--sl-font-size-large);
-}
-
-.menu-button {
-  font-size: var(--sl-font-size-x-large);
-  margin-right: var(--sl-spacing-x-small);
-}
-
 #map {
   width: 100%;
-  height: 100%;
+  height: 400px;
   position: relative;
 }
 


### PR DESCRIPTION
This uses a more traditional strategy of having the top-level
state live in the viewer component, and the menubar passes up
an event that changes that state, which then trickles down to
the sidebar.

Might fix some intermittent issues with the sidebar not opening
or closing when it should.
