### PR TITLE
Refactor to support 1:n resource:previewers

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,9 +8,11 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { PreviewError } from "./lib/errors";
 import { MapGeoJSONFeature } from "maplibre-gl";
 import { LayerControl } from "./lib/layers";
+import { AnyPreviewer } from "./lib/previewers/factory";
 export { PreviewError } from "./lib/errors";
 export { MapGeoJSONFeature } from "maplibre-gl";
 export { LayerControl } from "./lib/layers";
+export { AnyPreviewer } from "./lib/previewers/factory";
 export namespace Components {
     interface OgmAlerts {
         "error"?: PreviewError;
@@ -27,7 +29,7 @@ export namespace Components {
           * @default 0
          */
         "padding": number;
-        "previewResource": IIIFResource;
+        "previewer": ImagePreviewer;
         "theme": 'light' | 'dark';
     }
     interface OgmLayers {
@@ -43,7 +45,7 @@ export namespace Components {
           * @default 0
          */
         "padding": number;
-        "previewResource": Resource;
+        "previewer": MapPreviewer;
         "theme": 'light' | 'dark';
     }
     interface OgmMenubar {
@@ -64,7 +66,7 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmPreview {
-        "previewResource": Resource;
+        "previewer": AnyPreviewer;
         "sidebarPadding": number;
         "theme": 'light' | 'dark';
     }
@@ -113,6 +115,10 @@ export interface OgmMapCustomEvent<T> extends CustomEvent<T> {
 export interface OgmMenubarCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLOgmMenubarElement;
+}
+export interface OgmPreviewsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLOgmPreviewsElement;
 }
 declare global {
     interface HTMLOgmAlertsElement extends Components.OgmAlerts, HTMLStencilElement {
@@ -224,7 +230,19 @@ declare global {
         prototype: HTMLOgmPreviewElement;
         new (): HTMLOgmPreviewElement;
     };
+    interface HTMLOgmPreviewsElementEventMap {
+        "previewsLoading": void;
+        "previewsLoaded": void;
+    }
     interface HTMLOgmPreviewsElement extends Components.OgmPreviews, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLOgmPreviewsElementEventMap>(type: K, listener: (this: HTMLOgmPreviewsElement, ev: OgmPreviewsCustomEvent<HTMLOgmPreviewsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLOgmPreviewsElementEventMap>(type: K, listener: (this: HTMLOgmPreviewsElement, ev: OgmPreviewsCustomEvent<HTMLOgmPreviewsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLOgmPreviewsElement: {
         prototype: HTMLOgmPreviewsElement;
@@ -276,7 +294,7 @@ declare namespace LocalJSX {
           * @default 0
          */
         "padding"?: number;
-        "previewResource"?: IIIFResource;
+        "previewer"?: ImagePreviewer;
         "theme"?: 'light' | 'dark';
     }
     interface OgmLayers {
@@ -297,7 +315,7 @@ declare namespace LocalJSX {
           * @default 0
          */
         "padding"?: number;
-        "previewResource"?: Resource;
+        "previewer"?: MapPreviewer;
         "theme"?: 'light' | 'dark';
     }
     interface OgmMenubar {
@@ -319,11 +337,13 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmPreview {
-        "previewResource"?: Resource;
+        "previewer"?: AnyPreviewer;
         "sidebarPadding"?: number;
         "theme"?: 'light' | 'dark';
     }
     interface OgmPreviews {
+        "onPreviewsLoaded"?: (event: OgmPreviewsCustomEvent<void>) => void;
+        "onPreviewsLoading"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "record"?: OgmRecord;
         "sidebarPadding"?: number;
         "theme"?: 'light' | 'dark';

--- a/src/components/ogm-image/ogm-image.tsx
+++ b/src/components/ogm-image/ogm-image.tsx
@@ -3,7 +3,7 @@ import { Viewer } from 'openseadragon';
 
 import { getElement, findElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
-import type IIIFResource from '../../lib/resources/iiif';
+import type ImagePreviewer from '../../lib/previewers/image';
 
 @Component({
   tag: 'ogm-image',
@@ -12,7 +12,7 @@ import type IIIFResource from '../../lib/resources/iiif';
 })
 export class OgmImage {
   @Element() el: HTMLElement;
-  @Prop() previewResource: IIIFResource;
+  @Prop() previewer: ImagePreviewer;
   @Prop() theme: 'light' | 'dark';
   @Prop() padding: number = 0;
   @Event() imageLoaded: EventEmitter<void>;
@@ -51,8 +51,8 @@ export class OgmImage {
       this.reportError(new Error(event.message));
     });
 
-    // If we do have a source, load the images
-    if (this.previewResource) await this.loadImages();
+    // The viewer is ready, so whatever preview we were given can be drawn into it
+    await this.loadPreview();
   }
 
   // Destroy the viewer when we are removed from the DOM
@@ -60,10 +60,11 @@ export class OgmImage {
     this.viewer?.destroy();
   }
 
-  // Update preview when source changes
-  @Watch('previewResource')
-  async onSourceChange() {
-    if (this.previewResource) await this.loadImages();
+  // A different preview to draw. The one leaving closes itself out of the viewer first.
+  @Watch('previewer')
+  async onPreviewerChange(_previewer: ImagePreviewer, previous?: ImagePreviewer) {
+    if (previous) await previous.clearPreview();
+    await this.loadPreview();
   }
 
   @Watch('padding')
@@ -76,18 +77,19 @@ export class OgmImage {
     return await this.viewer.viewport.setMargins({ left: this.padding });
   }
 
-  // Get all of the IIIF image URLs and send them to OpenSeadragon
-  // This makes a request to fetch and cache the manifest
-  private async loadImages() {
+  // Draw the current preview into the viewer. Reading a manifest is a fetch, so this is where a
+  // IIIF preview first has the chance to fail.
+  private async loadPreview() {
+    if (!this.previewer || !this.viewer) return;
+
     this.errorReported = false;
     this.imageLoading.emit();
 
     try {
-      const images = await this.previewResource.getIIIFImageUrls();
-      if (!images) throw new Error('No IIIF images found for source');
-      this.viewer.open(images);
+      this.previewer.attach(this.viewer);
+      await this.previewer.preview();
     } catch (error) {
-      console.error(`Error loading IIIF images for ${this.previewResource.url}:`, error);
+      console.error(`Error previewing ${this.previewer.url}:`, error);
       this.imageLoaded.emit();
       this.reportError(error);
     }
@@ -95,9 +97,9 @@ export class OgmImage {
 
   // Emit a single preview error per load attempt
   private reportError(error?: unknown) {
-    if (this.errorReported || !this.previewResource) return;
+    if (this.errorReported || !this.previewer) return;
     this.errorReported = true;
-    this.previewError.emit(referenceError(error, this.previewResource.label(), this.previewResource.url));
+    this.previewError.emit(referenceError(error, this.previewer.label(), this.previewer.url));
   }
 
   render() {

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -2,42 +2,14 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 import maplibregl from 'maplibre-gl';
 import { Protocol as PMTilesProtocol } from 'pmtiles';
 
-import CogResource from '../../lib/resources/cog';
-import EsriDynamicMapLayerResource from '../../lib/resources/esri-dynamic-map-layer';
-import EsriFeatureLayerResource from '../../lib/resources/esri-feature-layer';
-import EsriImageMapLayerResource from '../../lib/resources/esri-image-map-layer';
-import EsriTiledMapLayerResource from '../../lib/resources/esri-tiled-map-layer';
-import GeoJsonResource from '../../lib/resources/geojson';
-import OpenIndexMapResource from '../../lib/resources/openindexmap';
-import PMTilesResource from '../../lib/resources/pmtiles';
-import RasterResource from '../../lib/resources/raster';
-import Resource from '../../lib/resources/resource';
-import TileJsonResource from '../../lib/resources/tilejson';
-import WmsResource from '../../lib/resources/wms';
-import WmtsResource from '../../lib/resources/wmts';
-
 import { getElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
 import { dedupeFeatures } from '../../lib/features';
 import { mercatorBbox, type PixelWindow } from '../../lib/geometry';
 import { isLayerDrawn, toLayerControlItems as getLayerControls, type LayerControl, type LayerState } from '../../lib/layers';
 import LayersControl from '../../lib/layers-control';
-import CogPreviewer from '../../lib/previewers/cog';
-import EsriDynamicMapLayerPreviewer from '../../lib/previewers/esri-dynamic-map-layer';
-import EsriFeatureLayerPreviewer from '../../lib/previewers/esri-feature-layer';
-import EsriImageMapLayerPreviewer from '../../lib/previewers/esri-image-map-layer';
-import EsriTiledMapLayerPreviewer from '../../lib/previewers/esri-tiled-map-layer';
-import GeoJsonPreviewer from '../../lib/previewers/geojson';
 import InspectableRasterPreviewer from '../../lib/previewers/inspectable-raster';
-import MapPreviewer from '../../lib/previewers/map';
-import OpenIndexMapPreviewer from '../../lib/previewers/openindexmap';
-import PMTilesRasterPreviewer from '../../lib/previewers/pmtiles-raster';
-import PMTilesVectorPreviewer from '../../lib/previewers/pmtiles-vector';
-import RasterPreviewer from '../../lib/previewers/raster';
-import TileJsonRasterPreviewer from '../../lib/previewers/tilejson-raster';
-import TileJsonVectorPreviewer from '../../lib/previewers/tilejson-vector';
-import WmtsPreviewer from '../../lib/previewers/wmts';
-import WmsPreviewer from '../../lib/previewers/wms';
+import type MapPreviewer from '../../lib/previewers/map';
 import MapLibreTheme from '../../lib/themes/maplibre';
 
 // Register PMTiles protocol
@@ -58,7 +30,7 @@ const QUERY_WINDOW = 51;
 })
 export class OgmMap {
   @Element() el: HTMLElement;
-  @Prop() previewResource: Resource;
+  @Prop() previewer: MapPreviewer;
   @Prop() theme: 'light' | 'dark';
   @Prop() padding: number = 0;
   @Event() mapIdle: EventEmitter<void>;
@@ -88,9 +60,6 @@ export class OgmMap {
   // Container element reference for fullscreen
   protected containerEl: HTMLElement;
 
-  // Previewer for the currently previewed resource
-  protected previewer: MapPreviewer | undefined = undefined;
-
   // Set up the mapLibre map and event bindings on load
   componentDidLoad() {
     this.mapTheme = new MapLibreTheme(this.el);
@@ -105,7 +74,7 @@ export class OgmMap {
     });
     this.getContainer();
     this.addControls();
-    this.map.on('load', () => this.loadResource(this.previewResource));
+    this.map.on('load', () => this.loadPreview());
     this.map.on('mousemove', this.handleHover.bind(this));
     this.map.on('click', this.handleClick.bind(this));
     this.map.on('error', this.handleMapError.bind(this));
@@ -161,33 +130,17 @@ export class OgmMap {
     );
   }
 
-  // Get the appropriate previewer for our resource
-  protected async getMapPreviewer(map: maplibregl.Map) {
-    const style = this.mapTheme.getStyle();
-    if (this.previewResource instanceof OpenIndexMapResource) return new OpenIndexMapPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof EsriFeatureLayerResource) return new EsriFeatureLayerPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof GeoJsonResource) return new GeoJsonPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof PMTilesResource) {
-      if (await this.previewResource.isVector()) return new PMTilesVectorPreviewer(this.previewResource, map, style);
-      else return new PMTilesRasterPreviewer(this.previewResource, map, style);
-    } else if (this.previewResource instanceof TileJsonResource) {
-      if (await this.previewResource.isVector()) return new TileJsonVectorPreviewer(this.previewResource, map, style);
-      else return new TileJsonRasterPreviewer(this.previewResource, map, style);
-    } else if (this.previewResource instanceof WmsResource) return new WmsPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof CogResource) return new CogPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof WmtsResource) return new WmtsPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof EsriTiledMapLayerResource) return new EsriTiledMapLayerPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof EsriDynamicMapLayerResource) return new EsriDynamicMapLayerPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof EsriImageMapLayerResource) return new EsriImageMapLayerPreviewer(this.previewResource, map, style);
-    else if (this.previewResource instanceof RasterResource) return new RasterPreviewer(this.previewResource, map, style);
+  @Watch('previewer')
+  async onPreviewerChange(_previewer: MapPreviewer, previous?: MapPreviewer) {
+    if (previous) await previous.clearPreview();
+    await this.loadPreview();
   }
 
-  @Watch('previewResource')
-  async loadResource(resource: Resource) {
-    // Do nothing if we didn't get passed a resource
-    if (!resource) return;
+  // Draw the current preview onto the map.
+  async loadPreview() {
+    if (!this.previewer || !this.map) return;
 
-    // Fresh load attempt: allow one error to be reported again for this source
+    // Fresh load attempt: allow one error to be reported again for this preview
     this.errorReported = false;
 
     // Indicate loading state so we can show the spinner
@@ -202,31 +155,22 @@ export class OgmMap {
     // Close popup if one is open
     this.destroyPopup();
 
-    // Clear the existing preview
-    if (this.previewer) {
-      await this.previewer.clearPreview();
-      this.previewer = undefined;
-    }
-
     try {
-      // Get the appropriate previewer for our resource and preview it
-      this.previewer = await this.getMapPreviewer(this.map);
-      if (!this.previewer) throw new Error(`No previewer found for resource: ${resource.constructor.name}`);
+      // The style is only known now: it comes out of the theme, and the theme can change under a
+      // preview that is already on screen
+      this.previewer.attach(this.map, this.mapTheme.getStyle());
       await this.previewer.preview();
 
       // Set up the layer controls
       this.applyLayerState();
       this.setupLayerControls();
 
-      // Fit to bounds from the record; the spinner stays up until the map finishes moving
-      const bounds = await this.previewResource.getBounds();
+      // Fit to the preview's bounds; the spinner stays up until the map finishes moving
+      const bounds = await this.previewer.getBounds();
       if (bounds) await this.fitMapBounds(bounds);
     } catch (error) {
-      console.error(`Error previewing resource ${resource.url}:`, error);
-      if (!this.errorReported) {
-        this.errorReported = true;
-        this.previewError.emit(referenceError(error, resource.label(), resource.url));
-      }
+      console.error(`Error previewing ${this.previewer.url}:`, error);
+      this.reportError(error);
     } finally {
       this.mapIdle.emit();
     }
@@ -236,19 +180,28 @@ export class OgmMap {
   @Watch('theme')
   onThemeChange() {
     if (!this.map) return;
+    // The popup reads from sources setStyle is about to drop, so it goes first
+    this.destroyPopup();
     // The panel is still on screen over the window this opens, and a layer can't be styled inside it
     this.mapStyleLoaded = false;
     this.map.setStyle(this.mapTheme.getBaseMapStyle());
-    this.map.once('style.load', async () => await this.loadResource(this.previewResource));
+    // The same preview, drawn again into the style document the swap just emptied
+    this.map.once('style.load', async () => await this.loadPreview());
   }
 
-  // Surface MapLibre errors tied to the current previewed resource, skipping the
-  // noise from basemap/glyph/sprite loads, and deduped to a single alert per load attempt.
+  // Surface MapLibre errors tied to the current preview, skipping the noise from basemap/glyph/
+  // sprite loads, and deduped to a single alert per load attempt.
   protected handleMapError(event: maplibregl.ErrorEvent & { sourceId?: string }) {
-    if (this.errorReported || !this.previewResource || !this.previewer) return;
+    if (this.errorReported || !this.previewer) return;
     if (!this.previewer.sourceIds.includes(event.sourceId ?? '')) return;
+    this.reportError(event.error);
+  }
+
+  // Emit a single preview error per load attempt
+  private reportError(error: unknown) {
+    if (this.errorReported || !this.previewer) return;
     this.errorReported = true;
-    this.previewError.emit(referenceError(event.error, this.previewResource.label(), this.previewResource.url));
+    this.previewError.emit(referenceError(error, this.previewer.label(), this.previewer.url));
   }
 
   // Fit the map to the given bounds; resolve once the move finishes
@@ -364,7 +317,7 @@ export class OgmMap {
     // Get the features, if any, at the clicked point. If none, do nothing. A failed request means
     // this one click went unanswered, not that the preview is broken, so it stays out of the alerts.
     const features = await this.handleInspection(event.point).catch(error => {
-      console.error(`Error inspecting ${this.previewResource?.url}:`, error);
+      console.error(`Error inspecting ${this.previewer?.url}:`, error);
       return [];
     });
     if (features.length === 0) return;

--- a/src/components/ogm-preview/ogm-preview.test.tsx
+++ b/src/components/ogm-preview/ogm-preview.test.tsx
@@ -5,33 +5,50 @@ import { describe, it, expect, h, vi } from '@stencil/vitest';
 // when they try to initialize WebGL/OpenSeadragon (unavailable in the test DOM).
 import { render as stencilRender } from '@stencil/core';
 
+import GeoJsonPreviewer from '../../lib/previewers/geojson';
+import ImagePreviewer from '../../lib/previewers/image';
 import GeoJsonResource from '../../lib/resources/geojson';
+import IIIFResource from '../../lib/resources/iiif';
+import type { AnyPreviewer } from '../../lib/previewers/factory';
 import { referenceError } from '../../lib/errors';
 
 // Let Stencil's RAF-based update cycle flush after a state change (mirrors the vitest waitForChanges).
 const flush = () => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
-const renderPreview = async (resource: GeoJsonResource) => {
+const renderPreview = async (previewer: AnyPreviewer) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-  await stencilRender(<ogm-preview previewResource={resource}></ogm-preview>, container);
+  await stencilRender(<ogm-preview previewer={previewer}></ogm-preview>, container);
   const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
   await el.componentOnReady?.();
   consoleError.mockRestore();
   return el;
 };
 
+const mapPreviewer = () => new GeoJsonPreviewer(new GeoJsonResource('id', 'http://example.com/data.json'));
+
 describe('ogm-preview', () => {
-  it('renders a preview for a source', async () => {
-    const el = await renderPreview(new GeoJsonResource('id', 'http://example.com/data.json'));
+  it('draws a map preview with the map', async () => {
+    const el = await renderPreview(mapPreviewer());
     const shadowRoot = el.shadowRoot as ShadowRoot;
     expect(shadowRoot.querySelector('ogm-map')).not.toBeNull();
+    expect(shadowRoot.querySelector('ogm-image')).toBeNull();
     expect(shadowRoot.querySelector('ogm-alerts')).toBeNull();
   });
 
+  // The previewer is built here, in the test's own module realm, while the component under test
+  // comes from the built dist bundle. Routing on a string rather than a class is what lets these
+  // two disagree about identity and still land in the right viewer.
+  it('draws an image preview with the image viewer', async () => {
+    const el = await renderPreview(new ImagePreviewer(new IIIFResource('id', 'http://example.com/iiif/info.json')));
+    const shadowRoot = el.shadowRoot as ShadowRoot;
+    expect(shadowRoot.querySelector('ogm-image')).not.toBeNull();
+    expect(shadowRoot.querySelector('ogm-map')).toBeNull();
+  });
+
   it('shows the error over the preview when a previewError is reported', async () => {
-    const el = await renderPreview(new GeoJsonResource('id', 'http://example.com/data.json'));
+    const el = await renderPreview(mapPreviewer());
     const error = referenceError(new TypeError('Failed to fetch'), 'GeoJSON', 'http://example.com/data.json');
 
     el.dispatchEvent(new CustomEvent('previewError', { detail: error, bubbles: true }));

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -1,10 +1,9 @@
 import { Component, h, Host, Listen, Prop, State, Watch } from '@stencil/core';
 
-import IIIFResource from '../../lib/resources/iiif';
-import type Resource from '../../lib/resources/resource';
+import type { AnyPreviewer } from '../../lib/previewers/factory';
 import type { PreviewError } from '../../lib/errors';
 
-// Wraps a single resource's preview and surfaces error(s) during the preview.
+// Wraps a single preview and surfaces error(s) during it.
 @Component({
   tag: 'ogm-preview',
   styleUrl: 'ogm-preview.css',
@@ -12,12 +11,12 @@ import type { PreviewError } from '../../lib/errors';
 })
 export class OgmPreview {
   @Prop() theme: 'light' | 'dark';
-  @Prop() previewResource: Resource;
+  @Prop() previewer: AnyPreviewer;
   @Prop() sidebarPadding: number;
   @State() error?: PreviewError;
 
-  // A new resource is a fresh load attempt, so clear any error left over from the previous one.
-  @Watch('previewResource')
+  // A new preview is a fresh load attempt, so clear any error left over from the previous one.
+  @Watch('previewer')
   resetError() {
     this.error = undefined;
   }
@@ -29,12 +28,12 @@ export class OgmPreview {
     this.error = event.detail;
   }
 
-  // IIIF sources use the image viewer; every other source type is previewed on the map.
   private renderPreview() {
-    if (this.previewResource instanceof IIIFResource) {
-      return <ogm-image theme={this.theme} previewResource={this.previewResource} padding={this.sidebarPadding}></ogm-image>;
+    if (!this.previewer) return;
+    if (this.previewer.renderer === 'image') {
+      return <ogm-image theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-image>;
     }
-    return <ogm-map theme={this.theme} previewResource={this.previewResource} padding={this.sidebarPadding}></ogm-map>;
+    return <ogm-map theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-map>;
   }
 
   render() {

--- a/src/components/ogm-previews/ogm-previews.test.tsx
+++ b/src/components/ogm-previews/ogm-previews.test.tsx
@@ -39,8 +39,8 @@ const renderPreviews = async (record?: OgmRecord) => {
 const flush = () => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
 // Render previews and drill into the single <ogm-preview> to see which preview (map or image) it
-// chose. Going through <ogm-previews> means the source is constructed in the built component's module
-// realm, so <ogm-preview>'s `instanceof IIIFResource` check holds (unlike a source built in the test).
+// chose. The record here is built in the test's own module realm and the components come from the
+// built dist bundle; nothing downstream may test a class, only the strings they agree on.
 const renderPreviewChild = async (record: OgmRecord) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -95,5 +95,23 @@ describe('ogm-previews', () => {
 
     expect(previewShadow.querySelector('ogm-image')).not.toBeNull();
     expect(previewShadow.querySelector('ogm-map')).toBeNull();
+  });
+
+  // A tab is one preview, not one reference: a resource that can be shown more than one way gets a
+  // tab for each, and each of those tabs drives a panel holding exactly one preview.
+  it('gives every preview its own tab, and every tab its own panel', async () => {
+    const shadowRoot = await renderPreviews(
+      buildRecordWith({
+        'http://iiif.io/api/image': 'https://example.com/iiif/info.json',
+        'http://geojson.org/geojson-spec.html': 'https://example.com/data.json',
+      }),
+    );
+
+    const tabs = Array.from(shadowRoot.querySelectorAll('wa-tab'));
+    const panels = Array.from(shadowRoot.querySelectorAll('wa-tab-panel'));
+
+    expect(tabs.map(tab => tab.textContent?.trim())).toEqual(['IIIF Image', 'GeoJSON']);
+    expect(tabs.map(tab => tab.getAttribute('panel'))).toEqual(panels.map(panel => panel.getAttribute('name')));
+    expect(shadowRoot.querySelectorAll('ogm-preview')).toHaveLength(2);
   });
 });

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -1,22 +1,8 @@
-import { Component, h, Prop, State, Watch, Host } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
 import type OgmRecord from '../../lib/record';
-import type Resource from '../../lib/resources/resource';
 
-import CogResource from '../../lib/resources/cog';
-import EsriDynamicMapLayerResource from '../../lib/resources/esri-dynamic-map-layer';
-import EsriFeatureLayerResource from '../../lib/resources/esri-feature-layer';
-import EsriImageMapLayerResource from '../../lib/resources/esri-image-map-layer';
-import EsriTiledMapLayerResource from '../../lib/resources/esri-tiled-map-layer';
-import GeoJsonResource from '../../lib/resources/geojson';
-import OpenIndexMapResource from '../../lib/resources/openindexmap';
-import PMTilesResource from '../../lib/resources/pmtiles';
-import TileJsonResource from '../../lib/resources/tilejson';
-import TmsResource from '../../lib/resources/tms';
-import WmsResource from '../../lib/resources/wms';
-import WmtsResource from '../../lib/resources/wmts';
-import XyzResource from '../../lib/resources/xyz';
-import IIIFResource from '../../lib/resources/iiif';
-import IIIFManifestResource from '../../lib/resources/iiif-manifest';
+import { resourcesFor } from '../../lib/resources/factory';
+import { previewersForResources, type AnyPreviewer } from '../../lib/previewers/factory';
 
 @Component({
   tag: 'ogm-previews',
@@ -27,53 +13,61 @@ export class OgmPreviews {
   @Prop() theme: 'light' | 'dark';
   @Prop() record: OgmRecord;
   @Prop() sidebarPadding: number;
-  @State() resources: Resource[] = [];
+  @State() previewers: AnyPreviewer[] = [];
+  @Event() previewsLoading: EventEmitter<void>;
+  @Event() previewsLoaded: EventEmitter<void>;
 
-  // @Watch only fires on changes; handle the initial load here
+  // Which build of the list is the current one. A record can change while the previous one's
+  // previews are still being worked out, and the answer that arrives last is not necessarily the
+  // one still wanted.
+  private pending = 0;
+
+  // @Watch only fires on changes, so the record we were rendered with is handled here. Returning
+  // the promise makes Stencil hold the first render until the tabs are known, so the tab strip is
+  // never painted empty and then filled in.
   componentWillLoad() {
-    if (this.record) this.getSources(this.record);
+    return this.buildPreviewers(this.record);
   }
 
-  // Given a record, get all of the valid sources that can be used to preview it on a map
   @Watch('record')
-  protected getSources(record: OgmRecord) {
-    while (this.resources.length) this.resources.pop();
-    const recordBounds = record.getBounds();
-
-    if (record.references.iiifImageUrl) this.resources.push(new IIIFResource(record.id, record.references.iiifImageUrl, recordBounds));
-    if (record.references.iiifManifestUrl) this.resources.push(new IIIFManifestResource(record.id, record.references.iiifManifestUrl, recordBounds));
-    if (record.references.pmtilesUrl) this.resources.push(new PMTilesResource(record.id, record.references.pmtilesUrl, recordBounds));
-    if (record.references.tilejsonUrl) this.resources.push(new TileJsonResource(record.id, record.references.tilejsonUrl, recordBounds));
-    if (record.references.indexMapUrl) this.resources.push(new OpenIndexMapResource(record.id, record.references.indexMapUrl, recordBounds));
-    if (record.references.geojsonUrl) this.resources.push(new GeoJsonResource(record.id, record.references.geojsonUrl, recordBounds));
-    if (record.references.esriFeatureLayerUrl) this.resources.push(new EsriFeatureLayerResource(record.id, record.references.esriFeatureLayerUrl, recordBounds));
-    if (record.references.cogUrl) this.resources.push(new CogResource(record.id, record.references.cogUrl, recordBounds));
-    if (record.references.tmsUrl) this.resources.push(new TmsResource(record.id, record.references.tmsUrl, recordBounds));
-    if (record.references.xyzUrl) this.resources.push(new XyzResource(record.id, record.references.xyzUrl, recordBounds));
-    if (record.references.esriTiledMapLayerUrl) this.resources.push(new EsriTiledMapLayerResource(record.id, record.references.esriTiledMapLayerUrl, recordBounds));
-    if (record.references.esriDynamicMapLayerUrl) this.resources.push(new EsriDynamicMapLayerResource(record.id, record.references.esriDynamicMapLayerUrl, recordBounds));
-    if (record.references.esriImageMapLayerUrl) this.resources.push(new EsriImageMapLayerResource(record.id, record.references.esriImageMapLayerUrl, recordBounds));
-    if (record.references.wmtsUrl && record.wxsIdentifier)
-      this.resources.push(new WmtsResource(record.id, record.references.wmtsUrl, { layerIds: [record.wxsIdentifier] }, recordBounds));
-    if (record.references.wmsUrl && record.wxsIdentifier)
-      this.resources.push(new WmsResource(record.id, record.references.wmsUrl, { layerIds: [record.wxsIdentifier] }, recordBounds));
+  protected async onRecordChange(record?: OgmRecord) {
+    await this.buildPreviewers(record);
   }
 
-  // Render as tabs for switching between sources
+  // Every preview this record offers, one per tab
+  private async buildPreviewers(record?: OgmRecord) {
+    const build = ++this.pending;
+    if (!record) {
+      this.previewers = [];
+      return;
+    }
+
+    this.previewsLoading.emit();
+    try {
+      const previewers = await previewersForResources(resourcesFor(record));
+      // A newer record started building while this one was waiting; that one's answer is the keeper
+      if (build === this.pending) this.previewers = previewers;
+    } finally {
+      // Always paired with the emit above, even when superseded: ogm-viewer counts these
+      this.previewsLoaded.emit();
+    }
+  }
+
+  // Render as tabs for switching between previews
   render() {
-    if (!this.record || !this.resources.length) return;
+    if (!this.record || !this.previewers.length) return;
 
     return (
       <Host class={this.theme && `wa-${this.theme}`}>
         <wa-tab-group>
-          {this.resources.map((resource, idx) => (
-            <wa-tab key={idx} panel={`${resource.constructor.name}-${resource.id}-${idx}`}>
-              {resource.label()}
+          {this.previewers.map((previewer, idx) => (
+            <wa-tab key={idx} panel={previewer.previewId}>
+              {previewer.label()}
             </wa-tab>
           ))}
-          {this.resources.map((resource, idx) => (
-            <wa-tab-panel key={idx} name={`${resource.constructor.name}-${resource.id}-${idx}`} active={idx === 0}>
-              <ogm-preview theme={this.theme} previewResource={resource} sidebar-padding={this.sidebarPadding}></ogm-preview>
+          {this.previewers.map((previewer, idx) => (
+            <wa-tab-panel key={idx} name={previewer.previewId} active={idx === 0}>
+              <ogm-preview theme={this.theme} previewer={previewer} sidebar-padding={this.sidebarPadding}></ogm-preview>
             </wa-tab-panel>
           ))}
         </wa-tab-group>

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -77,7 +77,9 @@ export class OgmViewer {
     this.record = record;
   }
 
-  // Listen for a preview to report loading started
+  // Listen for a preview to report loading started. Working out which previews a record even has
+  // can mean reading a remote document, so that wait is counted here too.
+  @Listen('previewsLoading')
   @Listen('mapLoading')
   @Listen('imageLoading')
   setLoadingStarted() {
@@ -86,6 +88,7 @@ export class OgmViewer {
   }
 
   // When all in-flight previews have loaded, clear loading state
+  @Listen('previewsLoaded')
   @Listen('mapIdle')
   @Listen('imageLoaded')
   setLoadingFinished() {

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -2,6 +2,11 @@ import type { LayerSpecification as MapLibreLayerSpecification } from 'maplibre-
 
 // A MapLibre style layer, one piece of a logical layer. Vector layers can have
 // multiple of these, e.g. to style fills, outlines, and labels separately.
+//
+// A preview drawn by something other than MapLibre - an Allmaps warped map, a deck.gl overlay -
+// goes on as a CustomLayerInterface, whose type is 'custom'. That isn't one of the types below, so
+// the union will have to widen for one, and such a layer paints itself rather than through
+// setPaintProperty, so its previewer overrides applyOpacity.
 export type PreviewStyleLayer = {
   id: string;
   type: MapLibreLayerSpecification['type'];

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -11,9 +11,11 @@ import { type MapLibreStyle } from '../themes/maplibre';
 // NOTE: can't be built currently due to a bug; see:
 // https://github.com/OpenGeoMetadata/ogm-viewer/issues/100
 export default class DeckCogPreviewer extends Previewer {
+  readonly renderer = 'map' as const;
+
   declare protected resource: MapResource;
 
-  // Store reference to the map and styles
+  // Set by attach(), before anything is drawn; see MapPreviewer#attach
   protected style: MapLibreStyle;
   protected map: maplibregl.Map;
 
@@ -27,13 +29,13 @@ export default class DeckCogPreviewer extends Previewer {
   // Current opacity state
   protected opacity: number;
 
-  // Initialize with opacity at the theme's opacity value
-  constructor(resource: MapResource, map: maplibregl.Map, style: MapLibreStyle) {
-    super(resource);
+  // Bind to the map, and start out at the theme's opacity value
+  attach(map: maplibregl.Map, style: MapLibreStyle): this {
     this.map = map;
     this.style = style;
     this.opacity = this.style.opacity;
     this.deckOverlay = this.getDeckOverlay();
+    return this;
   }
 
   async preview(): Promise<void> {

--- a/src/lib/previewers/cog.test.ts
+++ b/src/lib/previewers/cog.test.ts
@@ -39,7 +39,7 @@ const COG_URL = 'https://example.com/scan.tif';
 // Nothing here reads the GeoTIFF: the source is built from the URL alone
 const preview = async () => {
   const map = new FakeMap();
-  const previewer = new CogPreviewer(new CogResource('princeton-fk4544658v', COG_URL), map as unknown as maplibregl.Map, style);
+  const previewer = new CogPreviewer(new CogResource('princeton-fk4544658v', COG_URL)).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
   return { map, previewer };
 };

--- a/src/lib/previewers/cog.ts
+++ b/src/lib/previewers/cog.ts
@@ -2,8 +2,8 @@ import maplibregl from 'maplibre-gl';
 import { cogProtocol } from '@geomatico/maplibre-cog-protocol';
 
 import RasterPreviewer from './raster';
-import CogResource from '../resources/cog';
-import { type MapLibreStyle } from '../themes/maplibre';
+import type CogResource from '../resources/cog';
+import type Resource from '../resources/resource';
 import { type AddRasterSourceObject } from './raster';
 
 // COG previewer using MapLibre COG protocol plugin
@@ -12,9 +12,10 @@ import { type AddRasterSourceObject } from './raster';
 export default class CogPreviewer extends RasterPreviewer {
   declare protected resource: CogResource;
 
-  // Register the 'cog://' protocol handler with MapLibre when the previewer is created
-  constructor(resource: CogResource, map: maplibregl.Map, style: MapLibreStyle) {
-    super(resource, map, style);
+  // Register the 'cog://' protocol handler with MapLibre when the previewer is created. Takes a
+  // Resource like every other previewer - the narrowing that matters is on the field above.
+  constructor(resource: Resource) {
+    super(resource);
     maplibregl.addProtocol('cog', cogProtocol);
   }
 

--- a/src/lib/previewers/esri-feature-layer.test.ts
+++ b/src/lib/previewers/esri-feature-layer.test.ts
@@ -63,7 +63,7 @@ let previewer: EsriFeatureLayerPreviewer;
 
 beforeEach(async () => {
   map = new FakeMap();
-  previewer = new EsriFeatureLayerPreviewer(new TestResource('trees', LAYER), map as unknown as maplibregl.Map, style);
+  previewer = new EsriFeatureLayerPreviewer(new TestResource('trees', LAYER)).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
 });
 

--- a/src/lib/previewers/esri-raster.test.ts
+++ b/src/lib/previewers/esri-raster.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
 
 const dynamicPreviewer = (metadata: EsriMetadata = { capabilities: 'Map,Query,Data' }) => {
   const resource = stubMetadata(new EsriDynamicMapLayerResource('glacial', SERVICE), metadata);
-  return new EsriDynamicMapLayerPreviewer(resource, map as unknown as maplibregl.Map, style);
+  return new EsriDynamicMapLayerPreviewer(resource).attach(map as unknown as maplibregl.Map, style);
 };
 
 describe('EsriRasterPreviewer#preview', () => {
@@ -123,7 +123,7 @@ describe('EsriRasterPreviewer#preview', () => {
     (resource as unknown as { getMetadata: () => Promise<EsriMetadata> }).getMetadata = async () => {
       throw new Error('unreachable');
     };
-    const previewer = new EsriDynamicMapLayerPreviewer(resource, map as unknown as maplibregl.Map, style);
+    const previewer = new EsriDynamicMapLayerPreviewer(resource).attach(map as unknown as maplibregl.Map, style);
 
     await previewer.preview();
 
@@ -134,8 +134,8 @@ describe('EsriRasterPreviewer#preview', () => {
 
   it('gives each kind of ArcGIS layer its own source, so a record can carry several', async () => {
     const dynamic = dynamicPreviewer();
-    const image = new EsriImageMapLayerPreviewer(stubMetadata(new EsriImageMapLayerResource('glacial', IMAGE_SERVICE), {}), map as unknown as maplibregl.Map, style);
-    const tiled = new EsriTiledMapLayerPreviewer(stubMetadata(new EsriTiledMapLayerResource('glacial', SERVICE), XYZ_CACHE), map as unknown as maplibregl.Map, style);
+    const image = new EsriImageMapLayerPreviewer(stubMetadata(new EsriImageMapLayerResource('glacial', IMAGE_SERVICE), {})).attach(map as unknown as maplibregl.Map, style);
+    const tiled = new EsriTiledMapLayerPreviewer(stubMetadata(new EsriTiledMapLayerResource('glacial', SERVICE), XYZ_CACHE)).attach(map as unknown as maplibregl.Map, style);
 
     await dynamic.preview();
     await image.preview();
@@ -150,7 +150,7 @@ describe('EsriRasterPreviewer#preview', () => {
 describe('EsriTiledMapLayerPreviewer#preview', () => {
   it('passes the cache tiling straight through to the source', async () => {
     const resource = stubMetadata(new EsriTiledMapLayerResource('mn-landcover', SERVICE), XYZ_CACHE);
-    const previewer = new EsriTiledMapLayerPreviewer(resource, map as unknown as maplibregl.Map, style);
+    const previewer = new EsriTiledMapLayerPreviewer(resource).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
 
     const source = map.sources.get('mn-landcover-esri-tiled-map-layer');

--- a/src/lib/previewers/factory.test.ts
+++ b/src/lib/previewers/factory.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
+
+import { previewersFor, previewersForResources } from './factory';
+import type Resource from '../resources/resource';
+import type { ResourceKind } from '../resources/resource';
+
+import CogPreviewer from './cog';
+import EsriDynamicMapLayerPreviewer from './esri-dynamic-map-layer';
+import EsriFeatureLayerPreviewer from './esri-feature-layer';
+import EsriImageMapLayerPreviewer from './esri-image-map-layer';
+import EsriTiledMapLayerPreviewer from './esri-tiled-map-layer';
+import GeoJsonPreviewer from './geojson';
+import ImagePreviewer from './image';
+import OpenIndexMapPreviewer from './openindexmap';
+import PMTilesRasterPreviewer from './pmtiles-raster';
+import PMTilesVectorPreviewer from './pmtiles-vector';
+import RasterPreviewer from './raster';
+import TileJsonRasterPreviewer from './tilejson-raster';
+import TileJsonVectorPreviewer from './tilejson-vector';
+import WmsPreviewer from './wms';
+import WmtsPreviewer from './wmts';
+
+// The factory reads a resource's kind and, for a tileset, asks what it holds. Nothing else, so a
+// plain object stands in for one - and using a real class here would prove less, since the point
+// is that nothing is dispatched on the class.
+const resourceOfKind = (kind: string, extra: object = {}) => ({ kind, id: 'test-record', url: 'https://example.com/data', ...extra }) as unknown as Resource;
+
+// Every kind that resolves without reading anything remote. Note the three that the old instanceof
+// ladder had to hand-order: an index map and an ArcGIS feature layer are both kinds of GeoJSON, so
+// listing either after 'geojson' would have drawn it as plain GeoJSON.
+const SYNCHRONOUS: [ResourceKind, new (...args: never[]) => unknown][] = [
+  ['iiif-image', ImagePreviewer],
+  ['iiif-manifest', ImagePreviewer],
+  ['geojson', GeoJsonPreviewer],
+  ['openindexmap', OpenIndexMapPreviewer],
+  ['esri-feature-layer', EsriFeatureLayerPreviewer],
+  ['esri-dynamic-map-layer', EsriDynamicMapLayerPreviewer],
+  ['esri-image-map-layer', EsriImageMapLayerPreviewer],
+  ['esri-tiled-map-layer', EsriTiledMapLayerPreviewer],
+  ['wms', WmsPreviewer],
+  ['wmts', WmtsPreviewer],
+  ['cog', CogPreviewer],
+  ['tms', RasterPreviewer],
+  ['xyz', RasterPreviewer],
+];
+
+describe('previewersFor', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(SYNCHRONOUS)('previews a %s resource with the previewer written for it', async (kind, expected) => {
+    const previewers = await previewersFor(resourceOfKind(kind));
+
+    expect(previewers).toHaveLength(1);
+    // The exact class, not `instanceof`: half of these extend one of the others, and being handed
+    // the parent is precisely the failure the old ordered ladder could produce
+    expect(previewers[0].constructor).toBe(expected);
+  });
+
+  // These were the ladder's only async branches, and the reason the whole list is built async
+  describe('a tileset that could hold either kind of tiles', () => {
+    it.each([
+      ['pmtiles', true, PMTilesVectorPreviewer],
+      ['pmtiles', false, PMTilesRasterPreviewer],
+      ['tilejson', true, TileJsonVectorPreviewer],
+      ['tilejson', false, TileJsonRasterPreviewer],
+    ] as const)('reads a %s archive that says isVector=%s and picks accordingly', async (kind, isVector, expected) => {
+      const [previewer] = await previewersFor(resourceOfKind(kind, { isVector: async () => isVector }));
+
+      expect(previewer.constructor).toBe(expected);
+    });
+
+    // Losing the tab would hide the broken reference; the raster previewer will fail on the same
+    // URL and that failure is what reaches the user
+    it.each(['pmtiles', 'tilejson'] as const)('still offers a tab for a %s archive whose header cannot be read', async kind => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const unreadable = resourceOfKind(kind, {
+        isVector: async () => {
+          throw new Error('offline');
+        },
+      });
+
+      const [previewer] = await previewersFor(unreadable);
+
+      expect(previewer.constructor).toBe(kind === 'pmtiles' ? PMTilesRasterPreviewer : TileJsonRasterPreviewer);
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  it('offers nothing for a resource it does not recognize, rather than failing the record', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(await previewersFor(resourceOfKind('something-newer'))).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('previewersForResources', () => {
+  it('keeps the previews of a record in the order its resources were listed', async () => {
+    const previewers = await previewersForResources([resourceOfKind('iiif-image'), resourceOfKind('wms'), resourceOfKind('geojson')]);
+
+    expect(previewers.map(previewer => previewer.renderer)).toEqual(['image', 'map', 'map']);
+  });
+
+  // Each preview is one tab, so two that landed on the same id would collide in the tab group
+  it('gives every preview of a record its own id', async () => {
+    const previewers = await previewersForResources([resourceOfKind('iiif-image'), resourceOfKind('iiif-manifest'), resourceOfKind('wms')]);
+    const ids = previewers.map(previewer => previewer.previewId);
+
+    expect(new Set(ids).size).toEqual(ids.length);
+    expect(ids).toEqual(['test-record-iiif-image-image', 'test-record-iiif-manifest-image', 'test-record-wms-map']);
+  });
+
+  it('offers nothing for a record with no resources', async () => {
+    expect(await previewersForResources([])).toEqual([]);
+  });
+});

--- a/src/lib/previewers/factory.ts
+++ b/src/lib/previewers/factory.ts
@@ -1,0 +1,87 @@
+import type MapResource from '../resources/map';
+import type Resource from '../resources/resource';
+import type { ResourceKind } from '../resources/resource';
+
+import type MapPreviewer from './map';
+
+import CogPreviewer from './cog';
+import EsriDynamicMapLayerPreviewer from './esri-dynamic-map-layer';
+import EsriFeatureLayerPreviewer from './esri-feature-layer';
+import EsriImageMapLayerPreviewer from './esri-image-map-layer';
+import EsriTiledMapLayerPreviewer from './esri-tiled-map-layer';
+import GeoJsonPreviewer from './geojson';
+import ImagePreviewer from './image';
+import OpenIndexMapPreviewer from './openindexmap';
+import PMTilesRasterPreviewer from './pmtiles-raster';
+import PMTilesVectorPreviewer from './pmtiles-vector';
+import RasterPreviewer from './raster';
+import TileJsonRasterPreviewer from './tilejson-raster';
+import TileJsonVectorPreviewer from './tilejson-vector';
+import WmsPreviewer from './wms';
+import WmtsPreviewer from './wmts';
+
+// Every preview this library can draw. The renderer is the discriminant, so a component can tell
+// which one it's holding without a class test.
+export type AnyPreviewer = MapPreviewer | ImagePreviewer;
+
+// Builds every preview one resource offers
+type PreviewerBuilder = (resource: Resource) => AnyPreviewer[] | Promise<AnyPreviewer[]>;
+
+// Whether a tileset holds vector tiles. Reading that means reading a PMTiles header or a TileJSON
+// document, either of which can fail.
+const holdsVectors = async (resource: Resource): Promise<boolean> =>
+  await (resource as MapResource).isVector().catch(error => {
+    console.warn(`Could not tell whether ${resource.url} holds vector tiles:`, error);
+    return false;
+  });
+
+// How each kind of resource is previewed. Keyed rather than tested in order, so adding a
+// ResourceKind is a compile error until it says how it should be drawn, and a subclass no longer
+// has to be listed ahead of its parent to be reachable at all.
+const BUILDERS: Record<ResourceKind, PreviewerBuilder> = {
+  'iiif-image': resource => [new ImagePreviewer(resource)],
+  'iiif-manifest': resource => [new ImagePreviewer(resource)],
+  'geojson': resource => [new GeoJsonPreviewer(resource)],
+  'openindexmap': resource => [new OpenIndexMapPreviewer(resource)],
+  'esri-feature-layer': resource => [new EsriFeatureLayerPreviewer(resource)],
+  'esri-dynamic-map-layer': resource => [new EsriDynamicMapLayerPreviewer(resource)],
+  'esri-image-map-layer': resource => [new EsriImageMapLayerPreviewer(resource)],
+  'esri-tiled-map-layer': resource => [new EsriTiledMapLayerPreviewer(resource)],
+  'wms': resource => [new WmsPreviewer(resource)],
+  'wmts': resource => [new WmtsPreviewer(resource)],
+  'cog': resource => [new CogPreviewer(resource)],
+  'tms': resource => [new RasterPreviewer(resource)],
+  'xyz': resource => [new RasterPreviewer(resource)],
+
+  // An archive or a tileset document can describe either kind of tiles, and the only way to find
+  // out is to read it
+  'pmtiles': async resource => [(await holdsVectors(resource)) ? new PMTilesVectorPreviewer(resource) : new PMTilesRasterPreviewer(resource)],
+  'tilejson': async resource => [(await holdsVectors(resource)) ? new TileJsonVectorPreviewer(resource) : new TileJsonRasterPreviewer(resource)],
+};
+
+/**
+ * Every preview a single resource offers. A list, because one resource can be worth showing more
+ * than one way: a georeferenced scan is both an image to page through and a map to overlay, and
+ * each of those is its own tab.
+ */
+export async function previewersFor(resource: Resource): Promise<AnyPreviewer[]> {
+  const builder = BUILDERS[resource.kind];
+
+  // Only reached by a resource built from a copy of this library newer than the one drawing it
+  if (!builder) {
+    console.warn(`No preview for resource kind: ${resource.kind}`);
+    return [];
+  }
+
+  return await builder(resource);
+}
+
+/**
+ * Every preview a list of resources offers, in the order they were given - which is the tab order.
+ * Never rejects: this is awaited before the tabs are rendered, where a rejection would leave the
+ * whole record without a preview rather than the one reference that failed.
+ */
+export async function previewersForResources(resources: Resource[]): Promise<AnyPreviewer[]> {
+  const previewers = await Promise.all(resources.map(resource => previewersFor(resource)));
+  return previewers.flat();
+}

--- a/src/lib/previewers/geojson.test.ts
+++ b/src/lib/previewers/geojson.test.ts
@@ -60,14 +60,14 @@ const GEOJSON_URL = 'https://example.com/index-map.json';
 // Nothing here fetches: the source URL and the layer names are known without reading the document
 const previewGeoJson = async () => {
   const map = new FakeMap();
-  const previewer = new GeoJsonPreviewer(new GeoJsonResource('princeton-fk4544658v', GEOJSON_URL), map as unknown as maplibregl.Map, style);
+  const previewer = new GeoJsonPreviewer(new GeoJsonResource('princeton-fk4544658v', GEOJSON_URL)).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
   return { map, previewer };
 };
 
 const previewIndexMap = async () => {
   const map = new FakeMap();
-  const previewer = new OpenIndexMapPreviewer(new OpenIndexMapResource('princeton-fk4544658v', GEOJSON_URL), map as unknown as maplibregl.Map, style);
+  const previewer = new OpenIndexMapPreviewer(new OpenIndexMapResource('princeton-fk4544658v', GEOJSON_URL)).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
   return { map, previewer };
 };
@@ -98,6 +98,23 @@ describe('GeoJsonPreviewer#preview', () => {
 
     expect(map.sources.size).toEqual(0);
     expect(map.layers.size).toEqual(0);
+  });
+
+  // What a theme change leaves behind: setStyle() empties the style document, and the same
+  // previewer is asked to draw itself into the new one. What it says it put there has to describe
+  // the document in front of it, not every document it has ever drawn into - a second copy of a
+  // row would show the user the same layer twice in the layers panel.
+  it('draws again into an emptied style without doubling what it says it added', async () => {
+    const { map, previewer } = await previewGeoJson();
+
+    map.sources.clear();
+    map.layers.clear();
+    await previewer.preview();
+
+    expect(previewer.sourceIds).toEqual(['princeton-fk4544658v-geojson']);
+    expect(previewer.layerIds).toEqual(SUFFIXES.map(suffix => `princeton-fk4544658v-geojson-geojson-${suffix}`));
+    expect(previewer.previewLayers).toHaveLength(1);
+    expect(map.layers.size).toEqual(SUFFIXES.length);
   });
 });
 

--- a/src/lib/previewers/image.test.ts
+++ b/src/lib/previewers/image.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from '@stencil/vitest';
+import type { Viewer } from 'openseadragon';
+
+import ImagePreviewer from './image';
+import IIIFResource from '../resources/iiif';
+import IIIFManifestResource from '../resources/iiif-manifest';
+
+// Just enough of an OpenSeadragon viewer to record what the previewer opens and closes. The real
+// one can't be built outside a browser, which is why none of this could be tested until the logic
+// moved off ogm-image.
+class FakeViewer {
+  opened: string[][] = [];
+  closed = 0;
+
+  open(images: string[]) {
+    this.opened.push(images);
+  }
+  close() {
+    this.closed++;
+  }
+}
+
+const IMAGE_URL = 'https://example.com/iiif/image1/info.json';
+const MANIFEST_URL = 'https://example.com/manifest.json';
+
+// A minimal IIIF v3 manifest with two images, in the order they should be paged through
+const manifest = {
+  '@context': 'http://iiif.io/api/presentation/3/context.json',
+  'id': MANIFEST_URL,
+  'type': 'Manifest',
+  'items': ['image1', 'image2'].map(name => ({
+    id: `https://example.com/canvas/${name}`,
+    type: 'Canvas',
+    items: [
+      {
+        id: `https://example.com/annotationpage/${name}`,
+        type: 'AnnotationPage',
+        items: [
+          {
+            id: `https://example.com/annotation/${name}`,
+            type: 'Annotation',
+            body: { id: `https://example.com/${name}/full/full/0/default.jpg`, type: 'Image', service: { id: `https://example.com/${name}`, type: 'ImageService2' } },
+          },
+        ],
+      },
+    ],
+  })),
+};
+
+const serveManifest = (body: unknown) => vi.spyOn(global, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify(body)));
+
+let viewer: FakeViewer;
+
+const previewerFor = (resource: IIIFResource) => new ImagePreviewer(resource).attach(viewer as unknown as Viewer);
+
+describe('ImagePreviewer', () => {
+  beforeEach(() => (viewer = new FakeViewer()));
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('preview', () => {
+    // A bare IIIF Image reference is already the thing to open, so nothing is fetched to find out
+    it('opens the image a bare IIIF reference points at', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch');
+      await previewerFor(new IIIFResource('princeton-fk4544658v', IMAGE_URL)).preview();
+
+      expect(viewer.opened).toEqual([[IMAGE_URL]]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    // Page order is the manifest's order, which is the order the filmstrip offers them in
+    it('opens every image in a manifest, in the order it lists them', async () => {
+      serveManifest(manifest);
+      await previewerFor(new IIIFManifestResource('princeton-fk4544658v', MANIFEST_URL)).preview();
+
+      expect(viewer.opened).toEqual([['https://example.com/image1/info.json', 'https://example.com/image2/info.json']]);
+    });
+
+    // Previously this opened an empty viewer and said nothing; the tab has to report it instead
+    it('reports a manifest it could find no images in rather than opening nothing', async () => {
+      serveManifest({ ...manifest, items: [] });
+
+      await expect(previewerFor(new IIIFManifestResource('princeton-fk4544658v', MANIFEST_URL)).preview()).rejects.toThrow('No IIIF images found');
+      expect(viewer.opened).toEqual([]);
+    });
+
+    // The failure belongs to this preview, so it has to reach the tab rather than be swallowed
+    it('passes on a manifest that could not be fetched', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(new Response('Not found', { status: 404, statusText: 'Not Found' }));
+
+      await expect(previewerFor(new IIIFManifestResource('princeton-fk4544658v', MANIFEST_URL)).preview()).rejects.toMatchObject({ name: 'HttpError', status: 404 });
+      expect(viewer.opened).toEqual([]);
+    });
+  });
+
+  describe('clearPreview', () => {
+    it('closes what it opened', async () => {
+      const previewer = previewerFor(new IIIFResource('princeton-fk4544658v', IMAGE_URL));
+      await previewer.preview();
+      await previewer.clearPreview();
+
+      expect(viewer.closed).toEqual(1);
+    });
+
+    // Reachable for a preview whose tab was never drawn: there is no viewer to close
+    it('does nothing when it was never attached to a viewer', async () => {
+      await expect(new ImagePreviewer(new IIIFResource('princeton-fk4544658v', IMAGE_URL)).clearPreview()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('identity', () => {
+    it('labels its tab and names its panel from the resource it draws', () => {
+      const image = previewerFor(new IIIFResource('princeton-fk4544658v', IMAGE_URL));
+      const manifestPreviewer = previewerFor(new IIIFManifestResource('princeton-fk4544658v', MANIFEST_URL));
+
+      expect(image.label()).toEqual('IIIF Image');
+      expect(manifestPreviewer.label()).toEqual('IIIF Manifest');
+
+      // Two previews of one record have to land on different tabs, even sharing a record id
+      expect(image.previewId).toEqual('princeton-fk4544658v-iiif-image-image');
+      expect(manifestPreviewer.previewId).toEqual('princeton-fk4544658v-iiif-manifest-image');
+    });
+  });
+});

--- a/src/lib/previewers/image.ts
+++ b/src/lib/previewers/image.ts
@@ -1,0 +1,39 @@
+import type { Viewer } from 'openseadragon';
+
+import Previewer from './previewer';
+import type IIIFResource from '../resources/iiif';
+
+// A preview drawn by an image viewer rather than a map. The shape mirrors MapPreviewer: ogm-image
+// builds the viewer and hands it over, and this is what knows how to put a resource into it and
+// take it back out. One class rather than a hierarchy, because the difference between a bare image
+// URL and a manifest that has to be fetched and walked already lives in the resource.
+export default class ImagePreviewer extends Previewer {
+  readonly renderer = 'image' as const;
+
+  declare protected resource: IIIFResource;
+
+  // Set by attach(), before anything is drawn. Not a constructor argument, for the same reason a
+  // map isn't: OpenSeadragon needs an element to mount into, so the viewer doesn't exist until
+  // ogm-image has rendered - long after a record's previews have been worked out.
+  protected viewer: Viewer;
+
+  attach(viewer: Viewer): this {
+    this.viewer = viewer;
+    return this;
+  }
+
+  // Open this resource's images, in order. A manifest is fetched and walked here, so this is the
+  // first thing that can fail for a IIIF preview.
+  async preview(): Promise<void> {
+    const images = await this.resource.getIIIFImageUrls();
+    if (!images.length) throw new Error('No IIIF images found for this preview');
+    this.viewer.open(images);
+  }
+
+  // OpenSeadragon owns its own canvas, so unlike a map there is no shared document to take this
+  // preview back out of - closing is the whole of it.
+  async clearPreview(): Promise<void> {
+    if (!this.viewer) return;
+    this.viewer.close();
+  }
+}

--- a/src/lib/previewers/inspectable-raster.ts
+++ b/src/lib/previewers/inspectable-raster.ts
@@ -38,6 +38,7 @@ export default abstract class InspectableRasterPreviewer extends RasterPreviewer
   // but the extra source is ours to clean up
   async clearPreview(): Promise<void> {
     await super.clearPreview();
+    if (!this.attached) return;
     if (this.map.getSource(this.highlightSourceId)) {
       this.map.removeSource(this.highlightSourceId);
     }

--- a/src/lib/previewers/map.ts
+++ b/src/lib/previewers/map.ts
@@ -9,9 +9,13 @@ import { type MapLibreStyle } from '../themes/maplibre';
 type AddSourceObject = SourceSpecification & { id: string };
 
 export default abstract class MapPreviewer extends Previewer {
+  readonly renderer = 'map' as const;
+
   declare protected resource: MapResource;
 
-  // Store reference to the map and styles
+  // Set by attach(), before anything is drawn. Not constructor arguments: the map is built by
+  // ogm-map once its own element exists, long after a record's previews have been worked out, and
+  // setStyle() hands back a different style on every theme change.
   protected style: MapLibreStyle;
   protected map: maplibregl.Map;
 
@@ -25,37 +29,58 @@ export default abstract class MapPreviewer extends Previewer {
   previewLayers: Layer[] = [];
 
   // A memo of the last instruction applyLayerState was given, not a source of truth: ogm-map owns
-  // the user's choices, because setStyle rebuilds this object from scratch on every theme change.
+  // the user's choices, because setStyle empties the style document on every theme change and
+  // every layer they were made about is drawn again from scratch.
   private layerState: ReadonlyMap<string, LayerState> = new Map();
 
-  constructor(resource: MapResource, map: maplibregl.Map, style: MapLibreStyle) {
-    super(resource);
+  // Bind this preview to the map it draws on and the colors it draws with. Returns itself so a
+  // caller can build and bind in one breath.
+  attach(map: maplibregl.Map, style: MapLibreStyle): this {
     this.map = map;
     this.style = style;
+    return this;
+  }
+
+  // Whether this preview has a map to draw on yet. One built for a tab whose map never finished
+  // loading has nothing on any map to clean up.
+  protected get attached(): boolean {
+    return this.map !== undefined;
   }
 
   // Add source and preview layers if they don't already exist
   async preview(): Promise<void> {
+    // A preview is drawn more than once: setStyle() rebuilds the style document and takes every
+    // source and layer on it away, and the same previewer draws itself into the new one. What we
+    // record has to describe the document in front of us, not every document we've ever drawn
+    // into, so it starts empty each time rather than accumulating a copy per draw.
+    this.sourceIds = [];
+    this.layerIds = [];
+    this.previewLayers = [];
+
     const sources = await this.createSources();
 
     sources.forEach(source => {
       const { id, ...sourceSpec } = source as AddSourceObject;
+      // Recorded either way: a source already under this id is one we put there - ids carry the
+      // resource's own id - and clearPreview still has to take it back out.
+      this.sourceIds.push(id);
       if (this.map.getSource(id)) return;
       this.map.addSource(id, sourceSpec);
-      this.sourceIds.push(id);
     });
 
     const layers = await this.createLayers();
 
     layers.forEach(layer => {
+      this.layerIds.push(layer.id);
       if (this.map.getLayer(layer.id)) return;
       this.map.addLayer(layer);
-      this.layerIds.push(layer.id);
     });
   }
 
   // Remove preview layers and sources
   async clearPreview() {
+    if (!this.attached) return;
+
     this.layerIds.forEach(layerId => {
       if (this.map.getLayer(layerId)) {
         this.map.removeLayer(layerId);
@@ -143,8 +168,12 @@ export default abstract class MapPreviewer extends Previewer {
     return this.previewLayers.find(layer => layer.id === id);
   }
 
-  // Get the bounds of the preview data
-  abstract getBounds(): Promise<maplibregl.LngLatBoundsLike | undefined>;
+  // Where the map should be pointed to see this preview. The resource usually knows - from the
+  // record's bounding box, or from metadata it reads itself - so only a preview that learns its
+  // extent while drawing, like a warped image, has anything to override here.
+  async getBounds(): Promise<maplibregl.LngLatBoundsLike | undefined> {
+    return await this.resource.getBounds();
+  }
 
   // Create MapLibre sources for the preview
   protected abstract createSources(): Promise<AddSourceObject[]>;

--- a/src/lib/previewers/pmtiles-raster.ts
+++ b/src/lib/previewers/pmtiles-raster.ts
@@ -1,5 +1,4 @@
 import RasterPreviewer from './raster';
-import PMTilesResource from '../resources/pmtiles';
 import type { AddRasterSourceObject } from './raster';
 
 export default class PMTilesRasterPreviewer extends RasterPreviewer {
@@ -17,10 +16,5 @@ export default class PMTilesRasterPreviewer extends RasterPreviewer {
         url: await this.resource.getMapLibreSourceUrl(),
       },
     ];
-  }
-
-  // Raster PMTiles have bounds info in the header
-  async getBounds(): Promise<maplibregl.LngLatBoundsLike | undefined> {
-    return await (this.resource as unknown as PMTilesResource).getBounds();
   }
 }

--- a/src/lib/previewers/pmtiles.test.ts
+++ b/src/lib/previewers/pmtiles.test.ts
@@ -40,7 +40,7 @@ const PMTILES_URL = 'https://example.com/tiles.pmtiles';
 // touched for bounds
 const preview = async () => {
   const map = new FakeMap();
-  const previewer = new PMTilesRasterPreviewer(new PMTilesResource('princeton-fk4544658v', PMTILES_URL), map as unknown as maplibregl.Map, style);
+  const previewer = new PMTilesRasterPreviewer(new PMTilesResource('princeton-fk4544658v', PMTILES_URL)).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
   return { map, previewer };
 };

--- a/src/lib/previewers/previewer.ts
+++ b/src/lib/previewers/previewer.ts
@@ -1,13 +1,44 @@
 import type Resource from '../resources/resource';
 
-// Base class for rendering a resource into a preview
+// Which component draws a preview. A string rather than a class, so ogm-preview can route without
+// an instanceof: a class test only holds when both sides came from the same copy of the module.
+export type PreviewRenderer = 'map' | 'image';
+
+// One preview of one resource. A resource can offer more than one - a georeferenced scan is both
+// an image to page through and a layer on a map - so this, not the resource, is what a tab is.
 export default abstract class Previewer {
+  // The component that draws this preview
+  abstract readonly renderer: PreviewRenderer;
+
   protected resource: Resource;
 
   constructor(resource: Resource) {
     this.resource = resource;
   }
 
+  // Identifies the tab and the panel that show this preview. Every resource of one record carries
+  // the record's own id, so it takes the kind to tell them apart, and the renderer to tell two
+  // previews of one resource apart. Stable under minification, unlike constructor.name. Two
+  // previews of one resource drawn by the same component must override this.
+  get previewId(): string {
+    return `${this.resource.id}-${this.resource.kind}-${this.renderer}`;
+  }
+
+  // What the tab that selects this preview is called. A second preview of the same resource
+  // overrides this, since two tabs reading 'IIIF Manifest' would tell the user nothing.
+  label(): string {
+    return this.resource.label();
+  }
+
+  // The remote source this preview draws from. Reported alongside the label when a load fails,
+  // which is the only reason anything outside a previewer needs to know about its resource.
+  get url(): string {
+    return this.resource.url;
+  }
+
+  // Put this preview in front of the user, and take it back down. What that means is the
+  // subclass's business - style layers on a map, images in a viewer - but every preview does
+  // both, and the component that draws it does neither.
   abstract preview(): Promise<void>;
-  abstract clearPreview(): void;
+  abstract clearPreview(): Promise<void>;
 }

--- a/src/lib/previewers/raster.ts
+++ b/src/lib/previewers/raster.ts
@@ -52,8 +52,4 @@ export default class RasterPreviewer extends MapPreviewer {
       },
     ];
   }
-
-  async getBounds(): Promise<maplibregl.LngLatBoundsLike | undefined> {
-    return undefined;
-  }
 }

--- a/src/lib/previewers/tilejson-raster.ts
+++ b/src/lib/previewers/tilejson-raster.ts
@@ -21,11 +21,6 @@ export default class TileJsonRasterPreviewer extends RasterPreviewer {
     return `${this.resource.id}-tilejson`;
   }
 
-  // Raster tilesets have their bounds in the TileJSON document
-  async getBounds(): Promise<maplibregl.LngLatBoundsLike | undefined> {
-    return await this.tilejson.getBounds();
-  }
-
   // A TileJSON document can describe either kind of tileset, so its source isn't a RasterSource
   private get tilejson() {
     return this.resource as unknown as TileJsonSource;

--- a/src/lib/previewers/tilejson.test.ts
+++ b/src/lib/previewers/tilejson.test.ts
@@ -78,7 +78,7 @@ afterEach(() => vi.restoreAllMocks());
 describe('TileJsonRasterPreviewer#preview', () => {
   const preview = async (doc: object) => {
     const map = new FakeMap();
-    const previewer = new TileJsonRasterPreviewer(serve(doc), map as unknown as maplibregl.Map, style);
+    const previewer = new TileJsonRasterPreviewer(serve(doc)).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
     return { map, previewer };
   };
@@ -141,7 +141,7 @@ describe('TileJsonVectorPreviewer#previewLayers', () => {
 
   const preview = async (doc: object) => {
     const map = new FakeMap();
-    const previewer = new TileJsonVectorPreviewer(serve(doc), map as unknown as maplibregl.Map, style);
+    const previewer = new TileJsonVectorPreviewer(serve(doc)).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
     return { map, previewer };
   };
@@ -189,7 +189,7 @@ describe('TileJsonVectorPreviewer#previewLayers', () => {
 
   it('still offers a raster tileset exactly one row', async () => {
     const map = new FakeMap();
-    const previewer = new TileJsonRasterPreviewer(serve(rasterDoc), map as unknown as maplibregl.Map, style);
+    const previewer = new TileJsonRasterPreviewer(serve(rasterDoc)).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
 
     expect(previewer.previewLayers.map(layer => layer.title)).toEqual(['TileJSON']);
@@ -199,7 +199,7 @@ describe('TileJsonVectorPreviewer#previewLayers', () => {
 describe('TileJsonVectorPreviewer#preview', () => {
   const preview = async (doc: object) => {
     const map = new FakeMap();
-    const previewer = new TileJsonVectorPreviewer(serve(doc), map as unknown as maplibregl.Map, style);
+    const previewer = new TileJsonVectorPreviewer(serve(doc)).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
     return { map, previewer };
   };

--- a/src/lib/previewers/vector.ts
+++ b/src/lib/previewers/vector.ts
@@ -22,10 +22,6 @@ export default abstract class VectorPreviewer extends MapPreviewer {
     return this.resource.id;
   }
 
-  async getBounds() {
-    return await this.resource.getBounds();
-  }
-
   protected async createLayers(): Promise<LayerSpecification[]> {
     const layerIds = await this.resource.getVectorLayers();
     return layerIds.flatMap(layerId => {

--- a/src/lib/previewers/wms.test.ts
+++ b/src/lib/previewers/wms.test.ts
@@ -75,7 +75,7 @@ let previewer: WmsPreviewer;
 beforeEach(async () => {
   map = new FakeMap();
   const source = new WmsResource('s7st30', 'https://geoservices.lib.berkeley.edu/geoserver/wms', { layerIds: [] });
-  previewer = new WmsPreviewer(source, map as unknown as maplibregl.Map, style);
+  previewer = new WmsPreviewer(source).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
 });
 

--- a/src/lib/previewers/wmts.test.ts
+++ b/src/lib/previewers/wmts.test.ts
@@ -83,7 +83,7 @@ beforeEach(async () => {
   map = new FakeMap();
   resource = new StubWmtsResource('night-lights', 'https://example.org/wmts/1.0.0/WMTSCapabilities.xml', { layerIds: [] });
   resource.layers = LAYERS;
-  previewer = new WmtsPreviewer(resource, map as unknown as maplibregl.Map, style);
+  previewer = new WmtsPreviewer(resource).attach(map as unknown as maplibregl.Map, style);
   await previewer.preview();
 });
 
@@ -101,7 +101,7 @@ describe('WmtsPreviewer#previewLayers', () => {
 
   it('falls back to the identifier when the service published no title', async () => {
     resource.layers = [{ ...LAYERS[0], title: '   ' }];
-    previewer = new WmtsPreviewer(resource, map as unknown as maplibregl.Map, style);
+    previewer = new WmtsPreviewer(resource).attach(map as unknown as maplibregl.Map, style);
     await previewer.preview();
 
     expect(previewer.previewLayers.map(layer => layer.title)).toEqual(['lights']);

--- a/src/lib/resources/cog.ts
+++ b/src/lib/resources/cog.ts
@@ -1,6 +1,9 @@
 import RasterResource from './raster';
+import type { ResourceKind } from './resource';
 
 export default class CogResource extends RasterResource {
+  readonly kind: ResourceKind = 'cog';
+
   label() {
     return 'Cloud Optimized GeoTIFF';
   }

--- a/src/lib/resources/esri-dynamic-map-layer.ts
+++ b/src/lib/resources/esri-dynamic-map-layer.ts
@@ -1,8 +1,11 @@
 import EsriMapServerResource from './esri-map-server';
+import type { ResourceKind } from './resource';
 
 // A MapServer that draws the map on demand rather than serving tiles cut in advance. The service
 // re-renders at whatever extent MapLibre asks for, so a preview always shows the current data.
 export default class EsriDynamicMapLayerResource extends EsriMapServerResource {
+  readonly kind: ResourceKind = 'esri-dynamic-map-layer';
+
   label() {
     return 'ArcGIS Dynamic Map Layer';
   }

--- a/src/lib/resources/esri-feature-layer.ts
+++ b/src/lib/resources/esri-feature-layer.ts
@@ -2,6 +2,7 @@ import geojsonExtent from '@mapbox/geojson-extent';
 import type { LngLatBoundsLike } from 'maplibre-gl';
 
 import GeoJsonResource from './geojson';
+import type { ResourceKind } from './resource';
 import { esriExtentToBounds, esriQueryFeaturesToGeoJSON, fetchEsriJson, type EsriMetadata, type EsriQueryFeature } from '../esri';
 
 // How many features to ask for at once when the service doesn't say. ArcGIS caps this itself, and
@@ -23,6 +24,8 @@ type EsriQueryResponse = {
 // A single layer of a FeatureServer - or of a MapServer that allows querying - read as features
 // rather than as a picture of them, so the preview can style, label and select them client-side.
 export default class EsriFeatureLayerResource extends GeoJsonResource {
+  readonly kind: ResourceKind = 'esri-feature-layer';
+
   // Layer endpoint the requests are built from, with any trailing slash removed
   private layerUrl: string;
 

--- a/src/lib/resources/esri-image-map-layer.ts
+++ b/src/lib/resources/esri-image-map-layer.ts
@@ -1,4 +1,5 @@
 import EsriResource from './esri';
+import type { ResourceKind } from './resource';
 import { fetchEsriJson, hasCapability } from '../esri';
 import { pixelWindowCenter, type PixelWindow } from '../geometry';
 
@@ -16,6 +17,8 @@ const NO_DATA = 'NoData';
 // An ImageServer, which serves imagery or a raster of measurements - aerial photography, a
 // digital elevation model, a satellite mosaic - rendered on demand at the extent we ask for.
 export default class EsriImageMapLayerResource extends EsriResource {
+  readonly kind: ResourceKind = 'esri-image-map-layer';
+
   label() {
     return 'ArcGIS Image Map Layer';
   }

--- a/src/lib/resources/esri-tiled-map-layer.ts
+++ b/src/lib/resources/esri-tiled-map-layer.ts
@@ -1,4 +1,5 @@
 import EsriMapServerResource from './esri-map-server';
+import type { ResourceKind } from './resource';
 import { esriExtentToSourceBounds, hasCapability, isWebMercator, type EsriTileInfo } from '../esri';
 import type { EsriRasterSourceSpec } from './esri';
 
@@ -15,6 +16,8 @@ const ORIGIN_TOLERANCE = 1;
 // A MapServer whose map has been rendered into a cache of tiles ahead of time, so a preview reads
 // finished images instead of waiting for the server to draw them.
 export default class EsriTiledMapLayerResource extends EsriMapServerResource {
+  readonly kind: ResourceKind = 'esri-tiled-map-layer';
+
   label() {
     return 'ArcGIS Tiled Map Layer';
   }

--- a/src/lib/resources/factory.test.ts
+++ b/src/lib/resources/factory.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from '@stencil/vitest';
+import { LngLatBounds } from 'maplibre-gl';
+
+import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../record';
+import { resourcesFor } from './factory';
+import type Resource from './resource';
+import type { ResourceKind } from './resource';
+
+import CogResource from './cog';
+import EsriDynamicMapLayerResource from './esri-dynamic-map-layer';
+import EsriFeatureLayerResource from './esri-feature-layer';
+import EsriImageMapLayerResource from './esri-image-map-layer';
+import EsriTiledMapLayerResource from './esri-tiled-map-layer';
+import GeoJsonResource from './geojson';
+import IIIFResource from './iiif';
+import IIIFManifestResource from './iiif-manifest';
+import OpenIndexMapResource from './openindexmap';
+import PMTilesResource from './pmtiles';
+import TileJsonResource from './tilejson';
+import TmsResource from './tms';
+import WmsResource from './wms';
+import WmtsResource from './wmts';
+import XyzResource from './xyz';
+
+// A minimal Aardvark record carrying the given references
+const buildRecord = (references: Record<string, string>, extra: Partial<GeoBlacklightSchemaAardvark> = {}) =>
+  new OgmRecord({
+    id: 'berkeley-s7sq63',
+    dct_title_s: 'Calaveras County Contours',
+    gbl_resourceClass_sm: ['Datasets'],
+    dct_accessRights_s: 'Public',
+    gbl_mdVersion_s: 'Aardvark',
+    dct_references_s: JSON.stringify(references),
+    ...extra,
+  });
+
+// Every reference the factory knows how to build something from, with the class it builds and the
+// kind that class reports itself as - which is what chooses the previewer downstream
+const REFERENCES: [string, string, new (...args: never[]) => Resource, ResourceKind][] = [
+  ['http://iiif.io/api/image', 'https://example.com/iiif/info.json', IIIFResource, 'iiif-image'],
+  ['http://iiif.io/api/presentation#manifest', 'https://example.com/manifest.json', IIIFManifestResource, 'iiif-manifest'],
+  ['https://github.com/protomaps/PMTiles', 'https://example.com/tiles.pmtiles', PMTilesResource, 'pmtiles'],
+  ['https://github.com/mapbox/tilejson-spec', 'https://example.com/tiles.json', TileJsonResource, 'tilejson'],
+  ['https://openindexmaps.org', 'https://example.com/index.json', OpenIndexMapResource, 'openindexmap'],
+  ['http://geojson.org/geojson-spec.html', 'https://example.com/data.json', GeoJsonResource, 'geojson'],
+  ['urn:x-esri:serviceType:ArcGIS#FeatureLayer', 'https://example.com/arcgis/0', EsriFeatureLayerResource, 'esri-feature-layer'],
+  ['https://github.com/cogeotiff/cog-spec', 'https://example.com/scan.tif', CogResource, 'cog'],
+  ['https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification', 'https://example.com/tms', TmsResource, 'tms'],
+  ['https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames', 'https://example.com/{z}/{x}/{y}.png', XyzResource, 'xyz'],
+  ['urn:x-esri:serviceType:ArcGIS#TiledMapLayer', 'https://example.com/arcgis/tiled', EsriTiledMapLayerResource, 'esri-tiled-map-layer'],
+  ['urn:x-esri:serviceType:ArcGIS#DynamicMapLayer', 'https://example.com/arcgis/dynamic', EsriDynamicMapLayerResource, 'esri-dynamic-map-layer'],
+  ['urn:x-esri:serviceType:ArcGIS#ImageMapLayer', 'https://example.com/arcgis/image', EsriImageMapLayerResource, 'esri-image-map-layer'],
+  ['http://www.opengis.net/def/serviceType/ogc/wmts', 'https://example.com/geoserver/wmts', WmtsResource, 'wmts'],
+  ['http://www.opengis.net/def/serviceType/ogc/wms', 'https://example.com/geoserver/wms', WmsResource, 'wms'],
+];
+
+describe('resourcesFor', () => {
+  it.each(REFERENCES)('builds a resource for the %s reference', (uri, url, expected, kind) => {
+    // The WxS services need an identifier before they'll yield anything; see below
+    const record = buildRecord({ [uri]: url }, { gbl_wxsIdentifier_s: 's7sq63' });
+    const resources = resourcesFor(record);
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0]).toBeInstanceOf(expected);
+    expect(resources[0].url).toEqual(url);
+    expect(resources[0].id).toEqual('berkeley-s7sq63');
+
+    // A subclass that forgot to override this would be previewed as whatever its parent is: an
+    // index map as plain GeoJSON, a manifest as a single image
+    expect(resources[0].kind).toEqual(kind);
+  });
+
+  // This order is the tab order, which is the only reason it matters that it's stable
+  it('offers resources in the order they should be presented', () => {
+    const record = buildRecord(Object.fromEntries(REFERENCES.map(([uri, url]) => [uri, url])), { gbl_wxsIdentifier_s: 's7sq63' });
+
+    expect(resourcesFor(record).map(resource => resource.constructor)).toEqual(REFERENCES.map(([, , expected]) => expected));
+  });
+
+  it('offers nothing for a record with no previewable references', () => {
+    expect(resourcesFor(buildRecord({ 'http://schema.org/downloadUrl': 'https://example.com/data.zip' }))).toEqual([]);
+  });
+
+  // A WxS endpoint is a catalogue, so without an identifier we don't know what to ask it for
+  it.each(['http://www.opengis.net/def/serviceType/ogc/wms', 'http://www.opengis.net/def/serviceType/ogc/wmts'])(
+    'skips the %s reference when the record names no layer within it',
+    uri => {
+      expect(resourcesFor(buildRecord({ [uri]: 'https://example.com/geoserver' }))).toEqual([]);
+    },
+  );
+
+  // Asserted through XYZ, which reports back exactly the bounds it was handed. Resources that can
+  // work their own extent out - a PMTiles header, a GeoJSON document - go and read it when the
+  // record didn't say, and that fallback is theirs to test, not the factory's.
+  describe('bounds', () => {
+    const xyzReference = { 'https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames': 'https://example.com/{z}/{x}/{y}.png' };
+
+    it("hands each resource the record's bounding box", async () => {
+      const record = buildRecord(xyzReference, { dcat_bbox: 'ENVELOPE(-120.6,-120.0,38.5,38.0)' });
+      const [resource] = resourcesFor(record);
+
+      expect(await resource.getBounds()).toEqual(new LngLatBounds([-120.6, 38.0], [-120.0, 38.5]));
+    });
+
+    it('leaves the bounds unset when the record has no bounding box', async () => {
+      const [resource] = resourcesFor(buildRecord(xyzReference));
+
+      expect(await resource.getBounds()).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/resources/factory.ts
+++ b/src/lib/resources/factory.ts
@@ -1,0 +1,48 @@
+import type OgmRecord from '../record';
+import type Resource from './resource';
+
+import CogResource from './cog';
+import EsriDynamicMapLayerResource from './esri-dynamic-map-layer';
+import EsriFeatureLayerResource from './esri-feature-layer';
+import EsriImageMapLayerResource from './esri-image-map-layer';
+import EsriTiledMapLayerResource from './esri-tiled-map-layer';
+import GeoJsonResource from './geojson';
+import IIIFResource from './iiif';
+import IIIFManifestResource from './iiif-manifest';
+import OpenIndexMapResource from './openindexmap';
+import PMTilesResource from './pmtiles';
+import TileJsonResource from './tilejson';
+import TmsResource from './tms';
+import WmsResource from './wms';
+import WmtsResource from './wmts';
+import XyzResource from './xyz';
+
+/**
+ * Every previewable resource a record's references point at, in the order they're offered to the
+ * user - this list is the tab order.
+ */
+export function resourcesFor(record: OgmRecord): Resource[] {
+  const { id, references, wxsIdentifier } = record;
+  const bounds = record.getBounds();
+  const resources: Resource[] = [];
+
+  if (references.iiifImageUrl) resources.push(new IIIFResource(id, references.iiifImageUrl, bounds));
+  if (references.iiifManifestUrl) resources.push(new IIIFManifestResource(id, references.iiifManifestUrl, bounds));
+  if (references.pmtilesUrl) resources.push(new PMTilesResource(id, references.pmtilesUrl, bounds));
+  if (references.tilejsonUrl) resources.push(new TileJsonResource(id, references.tilejsonUrl, bounds));
+  if (references.indexMapUrl) resources.push(new OpenIndexMapResource(id, references.indexMapUrl, bounds));
+  if (references.geojsonUrl) resources.push(new GeoJsonResource(id, references.geojsonUrl, bounds));
+  if (references.esriFeatureLayerUrl) resources.push(new EsriFeatureLayerResource(id, references.esriFeatureLayerUrl, bounds));
+  if (references.cogUrl) resources.push(new CogResource(id, references.cogUrl, bounds));
+  if (references.tmsUrl) resources.push(new TmsResource(id, references.tmsUrl, bounds));
+  if (references.xyzUrl) resources.push(new XyzResource(id, references.xyzUrl, bounds));
+  if (references.esriTiledMapLayerUrl) resources.push(new EsriTiledMapLayerResource(id, references.esriTiledMapLayerUrl, bounds));
+  if (references.esriDynamicMapLayerUrl) resources.push(new EsriDynamicMapLayerResource(id, references.esriDynamicMapLayerUrl, bounds));
+  if (references.esriImageMapLayerUrl) resources.push(new EsriImageMapLayerResource(id, references.esriImageMapLayerUrl, bounds));
+
+  // A WxS endpoint is a catalogue; without an identifier we don't know which layer of it to ask for
+  if (references.wmtsUrl && wxsIdentifier) resources.push(new WmtsResource(id, references.wmtsUrl, { layerIds: [wxsIdentifier] }, bounds));
+  if (references.wmsUrl && wxsIdentifier) resources.push(new WmsResource(id, references.wmsUrl, { layerIds: [wxsIdentifier] }, bounds));
+
+  return resources;
+}

--- a/src/lib/resources/geojson.ts
+++ b/src/lib/resources/geojson.ts
@@ -2,9 +2,12 @@ import geojsonExtent from '@mapbox/geojson-extent';
 import type { LngLatBoundsLike } from 'maplibre-gl';
 
 import VectorResource from './vector';
+import type { ResourceKind } from './resource';
 import { fetchOrThrow } from '../errors';
 
 export default class GeoJsonResource extends VectorResource {
+  readonly kind: ResourceKind = 'geojson';
+
   // Data parsed from GeoJSON document
   private data: any;
 

--- a/src/lib/resources/iiif-manifest.ts
+++ b/src/lib/resources/iiif-manifest.ts
@@ -2,10 +2,13 @@ import iiif3 from '@iiif/presentation-3';
 import iiif2 from '@iiif/presentation-2';
 
 import IIIFResource from './iiif';
+import type { ResourceKind } from './resource';
 import { fetchOrThrow } from '../errors';
 
 // A manifest containing multiple IIIF image URLs for preview
 export default class IIIFManifestResource extends IIIFResource {
+  readonly kind: ResourceKind = 'iiif-manifest';
+
   // The parsed manifest contents
   protected manifest: iiif3.Manifest | iiif2.Manifest | undefined;
 

--- a/src/lib/resources/iiif.ts
+++ b/src/lib/resources/iiif.ts
@@ -1,7 +1,9 @@
-import Resource from './resource';
+import Resource, { type ResourceKind } from './resource';
 
 // A source of IIIF image URL(s) to be previewed
 export default class IIIFResource extends Resource {
+  readonly kind: ResourceKind = 'iiif-image';
+
   label() {
     return 'IIIF Image';
   }

--- a/src/lib/resources/openindexmap.ts
+++ b/src/lib/resources/openindexmap.ts
@@ -1,6 +1,9 @@
 import GeoJsonResource from './geojson';
+import type { ResourceKind } from './resource';
 
 export default class OpenIndexMapResource extends GeoJsonResource {
+  readonly kind: ResourceKind = 'openindexmap';
+
   // Distinguish the layer name from regular GeoJSON
   async getVectorLayers() {
     return ['indexmap'];

--- a/src/lib/resources/pmtiles.ts
+++ b/src/lib/resources/pmtiles.ts
@@ -2,7 +2,7 @@
 
 import { PMTiles, TileType, Header } from 'pmtiles';
 
-import Resource from './resource';
+import Resource, { type ResourceKind } from './resource';
 import { type LngLatBoundsLike } from 'maplibre-gl';
 
 // A single vector layer in a PMTiles tileset
@@ -18,6 +18,8 @@ interface Metadata {
 
 // Vector or raster tileset stored in a PMTiles archive at a URL
 export default class PMTilesResource extends Resource {
+  readonly kind: ResourceKind = 'pmtiles';
+
   // PMTiles object for reading metadata and tiles from the archive
   private archive: PMTiles;
 

--- a/src/lib/resources/resource.ts
+++ b/src/lib/resources/resource.ts
@@ -1,7 +1,30 @@
 import type { LngLatBoundsLike } from 'maplibre-gl';
 
+// Names the kind of data a resource holds. Previewers are chosen by matching on this string rather
+// than with `instanceof`: a class test only holds when both sides came from the same copy of the
+// module, and it forces every subclass to be tested ahead of its parent to be reachable at all.
+export type ResourceKind =
+  | 'cog'
+  | 'esri-dynamic-map-layer'
+  | 'esri-feature-layer'
+  | 'esri-image-map-layer'
+  | 'esri-tiled-map-layer'
+  | 'geojson'
+  | 'iiif-image'
+  | 'iiif-manifest'
+  | 'openindexmap'
+  | 'pmtiles'
+  | 'tilejson'
+  | 'tms'
+  | 'wms'
+  | 'wmts'
+  | 'xyz';
+
 // A source of previewable data at a URL
 export default abstract class Resource {
+  // Which kind of data this is; see ResourceKind
+  abstract readonly kind: ResourceKind;
+
   // URL to the remote data source
   url: string;
 

--- a/src/lib/resources/tilejson.ts
+++ b/src/lib/resources/tilejson.ts
@@ -1,5 +1,6 @@
 import { fetchOrThrow } from '../errors';
 import MapResource from './map';
+import type { ResourceKind } from './resource';
 
 // A single vector layer in a TileJSON tileset
 interface VectorLayer {
@@ -8,6 +9,8 @@ interface VectorLayer {
 
 // Vector or raster tileset described in a TileJSON document at a URL
 export default class TileJsonResource extends MapResource {
+  readonly kind: ResourceKind = 'tilejson';
+
   // Metadata parsed from TileJSON document
   private metadata: any;
 

--- a/src/lib/resources/tms.ts
+++ b/src/lib/resources/tms.ts
@@ -1,6 +1,9 @@
 import RasterResource from './raster';
+import type { ResourceKind } from './resource';
 
 export default class TmsResource extends RasterResource {
+  readonly kind: ResourceKind = 'tms';
+
   label() {
     return 'Tiled Map Service (TMS)';
   }

--- a/src/lib/resources/wms.ts
+++ b/src/lib/resources/wms.ts
@@ -1,5 +1,6 @@
 import { type LngLatBoundsLike } from 'maplibre-gl';
 import RasterResource from './raster';
+import type { ResourceKind } from './resource';
 import type { PixelWindow } from '../geometry';
 
 // Base params for WMS GetMap requests, which return raster tiles
@@ -46,6 +47,8 @@ const defaultWmsOptions: WmsOptions = {
 
 // Data accessed via WMS GetMap requests, which return raster tiles
 export default class WmsResource extends RasterResource {
+  readonly kind: ResourceKind = 'wms';
+
   private options: WmsOptions;
 
   // Memoized metadata via GetCapabilities request

--- a/src/lib/resources/wmts.ts
+++ b/src/lib/resources/wmts.ts
@@ -1,5 +1,6 @@
 import { LngLatBounds, type LngLatBoundsLike, type RasterSourceSpecification } from 'maplibre-gl';
 import RasterResource from './raster';
+import type { ResourceKind } from './resource';
 
 export type WmtsOptions = {
   layerIds: string[];
@@ -68,6 +69,8 @@ const MERCATOR_MAX_LATITUDE = 85.051129;
 // Layers (potentially multiple) accessed via WMTS GetTile requests
 // NOTE: in Aardvark, the reference URL is the GetCapabilities URL, not the tile URL
 export default class WmtsResource extends RasterResource {
+  readonly kind: ResourceKind = 'wmts';
+
   private options: WmtsOptions;
 
   // Memoized metadata via GetCapabilities request

--- a/src/lib/resources/xyz.ts
+++ b/src/lib/resources/xyz.ts
@@ -1,6 +1,9 @@
 import RasterResource from './raster';
+import type { ResourceKind } from './resource';
 
 export default class XyzResource extends RasterResource {
+  readonly kind: ResourceKind = 'xyz';
+
   label() {
     return 'XYZ Tile Service';
   }


### PR DESCRIPTION
This is required work to have both a IIIF image and georeferenced
map preview from a single manifest/image.
