### PR TITLE
Fix handling of null attributes in attribute table

### DIFF
--- a/src/components/ogm-attributes/ogm-attributes.test.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.test.tsx
@@ -1,0 +1,30 @@
+import { render, describe, it, expect, h } from '@stencil/vitest';
+import type { MapGeoJSONFeature } from 'maplibre-gl';
+
+// A WMS GetFeatureInfo response, where attributes that don't apply to the feature come back null
+const feature = {
+  type: 'Feature',
+  id: 'cugir007741.1',
+  geometry: { type: 'Point', coordinates: [-73.903384, 44.365321] },
+  properties: { region: 5, stat_name: 'EMN - WHITEFACE MT. SMT', ozone: 'Y', pm_2_5: null },
+} as unknown as MapGeoJSONFeature;
+
+const rows = (root: HTMLElement) =>
+  Array.from((root.shadowRoot as ShadowRoot).querySelectorAll('tbody tr')).map(tr => Array.from(tr.querySelectorAll('td')).map(td => td.textContent));
+
+describe('ogm-attributes', () => {
+  it('renders nothing without features', async () => {
+    const { root } = await render(<ogm-attributes features={[]}></ogm-attributes>);
+    expect((root.shadowRoot as ShadowRoot).querySelector('table')).toBeNull();
+  });
+
+  it('renders a row per attribute, leaving the value empty for a null', async () => {
+    const { root } = await render(<ogm-attributes features={[feature]}></ogm-attributes>);
+    expect(rows(root)).toEqual([
+      ['region', '5'],
+      ['stat_name', 'EMN - WHITEFACE MT. SMT'],
+      ['ozone', 'Y'],
+      ['pm_2_5', ''],
+    ]);
+  });
+});

--- a/src/components/ogm-attributes/ogm-attributes.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.tsx
@@ -83,7 +83,7 @@ export class OgmAttributes {
             {Object.entries(feature.properties || {}).map(([key, value]) => (
               <tr key={key}>
                 <td class="key">{key}</td>
-                <td class="value" innerHTML={Autolinker.link(value.toString(), { hashtag: false, mention: false, phone: false })}></td>
+                <td class="value" innerHTML={Autolinker.link(value?.toString() ?? '', { hashtag: false, mention: false, phone: false })}></td>
               </tr>
             ))}
           </tbody>

--- a/src/index.html
+++ b/src/index.html
@@ -100,6 +100,11 @@
           Calaveras Tracts (Polygon, WMS)
         </button>
         <button
+          data-record-url="https://raw.githubusercontent.com/geoblacklight/geoblacklight/b0f8e0f854949f297d83c11598b7fb0669b50c6e/spec/fixtures/solr_documents/cornell_html_metadata.json"
+        >
+          Air Stations (Points, WMS)
+        </button>
+        <button
           data-record-url="https://raw.githubusercontent.com/OpenGeoMetadata/edu.berkeley/02b742b5d7ea01aa77bad37a4429951164b34eab/metadata-aardvark/s7042k/geoblacklight.json"
         >
           Bangladesh Topo (Raster, WMS, Restricted)


### PR DESCRIPTION
This was causing rendering errors for rows that didn't have a
value.
