### PR TITLE
Show the filmstrip for IIIF items

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,11 +11,13 @@ export { OgmRecord } from "./lib/record";
 export { EaseToOptions } from "maplibre-gl";
 export namespace Components {
     interface OgmImage {
+        "padding": number;
         "record": OgmRecord;
         "theme": 'light' | 'dark';
     }
     interface OgmMap {
         "easeMapTo": (options: EaseToOptions) => Promise<maplibregl.Map>;
+        "padding": number;
         "previewOpacity": number;
         "record": OgmRecord;
         "theme": 'light' | 'dark';
@@ -163,12 +165,14 @@ declare namespace LocalJSX {
     interface OgmImage {
         "onImageLoaded"?: (event: OgmImageCustomEvent<void>) => void;
         "onImageLoading"?: (event: OgmImageCustomEvent<void>) => void;
+        "padding"?: number;
         "record"?: OgmRecord;
         "theme"?: 'light' | 'dark';
     }
     interface OgmMap {
         "onMapIdle"?: (event: OgmMapCustomEvent<void>) => void;
         "onMapLoading"?: (event: OgmMapCustomEvent<void>) => void;
+        "padding"?: number;
         "previewOpacity"?: number;
         "record"?: OgmRecord;
         "theme"?: 'light' | 'dark';

--- a/src/components/ogm-image/ogm-image.tsx
+++ b/src/components/ogm-image/ogm-image.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, Watch, Prop, Event, EventEmitter } from '@stencil/core';
 import { Viewer } from 'openseadragon';
 
-import { findElement } from '../../lib/elements';
+import { getElement, findElement } from '../../lib/elements';
 import type { OgmRecord } from '../../lib/record';
 
 @Component({
@@ -13,6 +13,7 @@ export class OgmImage {
   @Element() el: HTMLElement;
   @Prop() record: OgmRecord;
   @Prop() theme: 'light' | 'dark';
+  @Prop() padding: number = 0;
   @Event() imageLoaded: EventEmitter<void>;
   @Event() imageLoading: EventEmitter<void>;
 
@@ -22,18 +23,18 @@ export class OgmImage {
   // Set up OpenSeadragon viewer on load
   async componentDidLoad() {
     this.viewer = new Viewer({
-      element: findElement(this.el, '#openseadragon'),
+      element: getElement(this.el, '#openseadragon'),
       prefixUrl: 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
       visibilityRatio: 1,
       sequenceMode: true,
-      //@ts-ignore
-      drawer: typeof jest === 'undefined' ? 'webgl' : 'html', // No WebGL in tests
-      zoomInButton: findElement(this.el, '.zoom-in'),
-      zoomOutButton: findElement(this.el, '.zoom-out'),
-      homeButton: findElement(this.el, '.home'),
-      fullPageButton: findElement(this.el, '.full-page'),
-      nextButton: findElement(this.el, '.next'),
-      previousButton: findElement(this.el, '.prev'),
+      showReferenceStrip: true,
+      crossOriginPolicy: 'Anonymous',
+      zoomInButton: getElement(this.el, '.zoom-in'),
+      zoomOutButton: getElement(this.el, '.zoom-out'),
+      homeButton: getElement(this.el, '.home'),
+      fullPageButton: getElement(this.el, '.full-page'),
+      nextButton: getElement(this.el, '.next'),
+      previousButton: getElement(this.el, '.prev'),
     });
     this.viewer.addHandler('open', () => this.imageLoaded.emit());
     if (this.record) await this.loadImages();
@@ -43,6 +44,16 @@ export class OgmImage {
   @Watch('record')
   async onRecordChange() {
     if (this.record) await this.loadImages();
+  }
+
+  @Watch('padding')
+  async onPaddingChange() {
+    // Move the filmstrip if there is one
+    const filmstrip = findElement(this.el, '.referencestrip');
+    if (filmstrip) filmstrip.style.setProperty('margin-left', `${this.padding}px`);
+
+    // Move the viewer viewport
+    return await this.viewer.viewport.setMargins({ left: this.padding });
   }
 
   // Get all of the IIIF image URLs and send them to OpenSeadragon

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -3,7 +3,7 @@ import maplibregl from 'maplibre-gl';
 import { getPreviewSource, getPreviewLayers, getBoundsPreviewSource, getBoundsPreviewLayers, recordDeckGLCOGLayer } from '../../lib/sources';
 import { MapboxOverlay as DeckOverlay } from '@deck.gl/mapbox';
 
-import { findElement } from '../../lib/elements';
+import { getElement } from '../../lib/elements';
 import type { OgmRecord } from '../../lib/record';
 import type { AddLayerObject, EaseToOptions } from 'maplibre-gl';
 import type { AddSourceObject } from '../../lib/sources';
@@ -18,6 +18,7 @@ export class OgmMap {
   @Prop() record: OgmRecord;
   @Prop() theme: 'light' | 'dark';
   @Prop() previewOpacity: number = 100;
+  @Prop() padding: number = 0;
   @Event() mapIdle: EventEmitter<void>;
   @Event() mapLoading: EventEmitter<void>;
 
@@ -39,7 +40,7 @@ export class OgmMap {
   // Set up the mapLibre map and event bindings on load
   componentDidLoad() {
     this.map = new maplibregl.Map({
-      container: findElement(this.el, '#map'),
+      container: getElement(this.el, '#map'),
       attributionControl: false,
       style: this.baseMapStyle,
       center: [0, 0],
@@ -138,6 +139,12 @@ export class OgmMap {
   // Fit the map to the provided bounds
   fitMapBounds(bounds: maplibregl.LngLatBoundsLike) {
     this.map.fitBounds(bounds, { padding: 40 });
+  }
+
+  // When padding is changed, move the map over to make room for the sidebar
+  @Watch('padding')
+  async onPaddingChange() {
+    return await this.easeMapTo({ padding: { left: this.padding } });
   }
 
   // Move the map (e.g. when the sidebar moves)

--- a/src/components/ogm-settings/ogm-settings.tsx
+++ b/src/components/ogm-settings/ogm-settings.tsx
@@ -1,8 +1,8 @@
-import { Component, Listen, Prop, EventEmitter, Event, Element, h } from '@stencil/core';
-import type { OgmRecord } from '../../lib/record';
 import type { SlRange } from '@shoelace-style/shoelace';
+import { Component, Element, Event, EventEmitter, h, Listen, Prop } from '@stencil/core';
 
-import { findElement } from '../../lib/elements';
+import { getElement } from '../../lib/elements';
+import type { OgmRecord } from '../../lib/record';
 
 @Component({
   tag: 'ogm-settings',
@@ -17,7 +17,7 @@ export class OgmSettings {
   private slRange: SlRange;
 
   componentDidLoad() {
-    this.slRange = findElement(this.el, 'sl-range') as SlRange;
+    this.slRange = getElement(this.el, 'sl-range') as SlRange;
   }
 
   @Listen('sl-input')

--- a/src/components/ogm-sidebar/ogm-sidebar.tsx
+++ b/src/components/ogm-sidebar/ogm-sidebar.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 
-import { findElement } from '../../lib/elements';
+import { getElement, findElement } from '../../lib/elements';
 import type { OgmRecord } from '../../lib/record';
 import type { SlTabGroup } from '@shoelace-style/shoelace';
 
@@ -19,7 +19,7 @@ export class OgmSidebar {
 
   // Find the tab group element after the component is loaded
   componentDidLoad() {
-    this.tabs = findElement(this.el, 'sl-tab-group') as SlTabGroup;
+    this.tabs = getElement(this.el, 'sl-tab-group') as SlTabGroup;
   }
 
   // Name of the currently active tab panel in sidebar, if one is active

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -1,7 +1,6 @@
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { Component, Element, Listen, Method, Prop, State, Watch, getAssetPath, h } from '@stencil/core';
 
-import { findElement } from '../../lib/elements';
 import { OgmRecord } from '../../lib/record';
 
 // Only need to call this once, at the top level
@@ -29,11 +28,11 @@ export class OgmViewer {
   @Prop() recordUrl: string;
   @Prop() theme: 'light' | 'dark' = this.getThemePreference();
   @State() record: OgmRecord;
-  @State() sidebarOpen: boolean = false;
   @State() previewOpacity: number = 100;
+  @State() sidebarOpen: boolean = false;
 
   private loading: boolean = false;
-  private map: HTMLOgmMapElement;
+  private sidebarPadding: number = 0;
 
   // Prior to rendering, fetch the record if a URL is provided
   async componentWillLoad() {
@@ -45,18 +44,11 @@ export class OgmViewer {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  // After rendering, find the map element in the shadow DOM, if it's there
-  componentDidRender() {
-    this.map = findElement(this.el, 'ogm-map') as HTMLOgmMapElement;
-  }
-
   // Shift the map/image over when the sidebar is toggled open
   @Listen('sidebarToggled')
   toggleSidebar() {
     this.sidebarOpen = !this.sidebarOpen;
-    if (!this.map) return;
-    if (this.sidebarOpen) this.map.easeMapTo({ padding: { left: 400 } });
-    else this.map.easeMapTo({ padding: { left: 20 } });
+    this.sidebarPadding = this.sidebarOpen ? 400 : 0;
   }
 
   // When URL changes, fetch the new record
@@ -100,8 +92,8 @@ export class OgmViewer {
 
   // Choose a preview component based on the record type
   private renderPreview() {
-    if (this.record && this.record.references.iiifOnly) return <ogm-image theme={this.theme} record={this.record}></ogm-image>;
-    return <ogm-map preview-opacity={this.previewOpacity} theme={this.theme} record={this.record}></ogm-map>;
+    if (this.record && this.record.references.iiifOnly) return <ogm-image theme={this.theme} record={this.record} padding={this.sidebarPadding}></ogm-image>;
+    return <ogm-map preview-opacity={this.previewOpacity} theme={this.theme} record={this.record} padding={this.sidebarPadding}></ogm-map>;
   }
 
   render() {

--- a/src/lib/elements.ts
+++ b/src/lib/elements.ts
@@ -1,6 +1,11 @@
-// Helper to find elements in the shadow DOM
-export const findElement = (parent: HTMLElement, selector: string): HTMLElement => {
-  const el = parent?.shadowRoot?.querySelector(selector);
+// Look for an element in shadow DOM that may or may not be there
+export const findElement = (parent: HTMLElement, selector: string): HTMLElement | undefined => {
+  return parent?.shadowRoot?.querySelector(selector) || undefined;
+};
+
+// Get an element from shadow DOM that definitely should be there
+export const getElement = (parent: HTMLElement, selector: string): HTMLElement => {
+  const el = findElement(parent, selector);
   if (!el) throw new Error(`Could not find child of ${parent.tagName} with selector: ${selector}`);
   return el as HTMLElement;
 };


### PR DESCRIPTION
Also supports shifting IIIF image display (and the filmstrip)
over when the sidebar is opened/closed.

Closes #87
