### PR TITLE
Build ESM only, via dist-custom-elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,30 +2,24 @@
   "name": "ogm-viewer",
   "version": "0.6.1",
   "description": "A web-based viewer for previewing OpenGeoMetadata records",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
-  "collection": "dist/collection/collection-manifest.json",
-  "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/ogm-viewer/ogm-viewer.esm.js",
+  "module": "./dist/components/ogm-viewer.js",
+  "types": "./dist/components/ogm-viewer.d.ts",
+  "unpkg": "./dist/components/ogm-viewer.js",
+  "jsdelivr": "./dist/components/ogm-viewer.js",
   "exports": {
     ".": {
-      "import": "./dist/ogm-viewer/ogm-viewer.esm.js",
-      "require": "./dist/ogm-viewer/ogm-viewer.cjs.js"
+      "types": "./dist/components/ogm-viewer.d.ts",
+      "import": "./dist/components/ogm-viewer.js"
     },
-    "./loader": {
-      "import": "./loader/index.js",
-      "require": "./loader/index.cjs",
-      "types": "./loader/index.d.ts"
-    }
+    "./components/*": "./dist/components/*",
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stenciljs/component-starter.git"
+    "url": "https://github.com/OpenGeoMetadata/ogm-viewer.git"
   },
   "files": [
-    "dist/",
-    "loader/"
+    "dist/"
   ],
   "scripts": {
     "build": "stencil build",

--- a/src/components/ogm-previews/ogm-previews.test.tsx
+++ b/src/components/ogm-previews/ogm-previews.test.tsx
@@ -31,11 +31,17 @@ const renderPreviews = async (record?: OgmRecord) => {
   await stencilRender(<ogm-previews record={record}></ogm-previews>, container);
   const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
   await el.componentOnReady?.();
+  await flush();
   consoleError.mockRestore();
   return el.shadowRoot as ShadowRoot;
 };
 
 // Let Stencil's RAF-based update cycle flush so the nested <ogm-preview> renders its own shadow DOM.
+//
+// Needed after componentOnReady() as well, not just for the nested render. The element is already
+// defined when the vdom creates it, so it upgrades on the spot and componentWillLoad runs before the
+// record prop is assigned - the first render has no previewers and draws nothing. Setting the prop
+// is what starts the real build, by way of @Watch, and that lands a tick later.
 const flush = () => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
 // Render previews and drill into the single <ogm-preview> to see which preview (map or image) it
@@ -48,6 +54,7 @@ const renderPreviewChild = async (record: OgmRecord) => {
   await stencilRender(<ogm-previews record={record}></ogm-previews>, container);
   const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
   await el.componentOnReady?.();
+  await flush();
   const preview = (el.shadowRoot as ShadowRoot).querySelector('ogm-preview') as HTMLElement & { componentOnReady?: () => Promise<unknown> };
   await preview?.componentOnReady?.();
   await flush();

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -1,16 +1,8 @@
-import { setBasePath, getBasePath, registerIconLibrary } from '@awesome.me/webawesome';
-import { Component, Element, Host, Listen, Method, Prop, State, Watch, getAssetPath, h } from '@stencil/core';
+import { Component, Element, Host, Listen, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import OgmRecord from '../../lib/record';
 import { fetchOrThrow, recordError, type PreviewError } from '../../lib/errors';
-
-// Only need to call this once, at the top level
-setBasePath(getAssetPath(''));
-
-// Serve icons from our self-hosted bootstrap-icons subset instead of the default Font Awesome library
-registerIconLibrary('default', {
-  resolver: name => getBasePath(`assets/icons/${name}.svg`),
-});
+import { webAwesomeStylesheet } from '../../lib/init';
 
 // Import all required Web Awesome components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -122,7 +114,7 @@ export class OgmViewer {
   render() {
     return (
       <Host class={`wa-${this.theme}`}>
-        <link rel="stylesheet" href={getBasePath('assets/webawesome/styles/themes/default.css')} />
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         <div class={`container ${WA_SCOPE} wa-${this.theme}`}>
           <ogm-menubar theme={this.theme} record={this.record} loading={this.loading} hideTitle={this.hideTitle}></ogm-menubar>
           <div class="main-container">

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,0 +1,20 @@
+import { getBasePath, registerIconLibrary, setBasePath } from '@awesome.me/webawesome';
+
+// Where this library's own files live. Anchored to this module's URL rather than to Stencil's asset
+// path: the custom-elements build starts that path empty, so it would resolve against the embedding
+// page rather than against us, and every icon and the Web Awesome theme would 404 on any host that
+// doesn't happen to serve our assets at its own root. Stencil's setAssetPath() is not usable from
+// inside the library either - the compiler rewires getAssetPath() into component bundles but leaves
+// setAssetPath as a bare global reference, so calling it here throws at load. Reading import.meta.url
+// asks the only question that actually matters, and holds whether we're loaded from a CDN, from a
+// host's own assets, or from a dev server.
+setBasePath(new URL('.', import.meta.url).href);
+
+// Serve icons from our self-hosted bootstrap-icons subset instead of the default Font Awesome library
+registerIconLibrary('default', {
+  resolver: name => getBasePath(`assets/icons/${name}.svg`),
+});
+
+// The Web Awesome theme, which components link inside their own shadow root rather than at the top
+// of the page: loading it into the document would restyle the host app around us.
+export const webAwesomeStylesheet = (): string => getBasePath('assets/webawesome/styles/themes/default.css');

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,17 +2,32 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'ogm-viewer',
-  validatePrimaryPackageOutputTarget: true,
+  // Off because the check wants package.json's `module`/`types` pointed at dist/components/index.js,
+  // and for this output target that file is the Stencil runtime, not a barrel - importing it defines
+  // no elements at all. The component entries are what register the library, so package.json names
+  // dist/components/ogm-viewer.js instead, and the validator has no way to be told that.
+  validatePrimaryPackageOutputTarget: false,
   buildDist: true, // Always build all targets
   outputTargets: [
-    // This is the build target used by apps that will consume the viewer.
+    // This is the build target used by apps that will consume the viewer. It emits ESM only, which
+    // the `dist` target does not: `dist` also renders a CommonJS copy, and CommonJS cannot represent
+    // the top-level await that @developmentseed/lzw-tiff-decoder uses to initialize its wasm module.
+    // That is what kept the deck.gl COG previewer - the only one that can warp a COG that is not in
+    // Web Mercator - out of the build. See https://github.com/OpenGeoMetadata/ogm-viewer/issues/100
+    //
+    // Importing any component entry still defines every element in the library, so embedding is
+    // unchanged: one script tag, or one bare import, and <ogm-viewer> works.
     {
-      type: 'dist',
-      esmLoaderPath: '../loader',
-      isPrimaryPackageOutputTarget: true,
+      type: 'dist-custom-elements',
+      generateTypeDeclarations: true,
+      customElementsExportBehavior: 'auto-define-custom-elements',
+      // Bundle the Stencil runtime rather than leaving bare `@stencil/core/*` specifiers behind.
+      // Without this a browser loading us from a script tag has nothing to resolve them against.
+      externalRuntime: false,
+      // Unlike the other output targets, `dest` here is resolved from the project root
       copy: [
-        { src: '../assets', dest: 'assets' },
-        { src: '../node_modules/@awesome.me/webawesome/dist/styles', dest: 'assets/webawesome/styles' },
+        { src: '../assets', dest: 'dist/components/assets' },
+        { src: '../node_modules/@awesome.me/webawesome/dist/styles', dest: 'dist/components/assets/webawesome/styles' },
       ],
     },
     // This target is used for the GitHub Pages preview site.

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,7 +1,29 @@
-// Load Stencil components and register them as custom elements.
-import { defineCustomElements } from './dist/esm/loader.js';
-defineCustomElements();
+// Register the components under test as custom elements. The custom-elements build has no loader to
+// call: importing a component entry defines that component and everything it renders.
+//
+// Deliberately not ogm-viewer, which would define all eleven: it is the only component that imports
+// the Web Awesome element modules, and pulling those in would upgrade every wa-* element the other
+// components render. That would drag Web Awesome's own shadow DOM - lit marker comments and all -
+// into assertions that are about our markup, and break them on every Web Awesome release. Left
+// undefined, wa-* elements stay inert, which is what these tests were written against.
+//
+// Anything rendering ogm-viewer or ogm-sidebar needs a real browser rather than happy-dom, since
+// Web Awesome's form controls want ElementInternals as they upgrade.
+import './dist/components/ogm-alerts.js';
+import './dist/components/ogm-attributes.js';
+import './dist/components/ogm-layers.js';
+import './dist/components/ogm-menubar.js';
+import './dist/components/ogm-metadata.js';
+import './dist/components/ogm-preview.js';
+import './dist/components/ogm-previews.js';
+
+// Stand in for the mark that bootstrapLazy() would have set. Dev builds compile in Stencil's
+// profiling hooks, and appDidLoad measures against "st:app:start" - but only the lazy loader ever
+// marks it, so under this output target every component load rejects with "the mark has not been
+// set". Harmless in itself, but vitest counts unhandled rejections and fails the run over them.
+// Production builds drop the profiling code entirely, so this is a test-only gap.
+performance.mark('st:app:start');
+
 export {};
 
-// Note: you may need `buildDist: true` in your stencil.config
-// or `--prod` to use an output other than the browser lazy-loader
+// Note: this reads the built output, so `npm run build` has to have run first.


### PR DESCRIPTION
Switches the primary output target from `dist` to `dist-custom-elements`, which unblocks #100.

## Why

The `dist` target renders a CommonJS copy alongside the ESM one, and CommonJS cannot represent top-level await. `@developmentseed/lzw-tiff-decoder` uses TLA to initialize its wasm module, and it sits on the only import path that reaches `previewers/cog-deck.ts` — the one previewer that can warp a COG that isn't in Web Mercator. The CJS render is what has been keeping that previewer out of the build.

Dynamic import doesn't work around it: Rollup renders *every* chunk in the target format, dynamic-import chunks included. Verified.

The remaining alternative — keeping deck.gl out of the Rollup graph via a runtime import of an external URL — means maintaining an out-of-tree bundle, which is the thing we'd like to stop doing.

## Adoption is unchanged

The main concern with this target was whether it makes the common case harder. It doesn't:

- `dist/components/ogm-viewer.js` ends with a self-executing function that defines **all eleven elements**, each guarded by `customElements.get()`. A single `<script type="module" src="https://unpkg.com/ogm-viewer">` or a bare `import 'ogm-viewer'` registers the whole viewer exactly as before.
- Slightly smaller: **690 KB gzip**, was ~703 KB.
- Much smaller package: **0.8 MB tarball / 2.9 MB unpacked**, was 2.9 MB / 12 MB.

`module`, `types`, `unpkg` and `jsdelivr` now name `dist/components/ogm-viewer.js`. `jsdelivr` is spelled out explicitly because jsDelivr resolves `jsdelivr` → `browser` → `main`, and `main` is gone.

## Breaking

`ogm-viewer/loader` and `defineCustomElements()` no longer exist. That form of adoption has to become a plain import.

Both `require` conditions went away with it — they already pointed at `dist/ogm-viewer/ogm-viewer.cjs.js` and `loader/index.cjs`, neither of which this build has ever produced, so no working CJS consumer is affected.

## Two things the target needs that the lazy build handled itself

**Assets stopped resolving.** Under this target `getAssetPath` is `path => new URL(path, base)` with `base` defaulting to `""`, so the icons and the Web Awesome theme resolve against whatever page embeds us and 404. Stencil's own `setAssetPath()` isn't usable from inside the library — the compiler rewires `getAssetPath()` into component bundles but leaves `setAssetPath` as a bare global reference, so calling it throws `ReferenceError` at load.

New `src/lib/init.ts` anchors Web Awesome's base path to `import.meta.url` instead. That asks the only question that actually matters and holds whether we're loaded from a CDN, from a host's own assets, or from a dev server. It's also the natural home for the icon library registration, which was previously a module-scope side effect of `ogm-viewer.tsx` and so only ran for consumers of that one component — relevant to the standalone-preview work coming next.

**`copy.dest` is resolved from the project root** for this target rather than from the output directory, so it needs the full `dist/components/assets` path.

`validatePrimaryPackageOutputTarget` is off: the check wants `module`/`types` pointed at `dist/components/index.js`, but for this target that file is the Stencil runtime, not a barrel — importing it defines nothing at all. There's no way to tell the validator that.

## Test changes

Both come from eager definition rather than from the build itself.

`vitest-setup.ts` imports the seven component entries under test rather than `ogm-viewer`, which would define the Web Awesome elements too and pull their shadow DOM — lit marker comments and all — into assertions that are about our own markup. Left undefined, `wa-*` elements stay inert, which is what these tests were written against. Consequence worth knowing: anything that renders `ogm-viewer` or `ogm-sidebar` will need a real browser rather than happy-dom, since Web Awesome's form controls want `ElementInternals` as they upgrade. Neither has a test today.

`ogm-previews.test.tsx` waits a frame after `componentOnReady()`. The element upgrades the moment the vdom creates it, so `componentWillLoad` runs before the `record` prop is assigned and the first render draws nothing; `@Watch` starts the real build a tick later.

Separately, dev builds compile in Stencil's profiling hooks, where `appDidLoad` measures against an `st:app:start` mark that only `bootstrapLazy()` sets. Under this target every component load rejected with *"the mark has not been set"*, and vitest fails a run over unhandled rejections even when every assertion passes. The setup file sets the mark. Production builds drop the profiling code entirely, so this is test-only.

## Verified

- `npm test` — 34 files, 446 passed, 1 todo, **exit 0, no unhandled errors**. Identical to `main`.
- `npm run lint` — clean.
- `npm run build` — clean, no warnings. The `www` target is untouched, so the Pages preview still builds.
- **In a real browser**, loading only `dist/components/ogm-viewer.js` from a script tag: all 11 elements defined, Web Awesome theme loaded, icon SVGs rendering, map canvas live, zero failed network requests.

Also fixes `repository.url`, which still pointed at `stenciljs/component-starter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)