### PR TITLE
IIIF Component -  Adds IIIF manifest viewer support via Clover integration

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,6 +10,10 @@ import { EaseToOptions } from "maplibre-gl";
 export { OgmRecord } from "./utils/record";
 export { EaseToOptions } from "maplibre-gl";
 export namespace Components {
+    interface OgmIiif {
+        "manifestUrl": string;
+        "theme": 'light' | 'dark';
+    }
     interface OgmMap {
         "easeMapTo": (options: EaseToOptions) => Promise<maplibregl.Map>;
         "previewOpacity": number;
@@ -52,6 +56,12 @@ export interface OgmSettingsCustomEvent<T> extends CustomEvent<T> {
     target: HTMLOgmSettingsElement;
 }
 declare global {
+    interface HTMLOgmIiifElement extends Components.OgmIiif, HTMLStencilElement {
+    }
+    var HTMLOgmIiifElement: {
+        prototype: HTMLOgmIiifElement;
+        new (): HTMLOgmIiifElement;
+    };
     interface HTMLOgmMapElementEventMap {
         "mapIdle": void;
         "mapLoading": void;
@@ -123,6 +133,7 @@ declare global {
         new (): HTMLOgmViewerElement;
     };
     interface HTMLElementTagNameMap {
+        "ogm-iiif": HTMLOgmIiifElement;
         "ogm-map": HTMLOgmMapElement;
         "ogm-menubar": HTMLOgmMenubarElement;
         "ogm-metadata": HTMLOgmMetadataElement;
@@ -132,6 +143,10 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface OgmIiif {
+        "manifestUrl"?: string;
+        "theme"?: 'light' | 'dark';
+    }
     interface OgmMap {
         "onMapIdle"?: (event: OgmMapCustomEvent<void>) => void;
         "onMapLoading"?: (event: OgmMapCustomEvent<void>) => void;
@@ -164,6 +179,7 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface IntrinsicElements {
+        "ogm-iiif": OgmIiif;
         "ogm-map": OgmMap;
         "ogm-menubar": OgmMenubar;
         "ogm-metadata": OgmMetadata;
@@ -176,6 +192,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "ogm-iiif": LocalJSX.OgmIiif & JSXBase.HTMLAttributes<HTMLOgmIiifElement>;
             "ogm-map": LocalJSX.OgmMap & JSXBase.HTMLAttributes<HTMLOgmMapElement>;
             "ogm-menubar": LocalJSX.OgmMenubar & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;
             "ogm-metadata": LocalJSX.OgmMetadata & JSXBase.HTMLAttributes<HTMLOgmMetadataElement>;

--- a/src/components/ogm-iiif/ogm-iiif.css
+++ b/src/components/ogm-iiif/ogm-iiif.css
@@ -31,5 +31,3 @@ clover-viewer {
   justify-content: center;
   pointer-events: none;
 }
-
-

--- a/src/components/ogm-iiif/ogm-iiif.css
+++ b/src/components/ogm-iiif/ogm-iiif.css
@@ -1,0 +1,35 @@
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.wrapper {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+clover-viewer {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.clover-frame {
+  display: block;
+  border: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+

--- a/src/components/ogm-iiif/ogm-iiif.tsx
+++ b/src/components/ogm-iiif/ogm-iiif.tsx
@@ -1,0 +1,115 @@
+import { Component, Prop, State, Watch, h, Host } from '@stencil/core';
+
+@Component({
+  tag: 'ogm-iiif',
+  styleUrl: 'ogm-iiif.css',
+  shadow: false,
+})
+export class OgmIiif {
+  @Prop() manifestUrl: string;
+  @Prop() theme: 'light' | 'dark';
+
+  @State() cloverReady: boolean = false;
+  @State() loadError: boolean = false;
+  @State() frameLoaded: boolean = false;
+  private frameEl?: HTMLIFrameElement;
+
+  async componentWillLoad() {
+    // When rendering via iframe, no external script load is needed here.
+    this.cloverReady = true;
+  }
+
+  // Minimal HTML document to sandbox Clover IIIF inside an iframe.
+  private buildIframeSrcdoc(url: string): string {
+    const escapedUrl = url.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+    return `
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://www.unpkg.com/@samvera/clover-iiif@latest/dist/web-components/index.umd.js"></script>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      clover-viewer { display: block; height: 100%; width: 100%; }
+      /* Hide Clover header entirely */
+      .clover-viewer-header { display: none !important; }
+    </style>
+  </head>
+  <body class="${this.theme ? `sl-theme-${this.theme}` : ''}">
+    <clover-viewer iiif-content="${escapedUrl}"></clover-viewer>
+    <script>
+      // Turn off information panel as soon as toggle is available
+      (function() {
+        function tryCloseInfo() {
+          var t = document.getElementById('information-toggle');
+          if (!t) return false;
+          var state = t.getAttribute('aria-checked') || t.getAttribute('data-state');
+          if (state === 'true' || state === 'checked') {
+            t.click();
+          }
+          return true;
+        }
+        if (!tryCloseInfo()) {
+          var mo = new MutationObserver(function() {
+            if (tryCloseInfo()) mo.disconnect();
+          });
+          mo.observe(document.body, { childList: true, subtree: true });
+          setTimeout(function(){ mo.disconnect(); }, 5000);
+        }
+      })();
+    </script>
+  </body>
+</html>
+`.trim();
+  }
+
+  private updateIframeThemeClass() {
+    if (!this.frameEl?.contentWindow?.document?.body) return;
+    const body = this.frameEl.contentWindow.document.body;
+    body.classList.remove('sl-theme-light', 'sl-theme-dark');
+    if (this.theme) body.classList.add(`sl-theme-${this.theme}`);
+  }
+
+  componentDidLoad() {
+    this.updateIframeThemeClass();
+  }
+
+  // React to external theme prop changes
+  @Watch('theme')
+  onThemeChanged() {
+    this.updateIframeThemeClass();
+  }
+
+  render() {
+    if (this.loadError || !this.manifestUrl) return;
+    const srcdoc = this.buildIframeSrcdoc(this.manifestUrl);
+    return (
+      <Host class={this.theme && `sl-theme-${this.theme}`}>
+        <div class="wrapper">
+          {!this.frameLoaded && (
+            <div class="loading">
+              <sl-spinner></sl-spinner>
+            </div>
+          )}
+          {this.cloverReady && (
+            <iframe
+              class="clover-frame"
+              part="clover-frame"
+              srcdoc={srcdoc}
+              loading="lazy"
+              ref={el => (this.frameEl = el as HTMLIFrameElement)}
+              onLoad={() => {
+                this.frameLoaded = true;
+                this.updateIframeThemeClass();
+              }}
+              title="Clover IIIF Viewer"
+            ></iframe>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}
+
+

--- a/src/components/ogm-iiif/ogm-iiif.tsx
+++ b/src/components/ogm-iiif/ogm-iiif.tsx
@@ -134,19 +134,9 @@ export class OgmIiif {
               <sl-spinner></sl-spinner>
             </div>
           )}
-          {this.cloverReady && (
-            <iframe
-              class="clover-frame"
-              part="clover-frame"
-              srcdoc={srcdoc}
-              loading="lazy"
-              title="Clover IIIF Viewer"
-            ></iframe>
-          )}
+          {this.cloverReady && <iframe class="clover-frame" part="clover-frame" srcdoc={srcdoc} loading="lazy" title="Clover IIIF Viewer"></iframe>}
         </div>
       </Host>
     );
   }
 }
-
-

--- a/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
+++ b/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
@@ -133,7 +133,7 @@ describe('ogm-iiif', () => {
       });
 
       expect(page.root.getAttribute('class')).toBe('sl-theme-light');
-      
+
       const iframe = page.root.querySelector('iframe');
       const srcdoc = iframe.getAttribute('srcdoc');
       expect(srcdoc).toContain('sl-theme-light');
@@ -147,7 +147,7 @@ describe('ogm-iiif', () => {
       });
 
       expect(page.root.getAttribute('class')).toBe('sl-theme-dark');
-      
+
       const iframe = page.root.querySelector('iframe');
       const srcdoc = iframe.getAttribute('srcdoc');
       expect(srcdoc).toContain('sl-theme-dark');
@@ -161,7 +161,7 @@ describe('ogm-iiif', () => {
       });
 
       expect(page.root.getAttribute('class')).toBeNull();
-      
+
       const iframe = page.root.querySelector('iframe');
       const srcdoc = iframe.getAttribute('srcdoc');
       expect(srcdoc).toContain('<body class="">');
@@ -200,4 +200,3 @@ describe('ogm-iiif', () => {
     });
   });
 });
-

--- a/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
+++ b/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
@@ -1,0 +1,203 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { OgmIiif } from '../ogm-iiif';
+
+describe('ogm-iiif', () => {
+  describe('with no manifestUrl', () => {
+    it('does not render anything', async () => {
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif></ogm-iiif>,
+      });
+
+      expect(page.root).toEqualHtml(`
+        <ogm-iiif>
+        </ogm-iiif>
+      `);
+    });
+  });
+
+  describe('with empty manifestUrl', () => {
+    it('does not render anything', async () => {
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl=""></ogm-iiif>,
+      });
+
+      // Empty string is falsy, so component doesn't render (same as no manifestUrl)
+      expect(page.root.querySelector('iframe')).toBeNull();
+      expect(page.root.querySelector('.wrapper')).toBeNull();
+    });
+  });
+
+  describe('with a manifestUrl', () => {
+    it('renders iframe with correct attributes', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      expect(iframe).toBeTruthy();
+      expect(iframe.getAttribute('class')).toBe('clover-frame');
+      expect(iframe.getAttribute('title')).toBe('Clover IIIF Viewer');
+      expect(iframe.getAttribute('loading')).toBe('lazy');
+      expect(iframe.getAttribute('part')).toBe('clover-frame');
+    });
+
+    it('includes Clover UMD script in srcdoc', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('https://www.unpkg.com/@samvera/clover-iiif@latest/dist/web-components/index.umd.js');
+    });
+
+    it('includes clover-viewer element with correct iiif-content attribute', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('<clover-viewer');
+      expect(srcdoc).toContain('iiif-content="https://example.com/manifest.json"');
+    });
+
+    it('escapes URL properly in srcdoc', async () => {
+      const manifestUrl = 'https://example.com/manifest.json?param=value&other=test';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('&amp;');
+      expect(srcdoc).not.toContain('&other=');
+    });
+
+    it('includes CSS to hide clover-viewer-header', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('.clover-viewer-header');
+      expect(srcdoc).toContain('display: none !important');
+    });
+
+    it('includes script to close info panel', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('information-toggle');
+      expect(srcdoc).toContain('MutationObserver');
+    });
+
+    it('shows loading spinner initially', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const spinner = page.root.querySelector('sl-spinner');
+      expect(spinner).toBeTruthy();
+      const loadingDiv = page.root.querySelector('.loading');
+      expect(loadingDiv).toBeTruthy();
+    });
+  });
+
+  describe('with theme prop', () => {
+    it('applies light theme class', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl} theme="light"></ogm-iiif>,
+      });
+
+      expect(page.root.getAttribute('class')).toBe('sl-theme-light');
+      
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('sl-theme-light');
+    });
+
+    it('applies dark theme class', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl} theme="dark"></ogm-iiif>,
+      });
+
+      expect(page.root.getAttribute('class')).toBe('sl-theme-dark');
+      
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('sl-theme-dark');
+    });
+
+    it('handles missing theme prop gracefully', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      expect(page.root.getAttribute('class')).toBeNull();
+      
+      const iframe = page.root.querySelector('iframe');
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).toContain('<body class="">');
+    });
+  });
+
+  describe('with loadError state', () => {
+    it('does not render when loadError is true', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      // Set loadError state
+      page.rootInstance.loadError = true;
+      await page.waitForChanges();
+
+      expect(page.root.querySelector('iframe')).toBeNull();
+      expect(page.root.querySelector('.wrapper')).toBeNull();
+    });
+  });
+
+  describe('wrapper structure', () => {
+    it('renders wrapper div with correct structure', async () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const page = await newSpecPage({
+        components: [OgmIiif],
+        template: () => <ogm-iiif manifestUrl={manifestUrl}></ogm-iiif>,
+      });
+
+      const wrapper = page.root.querySelector('.wrapper');
+      expect(wrapper).toBeTruthy();
+      expect(wrapper.querySelector('iframe')).toBeTruthy();
+      expect(wrapper.querySelector('.loading')).toBeTruthy();
+    });
+  });
+});
+

--- a/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
+++ b/src/components/ogm-iiif/test/ogm-iiif.spec.tsx
@@ -1,3 +1,8 @@
+// Mock Shoelace spinner import for Jest (must be before other imports)
+jest.mock('@shoelace-style/shoelace/dist/components/spinner/spinner.js', () => ({}), {
+  virtual: true,
+});
+
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { OgmIiif } from '../ogm-iiif';

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -46,7 +46,9 @@ export class OgmMap {
     });
     this.containerEl = this.el.parentElement.parentElement;
     this.addControls();
-    this.map.on('idle', () => this.mapIdle.emit());
+    this.map.on('idle', () => {
+      if (this.el.isConnected) this.mapIdle.emit();
+    });
   }
 
   // Add controls to the map
@@ -109,6 +111,13 @@ export class OgmMap {
     this.previewLayers = [];
     this.boundsSource = null;
     this.previewSource = null;
+  }
+
+  // Clean up map listeners and instance when removed from DOM
+  disconnectedCallback() {
+    try {
+      this.map?.remove();
+    } catch {}
   }
 
   // Fit the map to the provided bounds

--- a/src/components/ogm-viewer/ogm-viewer.css
+++ b/src/components/ogm-viewer/ogm-viewer.css
@@ -22,5 +22,5 @@
 .map-container {
   position: relative;
   min-height: 400px;
-  height: 100%;
+  height: 70vh; /* ensure IIIF viewer/map has a concrete height */
 }

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -106,11 +106,7 @@ export class OgmViewer {
         <ogm-menubar theme={theme} record={this.record} loading={this.loading}></ogm-menubar>
         <div class="map-container">
           <ogm-sidebar theme={theme} record={this.record} open={this.sidebarOpen}></ogm-sidebar>
-          {iiif ? (
-            <ogm-iiif theme={theme} manifestUrl={iiif}></ogm-iiif>
-          ) : (
-            <ogm-map preview-opacity={this.previewOpacity} theme={theme} record={this.record}></ogm-map>
-          )}
+          {iiif ? <ogm-iiif theme={theme} manifestUrl={iiif}></ogm-iiif> : <ogm-map preview-opacity={this.previewOpacity} theme={theme} record={this.record}></ogm-map>}
         </div>
       </div>
     );

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -30,15 +30,14 @@ export class OgmViewer {
   @State() sidebarOpen: boolean = false;
   @State() previewOpacity: number = 100;
   @State() loading: boolean = false;
+  @State() resolvedTheme: 'light' | 'dark';
 
   private map: HTMLOgmMapElement;
 
   async componentWillLoad() {
-    // If no theme provided, detect the user's system preference
-    if (!this.theme) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      this.theme = prefersDark ? 'dark' : 'light';
-    }
+    // Resolve theme without mutating @Prop()
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    this.resolvedTheme = this.theme ?? (prefersDark ? 'dark' : 'light');
 
     // Fetch the record if a URL is provided
     if (this.recordUrl) return await this.updateRecord();
@@ -52,13 +51,20 @@ export class OgmViewer {
   @Listen('sidebarToggled')
   toggleSidebar() {
     this.sidebarOpen = !this.sidebarOpen;
-    if (this.sidebarOpen) this.map.easeMapTo({ padding: { left: 400 } });
-    else this.map.easeMapTo({ padding: { left: 20 } });
+    if (this.map) {
+      if (this.sidebarOpen) this.map.easeMapTo({ padding: { left: 400 } });
+      else this.map.easeMapTo({ padding: { left: 20 } });
+    }
   }
 
   @Watch('recordUrl')
   async updateRecord() {
     this.record = await this.fetchRecord(this.recordUrl);
+  }
+  @Watch('theme')
+  onThemeChanged(newTheme: 'light' | 'dark') {
+    if (!newTheme) return;
+    this.resolvedTheme = newTheme;
   }
 
   // Listen for opacity changes from the sidebar and adjust the preview layer
@@ -70,13 +76,19 @@ export class OgmViewer {
   // Listen for map to report loading started
   @Listen('mapLoading')
   setLoadingStarted() {
-    this.loading = true;
+    // Defer to avoid mutating state during render
+    requestAnimationFrame(() => {
+      this.loading = true;
+    });
   }
 
   // Listen for map to report loading finished
   @Listen('mapIdle')
   setLoadingFinished() {
-    this.loading = false;
+    // Defer to avoid mutating state during render
+    requestAnimationFrame(() => {
+      this.loading = false;
+    });
   }
 
   // Fetch a record by URL and parse it into an OgmRecord instance
@@ -87,12 +99,18 @@ export class OgmViewer {
   }
 
   render() {
+    const iiif = this.record?.references?.iiifManifest;
+    const theme = this.resolvedTheme;
     return (
-      <div class={`container sl-theme-${this.theme}`}>
-        <ogm-menubar theme={this.theme} record={this.record} loading={this.loading}></ogm-menubar>
+      <div class={`container sl-theme-${theme}`}>
+        <ogm-menubar theme={theme} record={this.record} loading={this.loading}></ogm-menubar>
         <div class="map-container">
-          <ogm-sidebar theme={this.theme} record={this.record} open={this.sidebarOpen}></ogm-sidebar>
-          <ogm-map preview-opacity={this.previewOpacity} theme={this.theme} record={this.record}></ogm-map>
+          <ogm-sidebar theme={theme} record={this.record} open={this.sidebarOpen}></ogm-sidebar>
+          {iiif ? (
+            <ogm-iiif theme={theme} manifestUrl={iiif}></ogm-iiif>
+          ) : (
+            <ogm-map preview-opacity={this.previewOpacity} theme={theme} record={this.record}></ogm-map>
+          )}
         </div>
       </div>
     );

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,5 +3,3 @@ declare namespace JSX {
     'clover-viewer': any;
   }
 }
-
-

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,7 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    'clover-viewer': any;
+  }
+}
+
+

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <link rel="shortcut icon" href="./build/assets/favicon.ico" />
     <script type="module" src="./build/ogm-viewer.esm.js"></script>
     <script nomodule src="./build/ogm-viewer.js"></script>
+    
 
     <style>
       body {
@@ -47,6 +48,7 @@
         width: clamp(800px, 70vw, 1000px);
         margin: 1rem auto;
       }
+      
     </style>
 
     <script>

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,6 @@
     <link rel="shortcut icon" href="./build/assets/favicon.ico" />
     <script type="module" src="./build/ogm-viewer.esm.js"></script>
     <script nomodule src="./build/ogm-viewer.js"></script>
-    
 
     <style>
       body {
@@ -48,7 +47,6 @@
         width: clamp(800px, 70vw, 1000px);
         margin: 1rem auto;
       }
-      
     </style>
 
     <script>

--- a/src/utils/references.ts
+++ b/src/utils/references.ts
@@ -99,4 +99,28 @@ export class References {
       .filter(([uri]) => METADATA_REFERENCE_URIS.includes(uri))
       .map(([uri, url]: [ReferenceURI, string]) => ({ url, label: REFERENCE_URIS[uri] }));
   }
+
+  // The IIIF Presentation manifest URL, if any
+  get iiifManifest() {
+    const url = this.references['http://iiif.io/api/presentation#manifest'];
+    return this.normalizeIiifManifest(url);
+  }
+
+  /**
+   * Some records incorrectly store a IIIF Content Search API endpoint
+   * under the IIIF Presentation manifest key. For known providers,
+   * normalize these URLs to a proper manifest endpoint so downstream
+   * viewers can load them successfully.
+   */
+  private normalizeIiifManifest(url?: string) {
+    if (!url) return url;
+    // University of Michigan (quod.lib.umich.edu) provides manifests at:
+    //   /cgi/i/image/api/manifest/:id
+    // but some records reference the search endpoint instead:
+    //   /cgi/i/image/api/search/:id
+    if (url.includes('quod.lib.umich.edu/cgi/i/image/api/search/')) {
+      return url.replace('/api/search/', '/api/manifest/');
+    }
+    return url;
+  }
 }

--- a/src/utils/test/references.spec.ts
+++ b/src/utils/test/references.spec.ts
@@ -1,0 +1,104 @@
+import { References } from '../references';
+
+describe('References', () => {
+  describe('iiifManifest getter', () => {
+    it('returns undefined when no manifest URL exists', () => {
+      const references = new References('{}');
+      expect(references.iiifManifest).toBeUndefined();
+    });
+
+    it('returns manifest URL unchanged for standard URLs', () => {
+      const manifestUrl = 'https://example.com/manifest.json';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': manifestUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(manifestUrl);
+    });
+
+    it('normalizes U-Michigan search URLs to manifest URLs', () => {
+      const searchUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/search/clark1ic:010356232';
+      const expectedManifestUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/manifest/clark1ic:010356232';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': searchUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(expectedManifestUrl);
+    });
+
+    it('does not normalize U-Michigan URLs that are already manifest URLs', () => {
+      const manifestUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/manifest/clark1ic:010356232';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': manifestUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(manifestUrl);
+    });
+
+    it('does not normalize non-U-Michigan URLs with search in path', () => {
+      const searchUrl = 'https://other-library.edu/api/search/manifest123';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': searchUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(searchUrl);
+    });
+
+    it('works alongside other reference getters', () => {
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': 'https://example.com/manifest.json',
+          'http://www.opengis.net/def/serviceType/ogc/wms': 'https://example.com/wms',
+          'https://github.com/cogeotiff/cog-spec': 'https://example.com/cog.tif',
+        }),
+      );
+      expect(references.iiifManifest).toBe('https://example.com/manifest.json');
+      expect(references.wms).toBe('https://example.com/wms');
+      expect(references.cog).toBe('https://example.com/cog.tif');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles malformed JSON gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const references = new References('invalid json');
+      expect(references.iiifManifest).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('handles empty string gracefully', () => {
+      const references = new References('');
+      expect(references.iiifManifest).toBeUndefined();
+    });
+  });
+
+  describe('URL normalization edge cases', () => {
+    it('handles U-Michigan URL with query parameters', () => {
+      const searchUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/search/clark1ic:010356232?param=value';
+      const expectedManifestUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/manifest/clark1ic:010356232?param=value';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': searchUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(expectedManifestUrl);
+    });
+
+    it('handles U-Michigan URL with hash fragments', () => {
+      const searchUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/search/clark1ic:010356232#fragment';
+      const expectedManifestUrl = 'https://quod.lib.umich.edu/cgi/i/image/api/manifest/clark1ic:010356232#fragment';
+      const references = new References(
+        JSON.stringify({
+          'http://iiif.io/api/presentation#manifest': searchUrl,
+        }),
+      );
+      expect(references.iiifManifest).toBe(expectedManifestUrl);
+    });
+  });
+});
+

--- a/src/utils/test/references.spec.ts
+++ b/src/utils/test/references.spec.ts
@@ -72,8 +72,11 @@ describe('References', () => {
     });
 
     it('handles empty string gracefully', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       const references = new References('');
       expect(references.iiifManifest).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 

--- a/src/utils/test/references.spec.ts
+++ b/src/utils/test/references.spec.ts
@@ -101,4 +101,3 @@ describe('References', () => {
     });
   });
 });
-


### PR DESCRIPTION
This DRAFT PR integrates the Clover IIIF viewer as a new viewer component. I'm not sure this matches your IIIF expectations for this project, but I tried to find a way to add IIIF support with as lightweight a footprint as possible.

The viewer is isolated in an iframe to avoid DOM conflicts with OpenSeadragon. The viewer automatically detects IIIF manifests in record references and switches from map view to IIIF image viewer as necessary.

Changes:

* Adds ogm-iiif component to render Clover in an iframe
* Enhances a new References utility with IIIF manifest URL normalization (fixes some B1G/U-Michigan search endpoint URLs)
* Updates ogm-viewer to conditionally render IIIF viewer or map
* Hides the default Clover header and IIIF info panel by default (redundant info already in the ogm-viewer)
* Add comprehensive test coverage for new components and utilities
* Fix Stencil lifecycle warnings by deferring state updates

Addresses #19

<img width="1169" height="983" alt="Screenshot 2025-11-11 at 1 41 38 PM" src="https://github.com/user-attachments/assets/733cc3b1-1db8-4f0f-9eb5-38ced73490a9" />



