### PR TITLE
Fix a bug when rendering without a record

### DIFF
--- a/src/components/ogm-map/ogm-map.css
+++ b/src/components/ogm-map/ogm-map.css
@@ -63,7 +63,7 @@
   .maplibregl-ctrl-group button:focus:focus-visible {
     box-shadow: 0 0 2px 2px #ff6900;
   }
-  
+
   .maplibregl-ctrl button.maplibregl-ctrl-globe-enabled .maplibregl-ctrl-icon {
     filter: invert(1);
   }

--- a/src/components/ogm-previews/ogm-previews.test.tsx
+++ b/src/components/ogm-previews/ogm-previews.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, h, vi } from '@stencil/vitest';
+// Render with Stencil's low-level render directly rather than @stencil/vitest's `render` wrapper: the
+// wrapper re-throws lifecycle errors, and the <ogm-map> mounted inside a preview panel throws when it
+// tries to initialize WebGL (unavailable in the test DOM). Stencil's own safeCall only routes that to
+// console.error, so stencilRender still produces the ogm-previews shadow DOM we want to assert on.
+import { render as stencilRender } from '@stencil/core';
+
+import OgmRecord from '../../lib/record';
+
+// Build a minimal Aardvark record, optionally with a WMS reference that yields one previewable source
+const buildRecord = (previewable: boolean) =>
+  new OgmRecord({
+    id: 'berkeley-s7sq63',
+    dct_title_s: 'Calaveras County Contours',
+    gbl_resourceClass_sm: ['Datasets'],
+    dct_accessRights_s: 'Public',
+    gbl_mdVersion_s: 'Aardvark',
+    ...(previewable
+      ? {
+          gbl_wxsIdentifier_s: 's7sq63',
+          dct_references_s: JSON.stringify({ 'http://www.opengis.net/def/serviceType/ogc/wms': 'https://example.com/geoserver/wms' }),
+        }
+      : {}),
+  });
+
+const renderPreviews = async (record?: OgmRecord) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  // The mounted <ogm-map> logs a swallowed WebGL init error; keep test output clean
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  await stencilRender(<ogm-previews record={record}></ogm-previews>, container);
+  const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
+  await el.componentOnReady?.();
+  consoleError.mockRestore();
+  return el.shadowRoot as ShadowRoot;
+};
+
+describe('ogm-previews', () => {
+  it('renders a tab for a record supplied at initial render', async () => {
+    const shadowRoot = await renderPreviews(buildRecord(true));
+
+    const tabs = shadowRoot.querySelectorAll('wa-tab');
+    expect(shadowRoot.querySelector('wa-tab-group')).not.toBeNull();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].textContent).toContain('WMS');
+  });
+
+  it('falls back to an empty map for a record with no previewable sources', async () => {
+    const shadowRoot = await renderPreviews(buildRecord(false));
+
+    expect(shadowRoot.querySelector('wa-tab-group')).toBeNull();
+    expect(shadowRoot.querySelector('ogm-map')).not.toBeNull();
+  });
+});

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -27,6 +27,11 @@ export class OgmPreviews {
   @Prop() sidebarPadding: number;
   @State() sources: Source[] = [];
 
+  // @Watch only fires on changes; handle the initial load here
+  componentWillLoad() {
+    if (this.record) this.getSources(this.record);
+  }
+
   // Pick the appropriate preview to render based on the source type
   protected renderPreview(source: Source) {
     if (source instanceof IIIFSource) return this.renderImagePreview(source);
@@ -63,7 +68,8 @@ export class OgmPreviews {
 
   // Render as tabs for switching between sources
   render() {
-    if (!this.record) return <ogm-map theme={this.theme} padding={this.sidebarPadding}></ogm-map>;
+    // Render a blank map if there is no record or no sources
+    if (!this.record || !this.sources.length) return <ogm-map theme={this.theme} padding={this.sidebarPadding}></ogm-map>;
 
     return (
       <Host class={this.theme && `wa-${this.theme}`}>


### PR DESCRIPTION
The lack of sources/tabs to render caused an error when the
tab group in OgmSources had no child tabs inside of it.
