### PR TITLE
Fix an issue with container height calculation

### DIFF
--- a/src/components/ogm-menubar/ogm-menubar.css
+++ b/src/components/ogm-menubar/ogm-menubar.css
@@ -1,4 +1,4 @@
-.menubar {
+:host {
   display: flex;
   align-items: center;
   gap: var(--sl-spacing-small);

--- a/src/components/ogm-viewer/ogm-viewer.css
+++ b/src/components/ogm-viewer/ogm-viewer.css
@@ -9,7 +9,8 @@
 }
 
 .container {
-  display: block;
+  display: flex;
+  flex-direction: column;
   position: relative;
   font-family: var(--sl-font-sans);
   border: var(--sl-panel-border-width) solid var(--sl-panel-border-color);
@@ -20,5 +21,6 @@
 
 .map-container {
   position: relative;
+  min-height: 400px;
   height: 100%;
 }


### PR DESCRIPTION
The overall container was obtaining a calculated height that did
not include the menubar's height, leading to slightly weird-looking
border and behavior in fullscreen.

Changing its display to flex fixed that.
