### PR TITLE
fix fullscreen map height

### DIFF
--- a/src/components/ogm-viewer/ogm-viewer.css
+++ b/src/components/ogm-viewer/ogm-viewer.css
@@ -16,11 +16,12 @@
   border: var(--sl-panel-border-width) solid var(--sl-panel-border-color);
   width: 100%;
   min-height: 400px;
+  height: 100%;
 }
 
 .map-container {
   position: relative;
-  height: 400px;
+  height: 100%;
 }
 
 #map {


### PR DESCRIPTION
closes #64 

<img width="1509" height="940" alt="Screenshot 2025-07-31 at 11 08 49 AM" src="https://github.com/user-attachments/assets/aa17542d-24e7-4403-a6ea-0d766c43d518" />
<img width="1087" height="759" alt="Screenshot 2025-07-31 at 11 08 39 AM" src="https://github.com/user-attachments/assets/90c31997-21ce-4100-9cd3-751445d859d2" />
