### PR TITLE
Fix a bug with source ID generation for index maps, COGs, and PMTiles

### DIFF
--- a/src/lib/previewers/cog.test.ts
+++ b/src/lib/previewers/cog.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import CogPreviewer from './cog';
+import CogResource from '../resources/cog';
+import type { MapLibreStyle } from '../themes/maplibre';
+
+// Just enough of a MapLibre map to record what the previewer adds
+class FakeMap {
+  sources = new Map<string, any>();
+  layers = new Map<string, any>();
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+  addSource(id: string, spec: any) {
+    this.sources.set(id, spec);
+  }
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+  addLayer(layer: any) {
+    // MapLibre refuses a layer whose source hasn't been added yet
+    if (!this.sources.has(layer.source)) throw new Error(`No source ${layer.source} for layer ${layer.id}`);
+    this.layers.set(layer.id, layer);
+  }
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+}
+
+// The previewer only reads the opacity
+const style = { opacity: 0.8 } as MapLibreStyle;
+
+const COG_URL = 'https://example.com/scan.tif';
+
+// Nothing here reads the GeoTIFF: the source is built from the URL alone
+const preview = async () => {
+  const map = new FakeMap();
+  const previewer = new CogPreviewer(new CogResource('princeton-fk4544658v', COG_URL), map as unknown as maplibregl.Map, style);
+  await previewer.preview();
+  return { map, previewer };
+};
+
+describe('CogPreviewer#preview', () => {
+  it('hands MapLibre the URL behind the cog:// protocol', async () => {
+    const { map, previewer } = await preview();
+    const source = map.sources.get('princeton-fk4544658v-cog');
+
+    expect(source.type).toEqual('raster');
+    expect(source.url).toEqual(`cog://${COG_URL}`);
+    expect(previewer.sourceIds).toEqual(['princeton-fk4544658v-cog']);
+  });
+
+  it('draws its raster layer from the source it added', async () => {
+    const { map, previewer } = await preview();
+
+    // A layer pointing at any other ID would be dropped by MapLibre, drawing nothing
+    expect([...map.layers.values()].every(layer => map.sources.has(layer.source))).toBe(true);
+    expect([...map.layers.keys()]).toEqual(['princeton-fk4544658v-cog']);
+    expect(previewer.layerIds).toEqual(['princeton-fk4544658v-cog']);
+  });
+
+  it('removes what it added when cleared', async () => {
+    const { map, previewer } = await preview();
+    await previewer.clearPreview();
+
+    expect(map.sources.size).toEqual(0);
+    expect(map.layers.size).toEqual(0);
+  });
+});

--- a/src/lib/previewers/cog.ts
+++ b/src/lib/previewers/cog.ts
@@ -18,11 +18,16 @@ export default class CogPreviewer extends RasterPreviewer {
     maplibregl.addProtocol('cog', cogProtocol);
   }
 
+  // A COG has no scheme to name it by, and the raster layer draws from this too
+  protected getSourceId(): string {
+    return `${this.resource.id}-cog`;
+  }
+
   // COG sources use 'url' instead of 'tiles' and have no scheme
   protected async createSources(): Promise<AddRasterSourceObject[]> {
     return [
       {
-        id: `${this.resource.id}-cog`,
+        id: this.getSourceId(),
         type: 'raster',
         url: await this.resource.getMapLibreSourceUrl(),
         tileSize: this.resource.getTileSize(),

--- a/src/lib/previewers/geojson.test.ts
+++ b/src/lib/previewers/geojson.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import GeoJsonPreviewer from './geojson';
+import OpenIndexMapPreviewer from './openindexmap';
+import GeoJsonResource from '../resources/geojson';
+import OpenIndexMapResource from '../resources/openindexmap';
+import type { MapLibreStyle } from '../themes/maplibre';
+
+// Just enough of a MapLibre map to record what the previewer adds
+class FakeMap {
+  sources = new Map<string, any>();
+  layers = new Map<string, any>();
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+  addSource(id: string, spec: any) {
+    this.sources.set(id, spec);
+  }
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+  addLayer(layer: any) {
+    // MapLibre refuses a layer whose source hasn't been added yet
+    if (!this.sources.has(layer.source)) throw new Error(`No source ${layer.source} for layer ${layer.id}`);
+    this.layers.set(layer.id, layer);
+  }
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+}
+
+// The previewers only read the colors and label styles, none of which these tests assert on
+const style = { opacity: 0.8, fillColor: '#00f', strokeColor: '#009', textColor: '#000', textFont: 'Noto Sans Regular', textSize: 12 } as MapLibreStyle;
+
+const GEOJSON_URL = 'https://example.com/index-map.json';
+
+// Nothing here fetches: the source URL and the layer names are known without reading the document
+const previewGeoJson = async () => {
+  const map = new FakeMap();
+  const previewer = new GeoJsonPreviewer(new GeoJsonResource('princeton-fk4544658v', GEOJSON_URL), map as unknown as maplibregl.Map, style);
+  await previewer.preview();
+  return { map, previewer };
+};
+
+const previewIndexMap = async () => {
+  const map = new FakeMap();
+  const previewer = new OpenIndexMapPreviewer(new OpenIndexMapResource('princeton-fk4544658v', GEOJSON_URL), map as unknown as maplibregl.Map, style);
+  await previewer.preview();
+  return { map, previewer };
+};
+
+const SUFFIXES = ['polygons', 'polygon-outlines', 'lines', 'points', 'polygon-labels', 'line-labels', 'point-labels'];
+
+describe('GeoJsonPreviewer#preview', () => {
+  it('hands MapLibre the document URL as a geojson source', async () => {
+    const { map, previewer } = await previewGeoJson();
+    const source = map.sources.get('princeton-fk4544658v-geojson');
+
+    expect(source.type).toEqual('geojson');
+    expect(source.data).toEqual(GEOJSON_URL);
+    expect(previewer.sourceIds).toEqual(['princeton-fk4544658v-geojson']);
+  });
+
+  it('draws its style layers from the source it added', async () => {
+    const { map } = await previewGeoJson();
+
+    // A layer pointing at any other ID would be dropped by MapLibre, drawing nothing
+    expect([...map.layers.values()].every(layer => map.sources.has(layer.source))).toBe(true);
+    expect([...map.layers.keys()]).toEqual(SUFFIXES.map(suffix => `princeton-fk4544658v-geojson-geojson-${suffix}`));
+  });
+
+  it('removes what it added when cleared', async () => {
+    const { map, previewer } = await previewGeoJson();
+    await previewer.clearPreview();
+
+    expect(map.sources.size).toEqual(0);
+    expect(map.layers.size).toEqual(0);
+  });
+});
+
+describe('OpenIndexMapPreviewer#preview', () => {
+  it('draws the index map polygons from the source it added', async () => {
+    const { map } = await previewIndexMap();
+    const polygons = map.layers.get('princeton-fk4544658v-geojson-indexmap-polygons');
+
+    expect(polygons.type).toEqual('fill');
+    expect(map.sources.has(polygons.source)).toBe(true);
+  });
+
+  it('styles the one layer an index map has', async () => {
+    const { map } = await previewIndexMap();
+
+    expect([...map.layers.keys()]).toEqual(SUFFIXES.map(suffix => `princeton-fk4544658v-geojson-indexmap-${suffix}`));
+  });
+});

--- a/src/lib/previewers/geojson.ts
+++ b/src/lib/previewers/geojson.ts
@@ -9,10 +9,16 @@ export type AddGeoJsonSourceObject = GeoJSONSourceSpecification & { id: string }
 export default class GeoJsonPreviewer extends VectorPreviewer {
   declare protected resource: GeoJsonResource;
 
+  // A record can reference the same data more than one way, so keep the sources distinct. The
+  // style layers draw from this too, so both have to come from here.
+  protected getSourceId(): string {
+    return `${this.resource.id}-geojson`;
+  }
+
   protected async createSources(): Promise<AddGeoJsonSourceObject[]> {
     return [
       {
-        id: `${this.resource.id}-geojson`,
+        id: this.getSourceId(),
         type: await this.resource.getMapLibreSourceType(),
         data: await this.resource.getMapLibreSourceUrl(),
         generateId: true, // autogenerate feature IDs for labeling

--- a/src/lib/previewers/pmtiles-raster.ts
+++ b/src/lib/previewers/pmtiles-raster.ts
@@ -3,11 +3,16 @@ import PMTilesResource from '../resources/pmtiles';
 import type { AddRasterSourceObject } from './raster';
 
 export default class PMTilesRasterPreviewer extends RasterPreviewer {
+  // An archive has no scheme to name it by, and the raster layer draws from this too
+  protected getSourceId(): string {
+    return `${this.resource.id}-pmtiles`;
+  }
+
   // PMTiles sources use 'url' instead of 'tiles' and have no scheme or tileSize
   protected async createSources(): Promise<AddRasterSourceObject[]> {
     return [
       {
-        id: `${this.resource.id}-pmtiles`,
+        id: this.getSourceId(),
         type: 'raster',
         url: await this.resource.getMapLibreSourceUrl(),
       },

--- a/src/lib/previewers/pmtiles.test.ts
+++ b/src/lib/previewers/pmtiles.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import PMTilesRasterPreviewer from './pmtiles-raster';
+import PMTilesResource from '../resources/pmtiles';
+import type { MapLibreStyle } from '../themes/maplibre';
+
+// Just enough of a MapLibre map to record what the previewer adds
+class FakeMap {
+  sources = new Map<string, any>();
+  layers = new Map<string, any>();
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+  addSource(id: string, spec: any) {
+    this.sources.set(id, spec);
+  }
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+  addLayer(layer: any) {
+    // MapLibre refuses a layer whose source hasn't been added yet
+    if (!this.sources.has(layer.source)) throw new Error(`No source ${layer.source} for layer ${layer.id}`);
+    this.layers.set(layer.id, layer);
+  }
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+}
+
+// The previewer only reads the opacity
+const style = { opacity: 0.8 } as MapLibreStyle;
+
+const PMTILES_URL = 'https://example.com/tiles.pmtiles';
+
+// Nothing here reads the archive: the source is built from the URL alone, and the header is only
+// touched for bounds
+const preview = async () => {
+  const map = new FakeMap();
+  const previewer = new PMTilesRasterPreviewer(new PMTilesResource('princeton-fk4544658v', PMTILES_URL), map as unknown as maplibregl.Map, style);
+  await previewer.preview();
+  return { map, previewer };
+};
+
+describe('PMTilesRasterPreviewer#preview', () => {
+  it('hands MapLibre the URL behind the pmtiles:// protocol', async () => {
+    const { map, previewer } = await preview();
+    const source = map.sources.get('princeton-fk4544658v-pmtiles');
+
+    expect(source.type).toEqual('raster');
+    expect(source.url).toEqual(`pmtiles://${PMTILES_URL}`);
+    expect(previewer.sourceIds).toEqual(['princeton-fk4544658v-pmtiles']);
+  });
+
+  it('draws its raster layer from the source it added', async () => {
+    const { map, previewer } = await preview();
+
+    // A layer pointing at any other ID would be dropped by MapLibre, drawing nothing
+    expect([...map.layers.values()].every(layer => map.sources.has(layer.source))).toBe(true);
+    expect([...map.layers.keys()]).toEqual(['princeton-fk4544658v-pmtiles']);
+    expect(previewer.layerIds).toEqual(['princeton-fk4544658v-pmtiles']);
+  });
+
+  it('removes what it added when cleared', async () => {
+    const { map, previewer } = await preview();
+    await previewer.clearPreview();
+
+    expect(map.sources.size).toEqual(0);
+    expect(map.layers.size).toEqual(0);
+  });
+});

--- a/src/lib/previewers/wms.ts
+++ b/src/lib/previewers/wms.ts
@@ -14,7 +14,7 @@ export default class WmsPreviewer extends RasterPreviewer {
   protected async createSources(): Promise<AddRasterSourceObject[]> {
     return [
       {
-        id: `${this.resource.id}-wms`,
+        id: this.getSourceId(),
         type: 'raster',
         tiles: [await this.resource.getMapLibreSourceUrl()],
         tileSize: this.resource.getTileSize(),


### PR DESCRIPTION
This was left over from a rebase and resulted in these source
types not being previewed correctly.
