### PR TITLE
For single unlabelled download, label it with the format

### DIFF
--- a/src/components/ogm-metadata/ogm-metadata.tsx
+++ b/src/components/ogm-metadata/ogm-metadata.tsx
@@ -55,7 +55,7 @@ export class OgmMetadata {
 
   // References is a special field with multiple parts
   private renderReferences() {
-    const downloadLinks = this.record.references.downloadLinks;
+    const downloadLinks = this.record.downloadLinks;
     const metadataLinks = this.record.references.metadataLinks;
     if (!downloadLinks.length && !metadataLinks.length) return;
 

--- a/src/components/ogm-metadata/test/ogm-metadata.spec.tsx
+++ b/src/components/ogm-metadata/test/ogm-metadata.spec.tsx
@@ -171,7 +171,7 @@ describe('ogm-metadata', () => {
   });
 
   describe('with single download URL', () => {
-    it('renders a single download link', async () => {
+    it('renders a single download link using the format as label', async () => {
       const record = new OgmRecord({
         id: 'stanford-ff359cr8805',
         dct_title_s: 'Coho Salmon Watersheds: San Francisco Bay Area, California, 2011',
@@ -183,6 +183,7 @@ describe('ogm-metadata', () => {
         gbl_resourceClass_sm: ['Datasets'],
         dct_accessRights_s: 'Public',
         gbl_mdVersion_s: 'Aardvark',
+        dct_format_s: 'Shapefile',
         dct_references_s: JSON.stringify({
           'http://schema.org/downloadUrl': 'https://stacks.stanford.edu/object/vx572wx7854',
         }),
@@ -202,7 +203,7 @@ describe('ogm-metadata', () => {
               <div class="field downloads">
                 <dt>Downloads</dt>
                 <dd>
-                  <a href="https://stacks.stanford.edu/object/vx572wx7854">Object</a>
+                  <a href="https://stacks.stanford.edu/object/vx572wx7854">Shapefile</a>
                 </dd>
               </div>
             </div>

--- a/src/utils/record.ts
+++ b/src/utils/record.ts
@@ -99,6 +99,7 @@ export const OGM_FIELD_NAMES = {
   georeferenced: 'Georeferenced',
   subjects: 'Subject',
   mdVersion: 'Metadata Version',
+  format: 'Format',
 };
 
 /**
@@ -149,6 +150,7 @@ export class OgmRecord {
   suppressed?: boolean;
   georeferenced?: boolean;
   subjects?: string[];
+  format?: string;
 
   constructor(data: GeoBlacklightSchemaAardvark) {
     if (data.gbl_mdVersion_s !== 'Aardvark') {
@@ -185,6 +187,7 @@ export class OgmRecord {
     this.geometry = data.locn_geometry;
     this.bbox = data.dcat_bbox;
     this.centroid = data.dcat_centroid;
+    this.format = data.dct_format_s;
 
     // Parse references from JSON string
     this.references = new References(data.dct_references_s || '{}');
@@ -192,14 +195,21 @@ export class OgmRecord {
 
   // String used for attribution of map layers. Uses, in order of preference:
   // - rightsHolder(s)
-  // - publisher(s)
   // - creator(s)
   // - provider
   get attribution() {
     if (this.rightsHolder && this.rightsHolder.length > 0) return this.rightsHolder.join(', ');
-    if (this.publishers && this.publishers.length > 0) return this.publishers.join(', ');
     if (this.creators && this.creators.length > 0) return this.creators.join(', ');
     if (this.provider) return this.provider;
+  }
+
+  // List of download links with URL and label
+  get downloadLinks() {
+    return this.references.downloadLinks.map(link => {
+      // If no label for download, use the format, falling back to 'Object'
+      if (!link.label) link.label = this.format || 'Object';
+      return link;
+    });
   }
 
   // Convert ENVELOPE syntax to LngLatBounds

--- a/src/utils/references.ts
+++ b/src/utils/references.ts
@@ -74,7 +74,7 @@ export class References {
     const fieldContents = this.references['http://schema.org/downloadUrl'];
     if (!fieldContents) return [];
     if (Array.isArray(fieldContents)) return fieldContents;
-    return [{ url: fieldContents, label: 'Object' }];
+    return [{ url: fieldContents, label: null }];
   }
 
   // List of metadata links with URL and label


### PR DESCRIPTION
This is GeoBlacklight's current behavior.
