### PR TITLE
Re-add support for COG rendering using maplibre plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@deck.gl/mapbox": "^9.3.1",
         "@deck.gl/mesh-layers": "^9.3.1",
         "@developmentseed/deck.gl-geotiff": "^0.7.0",
+        "@geomatico/maplibre-cog-protocol": "^0.9.0",
         "@iiif/presentation-2": "^1.0.4",
         "@iiif/presentation-3": "^2.2.3",
         "@luma.gl/core": "^9.3.3",
@@ -457,6 +458,21 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@geomatico/maplibre-cog-protocol": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@geomatico/maplibre-cog-protocol/-/maplibre-cog-protocol-0.9.0.tgz",
+      "integrity": "sha512-PHenAjgSm5fJHtk/lff76w5m66drHz8H+1LjeNk4nT72EqjKeWBCKHvKLdACY4a1ay8BrhaB2NkfFNTUVrV84g==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/sphericalmercator": "^2.0.2",
+        "d3-scale": "^4.0.2",
+        "geotiff": "^3.0.5",
+        "quick-lru": "^7.1.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": "^4.5.0 || ^5.0.0"
+      }
     },
     "node_modules/@iiif/presentation-2": {
       "version": "1.0.4",
@@ -990,6 +1006,11 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
       "license": "ISC"
     },
+    "node_modules/@mapbox/sphericalmercator": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-2.0.2.tgz",
+      "integrity": "sha512-Ai/S9qXupBzFCM0i4sYDIx1A0pDYMaD3xlhVg05JToYeyORq8aAuHbd6CCPC86HlLSjYmoPeljJ5tMVKtzd4Lg=="
+    },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
@@ -1212,6 +1233,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
@@ -3197,6 +3224,49 @@
       "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/geotiff": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.9.3",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/geotiff/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4608,6 +4678,12 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
@@ -4829,6 +4905,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/quickselect": {
       "version": "3.0.0",
@@ -5781,6 +5869,12 @@
         "@stencil/core": "^4.0.0 || ^5.0.0-0"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -5954,6 +6048,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
@@ -5973,6 +6073,12 @@
       "integrity": "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "license": "MIT AND BSD-3-Clause"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@deck.gl/mapbox": "^9.3.1",
     "@deck.gl/mesh-layers": "^9.3.1",
     "@developmentseed/deck.gl-geotiff": "^0.7.0",
+    "@geomatico/maplibre-cog-protocol": "^0.9.0",
     "@iiif/presentation-2": "^1.0.4",
     "@iiif/presentation-3": "^2.2.3",
     "@luma.gl/core": "^9.3.3",

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -1,0 +1,91 @@
+import { MapboxOverlay as DeckOverlay } from '@deck.gl/mapbox';
+import { COGLayer } from '@developmentseed/deck.gl-geotiff';
+import { DecoderPool } from '@developmentseed/geotiff';
+
+import Previewer from './previewer';
+import type Source from '../sources/source';
+
+// Deck.gl-based previewer for Cloud Optimized GeoTIFF (COG) sources
+// Can warp COGs on the fly; supports projections other than Web Mercator
+// NOTE: can't be built currently due to a bug; see:
+// https://github.com/OpenGeoMetadata/ogm-viewer/issues/100
+export default class DeckCogPreviewer extends Previewer {
+  protected map: maplibregl.Map;
+  protected deckOverlay: DeckOverlay;
+  protected layerId: string | undefined = undefined;
+
+  private bounds: maplibregl.LngLatBoundsLike | undefined = undefined;
+
+  constructor(source: Source, map: maplibregl.Map) {
+    super(source);
+    this.map = map;
+    this.deckOverlay = this.getDeckOverlay();
+  }
+
+  async preview(): Promise<void> {
+    if (!this.layerId) {
+      const layer = this.createLayer();
+      console.debug('Created COG preview layer', layer.id);
+      this.layerId = layer.id;
+      this.deckOverlay.setProps({ layers: [layer] });
+    }
+  }
+
+  async clearPreview() {
+    if (this.layerId) {
+      console.debug('Clearing COG preview layer', this.layerId);
+      this.deckOverlay.setProps({ layers: [] });
+      this.layerId = undefined;
+    }
+  }
+
+  protected getSourceId(): string {
+    return `${this.source.id}-cog`;
+  }
+
+  protected createLayer(): COGLayer {
+    return new COGLayer({
+      id: this.getSourceId(),
+      geotiff: this.source.getSourceUrl(),
+      onGeoTIFFLoad: (data, options) => {
+        console.debug('COG loaded', data, options);
+        const { west, south, east, north } = options.geographicBounds;
+        this.bounds = [
+          [west, south],
+          [east, north],
+        ];
+      },
+      parameters: { depthCompare: 'always', cullMode: 'back' },
+      // Disable the web worker decoder pool; this appears to cause errors because
+      // it can't find /worker.js?
+      // See: https://developmentseed.org/deck.gl-raster/api/geotiff/type-aliases/DecoderPoolOptions/
+      // See also: https://github.com/developmentseed/deck.gl-raster/issues/364
+      pool: new DecoderPool({
+        createWorker: undefined,
+      }),
+    });
+  }
+
+  async getBounds() {
+    return this.bounds;
+  }
+
+  // Get the shared deck.gl overlay used to render this previewer
+  protected getDeckOverlay(): DeckOverlay {
+    // No built-in way to query existing controls...
+    const overlay = this.map._controls.find(control => control instanceof DeckOverlay);
+    if (overlay) {
+      console.debug('Deck.gl overlay exists; skipping creation', overlay);
+      return overlay;
+    }
+    return this.createDeckOverlay();
+  }
+
+  // Create a deck.gl overlay and add it to the map
+  protected createDeckOverlay(): DeckOverlay {
+    const overlay = new DeckOverlay({ interleaved: true });
+    this.map.addControl(overlay);
+    console.debug('Deck.gl overlay created', overlay);
+    return overlay;
+  }
+}

--- a/src/lib/previewers/cog.ts
+++ b/src/lib/previewers/cog.ts
@@ -1,87 +1,32 @@
-import { MapboxOverlay as DeckOverlay } from '@deck.gl/mapbox';
-import { COGLayer } from '@developmentseed/deck.gl-geotiff';
-import { DecoderPool } from '@developmentseed/geotiff';
+import maplibregl, { RasterSourceSpecification } from 'maplibre-gl';
+import { cogProtocol } from '@geomatico/maplibre-cog-protocol';
 
-import Previewer from './previewer';
-import type Source from '../sources/source';
+import RasterPreviewer from './raster';
+import CogSource from '../sources/cog';
+import { MapLibreOptions } from './maplibre';
 
-export default class CogPreviewer extends Previewer {
-  protected map: maplibregl.Map;
-  protected deckOverlay: DeckOverlay;
-  protected layerId: string | undefined = undefined;
+// COG previewer using MapLibre COG protocol plugin
+// Only works for COGs in Web Mercator projection; can't warp in-browser
+// See: https://github.com/geomatico/maplibre-cog-protocol
+export default class CogPreviewer extends RasterPreviewer {
+  declare protected source: CogSource;
 
-  private bounds: maplibregl.LngLatBoundsLike | undefined = undefined;
-
-  constructor(source: Source, map: maplibregl.Map) {
-    super(source);
-    this.map = map;
-    this.deckOverlay = this.getDeckOverlay();
+  // Register the 'cog://' protocol handler with MapLibre when the previewer is created
+  constructor(source: CogSource, map: maplibregl.Map, options?: Partial<MapLibreOptions>) {
+    super(source, map, options);
+    maplibregl.addProtocol('cog', cogProtocol);
   }
 
-  async preview(): Promise<void> {
-    if (!this.layerId) {
-      const layer = this.createLayer();
-      console.debug('Created COG preview layer', layer.id);
-      this.layerId = layer.id;
-      this.deckOverlay.setProps({ layers: [layer] });
-    }
-  }
-
-  async clearPreview() {
-    if (this.layerId) {
-      console.debug('Clearing COG preview layer', this.layerId);
-      this.deckOverlay.setProps({ layers: [] });
-      this.layerId = undefined;
-    }
+  // COG sources use 'url' instead of 'tiles' and have no scheme
+  protected async createSource(): Promise<RasterSourceSpecification> {
+    return {
+      type: 'raster',
+      url: await this.source.getSourceUrl(),
+      tileSize: this.source.getTileSize(),
+    };
   }
 
   protected getSourceId(): string {
     return `${this.source.id}-cog`;
-  }
-
-  protected createLayer(): COGLayer {
-    return new COGLayer({
-      id: this.getSourceId(),
-      geotiff: this.source.getSourceUrl(),
-      onGeoTIFFLoad: (data, options) => {
-        console.debug('COG loaded', data, options);
-        const { west, south, east, north } = options.geographicBounds;
-        this.bounds = [
-          [west, south],
-          [east, north],
-        ];
-      },
-      parameters: { depthCompare: 'always', cullMode: 'back' },
-      // Disable the web worker decoder pool; this appears to cause errors because
-      // it can't find /worker.js?
-      // See: https://developmentseed.org/deck.gl-raster/api/geotiff/type-aliases/DecoderPoolOptions/
-      // See also: https://github.com/developmentseed/deck.gl-raster/issues/364
-      pool: new DecoderPool({
-        createWorker: undefined,
-      }),
-    });
-  }
-
-  async getBounds() {
-    return this.bounds;
-  }
-
-  // Get the shared deck.gl overlay used to render this previewer
-  protected getDeckOverlay(): DeckOverlay {
-    // No built-in way to query existing controls...
-    const overlay = this.map._controls.find(control => control instanceof DeckOverlay);
-    if (overlay) {
-      console.debug('Deck.gl overlay exists; skipping creation', overlay);
-      return overlay;
-    }
-    return this.createDeckOverlay();
-  }
-
-  // Create a deck.gl overlay and add it to the map
-  protected createDeckOverlay(): DeckOverlay {
-    const overlay = new DeckOverlay({ interleaved: true });
-    this.map.addControl(overlay);
-    console.debug('Deck.gl overlay created', overlay);
-    return overlay;
   }
 }

--- a/src/lib/previewers/index.ts
+++ b/src/lib/previewers/index.ts
@@ -1,3 +1,4 @@
+import CogSource from '../sources/cog';
 import GeoJSONSource from '../sources/geojson';
 import OpenIndexMapSource from '../sources/openindexmap';
 import PMTilesSource from '../sources/pmtiles';
@@ -5,6 +6,7 @@ import Source from '../sources/source';
 import WmsSource from '../sources/wms';
 
 import RasterSource from '../sources/raster';
+import CogPreviewer from './cog';
 import GeoJSONPreviewer from './geojson';
 import MapLibrePreviewer from './maplibre';
 import OpenIndexMapPreviewer from './openindexmap';
@@ -24,6 +26,7 @@ export const getMapPreviewers = async (sources: Source[], map: maplibregl.Map, o
       if (await source.isVector()) previewers.push(new PMTilesVectorPreviewer(source, map, options));
       else previewers.push(new PMTilesRasterPreviewer(source, map, options));
     } else if (source instanceof WmsSource) previewers.push(new WmsPreviewer(source, map, options));
+    else if (source instanceof CogSource) previewers.push(new CogPreviewer(source, map, options));
     else if (source instanceof RasterSource) previewers.push(new RasterPreviewer(source, map, options));
   }
 

--- a/src/lib/sources/cog.ts
+++ b/src/lib/sources/cog.ts
@@ -1,13 +1,18 @@
 import RasterSource from './raster';
 
 export default class CogSource extends RasterSource {
+  // Appends the cog:// protocol; must be registered first to work
+  getSourceUrl() {
+    return `cog://${this.url}`;
+  }
+
   // COGs have no specific scheme identifier for MapLibre
   getScheme() {
     return undefined;
   }
 
-  // We don't need to set an explicit tile size for COGs
-  getTileSize() {
+  // TODO: is it possible to read COG metadata to get bounds?
+  async getBounds() {
     return undefined;
   }
 }


### PR DESCRIPTION
This adds back support for rendering COGs in Web Mercator using
the Maplibre COG protocol plugin, since the deck.gl-based solution
isn't compatible with our build targets right now.

See https://github.com/OpenGeoMetadata/ogm-viewer/issues/100.
