### PR TITLE
Add a close button to inspection popups

### DIFF
--- a/src/components/ogm-map/ogm-map.css
+++ b/src/components/ogm-map/ogm-map.css
@@ -14,6 +14,11 @@
   padding: 0;
   box-shadow: var(--wa-shadow-l);
   border: var(--wa-panel-border-width) solid var(--wa-color-surface-border);
+
+  .maplibregl-popup-close-button {
+    background-color: white;
+    border-radius: 10px;
+  }
 }
 
 /* Dark mode map adjustments */
@@ -52,6 +57,10 @@
   div.maplibregl-popup-content {
     background-color: black;
     color: #ccc;
+  }
+
+  .maplibregl-popup-close-button {
+    background-color: black;
   }
 
   div.maplibregl-popup-anchor-right div.maplibregl-popup-tip {

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -248,7 +248,8 @@ export class OgmMap {
 
   // Create a new popup and set its content and location
   protected createPopup(location: maplibregl.LngLatLike) {
-    this.popup = new maplibregl.Popup({ maxWidth: 'none', closeButton: false }).setDOMContent(this.attributesEl).setLngLat(location).addTo(this.map);
+    this.popup = new maplibregl.Popup({ maxWidth: 'none' }).setDOMContent(this.attributesEl).setLngLat(location).addTo(this.map);
+    this.popup.on('close', this.clearFeatureSelection.bind(this));
   }
 
   // Remove popup from the map and clear the reference


### PR DESCRIPTION
If you're zoomed in really far, there's nowhere to click to
close the popup that isn't also an inspectable feature.
