### PR TITLE
Make every component usable outside <ogm-viewer>

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.claude
 assets
 dist
 loader

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "types": "./dist/components/ogm-viewer.d.ts",
       "import": "./dist/components/ogm-viewer.js"
     },
+    "./lib": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/components/index.js"
+    },
     "./components/*": "./dist/components/*",
     "./package.json": "./package.json"
   },
@@ -23,6 +27,7 @@
   ],
   "scripts": {
     "build": "stencil build",
+    "prepare": "stencil build",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil-test",
     "test:unit": "stencil-test --project unit",

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,57 @@ To programmatically control dark mode, you can use the `theme` attribute with a 
 <ogm-viewer record-url="https://example.com/record.json" theme="dark"></ogm-viewer>
 ```
 
+### Colors
+
+You can style the viewer's colors by setting CSS custom properties on its element.
+
+```css
+ogm-viewer {
+  --ogm-fill-color: #8f1414;
+  --ogm-stroke-color: #4a0a0a;
+}
+```
+
+Here are the supported properties and what they apply to:
+
+| Property                       | Applies to                                           |
+| ------------------------------ | ---------------------------------------------------- |
+| `--ogm-fill-color`             | Polygon and circle fill                              |
+| `--ogm-fill-highlight-color`   | Fill of a hovered feature                            |
+| `--ogm-fill-selected-color`    | Fill of the feature whose attributes are shown       |
+| `--ogm-fill-invalid-color`     | Fill of a feature marked unavailable                 |
+| `--ogm-stroke-color`           | Lines, and polygon and circle borders                |
+| `--ogm-stroke-highlight-color` | Stroke of a hovered feature                          |
+| `--ogm-stroke-selected-color`  | Stroke of the selected feature                       |
+| `--ogm-stroke-invalid-color`   | Stroke of a feature marked unavailable               |
+| `--ogm-text-color`             | Feature label text color                             |
+| `--ogm-text-halo-color`        | Feature label text outline color                     |
+| `--ogm-text-size`              | Feature label font size, in pixels                   |
+| `--ogm-font-family`            | Feature label font name (e.g. `"Noto Sans Regular"`) |
+| `--ogm-fill-opacity`           | Initial opacity of drawn data                        |
+| `--ogm-fill-highlight-opacity` | Opacity of a highlighted feature                     |
+| `--ogm-padding`                | Gap kept between the data and the map edge (pixels)  |
+
+By default, the viewer uses styles from [Web Awesome](https://webawesome.com/) that match the current mode (dark or light). Anything you override will be used in both modes.
+
+### Components
+
+If you're building your own viewer, you can adopt `<ogm-viewer>`'s components individually.
+
+The easiest way to render a single preview without the full viewer is to use the `<ogm-preview>` component with a `Previewer` and corresponding `Resource`. For example, to preview a GeoJSON resource:
+
+```javascript
+import 'ogm-viewer';
+import { GeoJsonPreviewer, GeoJsonResource } from 'ogm-viewer/lib';
+
+await customElements.whenDefined('ogm-preview');
+
+const resource = new GeoJsonResource('my-layer', 'https://example.com/data.json');
+document.querySelector('ogm-preview').previewer = new GeoJsonPreviewer(resource);
+```
+
+Note that `previewer` is a DOM property, not an attribute — await for the element to be defined and then set it in JavaScript.
+
 ## Development
 
 After cloning the repository, install dependencies:

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,9 @@ export { AnyPreviewer } from "./lib/previewers/factory";
 export namespace Components {
     interface OgmAlerts {
         "error"?: PreviewError;
+        /**
+          * @default themePreference()
+         */
         "theme": 'light' | 'dark';
     }
     interface OgmAttributes {
@@ -30,6 +33,9 @@ export namespace Components {
          */
         "padding": number;
         "previewer": ImagePreviewer;
+        /**
+          * @default themePreference()
+         */
         "theme": 'light' | 'dark';
     }
     interface OgmLayers {
@@ -46,6 +52,9 @@ export namespace Components {
          */
         "padding": number;
         "previewer": MapPreviewer;
+        /**
+          * @default themePreference()
+         */
         "theme": 'light' | 'dark';
     }
     interface OgmMenubar {
@@ -68,11 +77,17 @@ export namespace Components {
     interface OgmPreview {
         "previewer": AnyPreviewer;
         "sidebarPadding": number;
+        /**
+          * @default themePreference()
+         */
         "theme": 'light' | 'dark';
     }
     interface OgmPreviews {
         "record": OgmRecord;
         "sidebarPadding": number;
+        /**
+          * @default themePreference()
+         */
         "theme": 'light' | 'dark';
     }
     interface OgmSidebar {
@@ -91,7 +106,7 @@ export namespace Components {
         "loadRecord": (record: OgmRecord) => Promise<void>;
         "recordUrl": string;
         /**
-          * @default this.getThemePreference()
+          * @default themePreference()
          */
         "theme": 'light' | 'dark';
     }
@@ -277,6 +292,9 @@ declare global {
 declare namespace LocalJSX {
     interface OgmAlerts {
         "error"?: PreviewError;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmAttributes {
@@ -295,6 +313,9 @@ declare namespace LocalJSX {
          */
         "padding"?: number;
         "previewer"?: ImagePreviewer;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmLayers {
@@ -316,6 +337,9 @@ declare namespace LocalJSX {
          */
         "padding"?: number;
         "previewer"?: MapPreviewer;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmMenubar {
@@ -339,6 +363,9 @@ declare namespace LocalJSX {
     interface OgmPreview {
         "previewer"?: AnyPreviewer;
         "sidebarPadding"?: number;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmPreviews {
@@ -346,6 +373,9 @@ declare namespace LocalJSX {
         "onPreviewsLoading"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "record"?: OgmRecord;
         "sidebarPadding"?: number;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmSidebar {
@@ -363,7 +393,7 @@ declare namespace LocalJSX {
         "hideTitle"?: boolean;
         "recordUrl"?: string;
         /**
-          * @default this.getThemePreference()
+          * @default themePreference()
          */
         "theme"?: 'light' | 'dark';
     }

--- a/src/components/ogm-alerts/ogm-alerts.tsx
+++ b/src/components/ogm-alerts/ogm-alerts.tsx
@@ -1,5 +1,9 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import type { PreviewError } from '../../lib/errors';
 
 // Renders a single preview error, centered and filling its container. Used in place of a failed
@@ -10,14 +14,15 @@ import type { PreviewError } from '../../lib/errors';
   shadow: true,
 })
 export class OgmAlerts {
-  @Prop() theme: 'light' | 'dark';
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() error?: PreviewError;
 
   render() {
     if (!this.error) return null;
 
     return (
-      <Host class={this.theme && `wa-${this.theme}`}>
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         <div class="alerts" role="alert" aria-live="assertive">
           <wa-callout variant="danger" appearance="filled-outlined" class="alert">
             <wa-icon slot="icon" name="exclamation-triangle-fill" canvas="auto"></wa-icon>

--- a/src/components/ogm-attributes/ogm-attributes.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.tsx
@@ -1,6 +1,11 @@
 import { Component, Prop, State, Watch, Event, EventEmitter, h } from '@stencil/core';
 import { MapGeoJSONFeature } from 'maplibre-gl';
 import Autolinker from 'autolinker';
+
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/scroller/scroller.js';
+
 import { getFeatureTitle } from '../../lib/features';
 
 @Component({

--- a/src/components/ogm-image/ogm-image.tsx
+++ b/src/components/ogm-image/ogm-image.tsx
@@ -1,8 +1,12 @@
 import { Component, Element, h, Host, Watch, Prop, Event, EventEmitter } from '@stencil/core';
 import { Viewer } from 'openseadragon';
 
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+
 import { getElement, findElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import type ImagePreviewer from '../../lib/previewers/image';
 
 @Component({
@@ -13,7 +17,7 @@ import type ImagePreviewer from '../../lib/previewers/image';
 export class OgmImage {
   @Element() el: HTMLElement;
   @Prop() previewer: ImagePreviewer;
-  @Prop() theme: 'light' | 'dark';
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() padding: number = 0;
   @Event() imageLoaded: EventEmitter<void>;
   @Event() imageLoading: EventEmitter<void>;
@@ -104,7 +108,8 @@ export class OgmImage {
 
   render() {
     return (
-      <Host>
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         <div id="openseadragon">
           <div class="controls">
             <wa-button class="zoom-in" size="s" appearance="filled-outlined" pill>

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -2,8 +2,9 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 import maplibregl from 'maplibre-gl';
 import { Protocol as PMTilesProtocol } from 'pmtiles';
 
-import { getElement } from '../../lib/elements';
+import { closestAcrossShadows, findElement, getElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import { dedupeFeatures } from '../../lib/features';
 import { mercatorBbox, type PixelWindow } from '../../lib/geometry';
 import { isLayerDrawn, toLayerControlItems as getLayerControls, type LayerControl, type LayerState } from '../../lib/layers';
@@ -31,7 +32,7 @@ const QUERY_WINDOW = 51;
 export class OgmMap {
   @Element() el: HTMLElement;
   @Prop() previewer: MapPreviewer;
-  @Prop() theme: 'light' | 'dark';
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() padding: number = 0;
   @Event() mapIdle: EventEmitter<void>;
   @Event() mapLoading: EventEmitter<void>;
@@ -57,27 +58,27 @@ export class OgmMap {
   protected hoveredFeature: maplibregl.MapGeoJSONFeature | undefined = undefined;
   protected selectedFeature: maplibregl.MapGeoJSONFeature | undefined = undefined;
 
-  // Container element reference for fullscreen
-  protected containerEl: HTMLElement;
-
   // Set up the mapLibre map and event bindings on load
   componentDidLoad() {
-    this.mapTheme = new MapLibreTheme(this.el);
+    this.mapTheme = new MapLibreTheme(this.el, this.theme);
     this.map = new maplibregl.Map({
       container: getElement(this.el, '#map'),
-      attributionControl: false,
+      // The basemaps are CARTO's, over OpenStreetMap data; both require attribution. Compact so it
+      // is a single "i" in the corner until clicked, which is all an embedded map has room for.
+      attributionControl: { compact: true },
       cooperativeGestures: true,
       style: this.mapTheme.getBaseMapStyle(),
       center: [0, 0],
       zoom: 2,
       minZoom: 2,
     });
-    this.getContainer();
-    this.addControls();
+
+    // Bound before the controls go on: a control that can't be built shouldn't cost us the preview
     this.map.on('load', () => this.loadPreview());
     this.map.on('mousemove', this.handleHover.bind(this));
     this.map.on('click', this.handleClick.bind(this));
     this.map.on('error', this.handleMapError.bind(this));
+    this.addControls();
 
     // Style as a globe with atmosphere once style is loaded and set the flag
     this.map.on('style.load', () => {
@@ -97,13 +98,13 @@ export class OgmMap {
     if (this.map) this.map.remove();
   }
 
-  // Find the container element for the map (used for fullscreen control)
-  protected getContainer() {
-    const viewerEl = document.querySelector('ogm-viewer') as HTMLElement;
-    if (!viewerEl) throw new Error('Could not find ogm-viewer element');
-    const containerEl = getElement(viewerEl, '.container') as HTMLElement;
-    if (!containerEl) throw new Error('Could not find map container element');
-    this.containerEl = containerEl;
+  // What the fullscreen button expands. Under an <ogm-viewer> that's the whole viewer, so the
+  // menubar and sidebar come along with the map; on our own it is just us. Found by walking out
+  // through the shadow roots we sit in rather than by asking the document, which would pick the
+  // first viewer on the page whether or not it is the one we're inside.
+  protected getContainer(): HTMLElement {
+    const viewerEl = closestAcrossShadows(this.el, 'ogm-viewer');
+    return (viewerEl && findElement(viewerEl, '.container')) ?? this.el;
   }
 
   // Add controls to the map, ordered from top down
@@ -117,7 +118,7 @@ export class OgmMap {
     this.map.addControl(this.layersControl);
     this.map.addControl(
       new maplibregl.FullscreenControl({
-        container: this.containerEl,
+        container: this.getContainer(),
       }),
     );
     this.map.addControl(new maplibregl.GlobeControl());
@@ -180,6 +181,7 @@ export class OgmMap {
   @Watch('theme')
   onThemeChange() {
     if (!this.map) return;
+    this.mapTheme.theme = this.theme;
     // The popup reads from sources setStyle is about to drop, so it goes first
     this.destroyPopup();
     // The panel is still on screen over the window this opens, and a layer can't be styled inside it
@@ -442,7 +444,8 @@ export class OgmMap {
   // inside the shadow root.
   render() {
     return (
-      <Host>
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         <div id="map" class={`wa-${this.theme}`}></div>
         {this.layersPanelOpen && <ogm-layers theme={this.theme} layers={this.layerControls}></ogm-layers>}
       </Host>

--- a/src/components/ogm-menubar/ogm-menubar.test.tsx
+++ b/src/components/ogm-menubar/ogm-menubar.test.tsx
@@ -16,40 +16,22 @@ describe('ogm-menubar', () => {
       });
 
       const { root } = await render(<ogm-menubar record={record}></ogm-menubar>);
+      const shadowRoot = root.shadowRoot as ShadowRoot;
 
-      expect(root).toEqualHtml(`
-        <ogm-menubar class="hydrated">
-          <mock:shadow-root>
-            <div class="menubar undefined">
-              <wa-button appearance="plain" class="menu-button">
-                <wa-icon name="list" label="Open sidebar" canvas="auto"></wa-icon>
-              </wa-button>
-              <div class="title">
-                Coho Salmon Watersheds: San Francisco Bay Area, California, 2011
-              </div>
-            </div>
-          </mock:shadow-root>
-        </ogm-menubar>
-      `);
+      expect(shadowRoot.querySelector('.title')?.textContent?.trim()).toBe('Coho Salmon Watersheds: San Francisco Bay Area, California, 2011');
+      expect(shadowRoot.querySelector('.menubar')?.className).toBe('menubar');
+      expect(shadowRoot.querySelector('wa-button.menu-button wa-icon')?.getAttribute('name')).toBe('list');
     });
   });
 
   describe('without a record', () => {
-    it('does not render anything', async () => {
+    it('renders the bar and its button, with nothing in the title', async () => {
       const { root } = await render(<ogm-menubar></ogm-menubar>);
+      const shadowRoot = root.shadowRoot as ShadowRoot;
 
-      expect(root).toEqualHtml(`
-        <ogm-menubar class="hydrated">
-          <mock:shadow-root>
-            <div class="menubar undefined">
-              <wa-button appearance="plain" class="menu-button">
-                <wa-icon name="list" label="Open sidebar" canvas="auto"></wa-icon>
-              </wa-button>
-              <div class="title"></div>
-            </div>
-          </mock:shadow-root>
-        </ogm-menubar>
-      `);
+      expect(shadowRoot.querySelector('.title')?.textContent).toBe('');
+      expect(shadowRoot.querySelector('wa-button.menu-button')).not.toBeNull();
+      expect(shadowRoot.querySelector('.restricted-icon')).toBeNull();
     });
   });
 

--- a/src/components/ogm-menubar/ogm-menubar.tsx
+++ b/src/components/ogm-menubar/ogm-menubar.tsx
@@ -1,4 +1,10 @@
 import { Component, Prop, EventEmitter, h, Event } from '@stencil/core';
+
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+
 import type OgmRecord from '../../lib/record';
 
 @Component({
@@ -15,7 +21,7 @@ export class OgmMenubar {
 
   render() {
     return (
-      <div class={`menubar ${this.theme && `wa-${this.theme}`}`}>
+      <div class={{ menubar: true, [`wa-${this.theme}`]: !!this.theme }}>
         <wa-button appearance="plain" class="menu-button" onclick={this.sidebarToggled.emit}>
           <wa-icon name="list" label="Open sidebar" canvas="auto"></wa-icon>
         </wa-button>

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -1,5 +1,6 @@
 import { Component, h, Host, Listen, Prop, State, Watch } from '@stencil/core';
 
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import type { AnyPreviewer } from '../../lib/previewers/factory';
 import type { PreviewError } from '../../lib/errors';
 
@@ -10,7 +11,7 @@ import type { PreviewError } from '../../lib/errors';
   shadow: true,
 })
 export class OgmPreview {
-  @Prop() theme: 'light' | 'dark';
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() previewer: AnyPreviewer;
   @Prop() sidebarPadding: number;
   @State() error?: PreviewError;
@@ -38,7 +39,8 @@ export class OgmPreview {
 
   render() {
     return (
-      <Host>
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         {this.renderPreview()}
         {this.error && <ogm-alerts theme={this.theme} error={this.error}></ogm-alerts>}
       </Host>

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -1,6 +1,11 @@
 import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
-import type OgmRecord from '../../lib/record';
 
+import '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';
+import '@awesome.me/webawesome/dist/components/tab-panel/tab-panel.js';
+import '@awesome.me/webawesome/dist/components/tab/tab.js';
+
+import type OgmRecord from '../../lib/record';
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import { resourcesFor } from '../../lib/resources/factory';
 import { previewersForResources, type AnyPreviewer } from '../../lib/previewers/factory';
 
@@ -10,7 +15,7 @@ import { previewersForResources, type AnyPreviewer } from '../../lib/previewers/
   shadow: true,
 })
 export class OgmPreviews {
-  @Prop() theme: 'light' | 'dark';
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() record: OgmRecord;
   @Prop() sidebarPadding: number;
   @State() previewers: AnyPreviewer[] = [];
@@ -58,7 +63,8 @@ export class OgmPreviews {
     if (!this.record || !this.previewers.length) return;
 
     return (
-      <Host class={this.theme && `wa-${this.theme}`}>
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
         <wa-tab-group>
           {this.previewers.map((previewer, idx) => (
             <wa-tab key={idx} panel={previewer.previewId}>

--- a/src/components/ogm-sidebar/ogm-sidebar.tsx
+++ b/src/components/ogm-sidebar/ogm-sidebar.tsx
@@ -1,5 +1,10 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';
+import '@awesome.me/webawesome/dist/components/tab-panel/tab-panel.js';
+import '@awesome.me/webawesome/dist/components/tab/tab.js';
+
 import { getElement } from '../../lib/elements';
 import type OgmRecord from '../../lib/record';
 import type WaTabGroup from '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -2,24 +2,7 @@ import { Component, Element, Host, Listen, Method, Prop, State, Watch, h } from 
 
 import OgmRecord from '../../lib/record';
 import { fetchOrThrow, recordError, type PreviewError } from '../../lib/errors';
-import { webAwesomeStylesheet } from '../../lib/init';
-
-// Import all required Web Awesome components
-import '@awesome.me/webawesome/dist/components/button/button.js';
-import '@awesome.me/webawesome/dist/components/callout/callout.js';
-import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/scroller/scroller.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
-import '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';
-import '@awesome.me/webawesome/dist/components/tab-panel/tab-panel.js';
-import '@awesome.me/webawesome/dist/components/tab/tab.js';
-import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
-
-// Web Awesome activates its palette and semantic color variants on `:root` by default (with
-// `.wa-*` classes only needed to override the defaults). `:root` never matches inside a shadow
-// tree, so we opt into each default explicitly on our container to reproduce what a document-level
-// load would give us: the default palette plus the default hue for every color variant.
-const WA_SCOPE = 'wa-palette-default wa-brand-blue wa-neutral-gray wa-success-green wa-warning-yellow wa-danger-red';
+import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 
 @Component({
   tag: 'ogm-viewer',
@@ -29,7 +12,7 @@ const WA_SCOPE = 'wa-palette-default wa-brand-blue wa-neutral-gray wa-success-gr
 export class OgmViewer {
   @Element() el: HTMLElement;
   @Prop() recordUrl: string;
-  @Prop() theme: 'light' | 'dark' = this.getThemePreference();
+  @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() hideTitle: boolean = false;
   @State() record?: OgmRecord;
   @State() error?: PreviewError;
@@ -42,11 +25,6 @@ export class OgmViewer {
   // Prior to rendering, fetch the record if a URL is provided
   async componentWillLoad() {
     if (this.recordUrl) return await this.updateRecord();
-  }
-
-  // Check the user's theme preference via CSS media query
-  private getThemePreference() {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
   // Shift the map/image over when the sidebar is toggled open
@@ -115,7 +93,7 @@ export class OgmViewer {
     return (
       <Host class={`wa-${this.theme}`}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <div class={`container ${WA_SCOPE} wa-${this.theme}`}>
+        <div class={`container ${waScope(this.theme)}`}>
           <ogm-menubar theme={this.theme} record={this.record} loading={this.loading} hideTitle={this.hideTitle}></ogm-menubar>
           <div class="main-container">
             <ogm-sidebar theme={this.theme} record={this.record} open={this.sidebarOpen}></ogm-sidebar>

--- a/src/index.html
+++ b/src/index.html
@@ -49,6 +49,23 @@
         width: clamp(800px, 70vw, 1000px);
         margin: 1rem auto 0;
       }
+
+      /* A bare preview has no chrome to give it a size, so the embedding page picks one */
+      ogm-preview {
+        width: clamp(800px, 70vw, 1000px);
+        height: 500px;
+        margin: 1rem auto 0;
+        border: 1px solid #ccc;
+      }
+
+      /* The --ogm-* theming API. These inherit through the shadow boundary, which is the whole
+         point: nothing below has to know the embedding page exists. */
+      ogm-preview.branded {
+        --ogm-fill-color: #8f1414;
+        --ogm-stroke-color: #4a0a0a;
+        --ogm-fill-selected-color: #e98300;
+        --ogm-stroke-selected-color: #8f4700;
+      }
     </style>
 
     <script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,78 @@
 /**
- * @fileoverview entry point for your component library
+ * @fileoverview The library behind the components.
  *
- * This is the entry point for your component library. Use this file to export utilities,
- * constants or data structure that accompany your components.
+ * Everything here is also what the components use internally, from the same modules - so a resource
+ * or previewer built by hand is the same kind of object <ogm-map> would have built for itself, and
+ * the two share one copy of maplibre-gl. Reach for this when you have the data already and don't
+ * want the record-driven path: build a Resource, wrap it in a Previewer, hand that to <ogm-preview>.
  *
- * DO NOT use this file to export your components. Instead, use the recommended approaches
- * to consume components of this package as outlined in the `README.md`.
+ *   import { GeoJsonResource, GeoJsonPreviewer } from 'ogm-viewer/lib';
+ *
+ *   const resource = new GeoJsonResource('my-layer', 'https://example.com/data.json');
+ *   document.querySelector('ogm-preview').previewer = new GeoJsonPreviewer(resource);
+ *
+ * The components themselves are not exported here; importing 'ogm-viewer' defines them.
  */
 
 export type * from './components.d.ts';
+
+// A record, and the references it points at
+export { default as OgmRecord, OGM_FIELD_NAMES, type GeoBlacklightSchemaAardvark } from './lib/record';
+export { References, REFERENCE_URIS, type LabelledLinks, type ReferenceName, type ReferencesRecord, type ReferenceURI } from './lib/references';
+
+// What a record's references point at. `resourcesFor` is the record-driven path; the classes are
+// there for when you already know what you have.
+export { resourcesFor } from './lib/resources/factory';
+export { default as Resource, type ResourceKind } from './lib/resources/resource';
+export { default as MapResource } from './lib/resources/map';
+export { default as RasterResource } from './lib/resources/raster';
+export { default as VectorResource } from './lib/resources/vector';
+export { default as EsriResource, EXPORT_TILE_SIZE, type EsriRasterSourceSpec } from './lib/resources/esri';
+export { default as EsriMapServerResource } from './lib/resources/esri-map-server';
+export { default as IIIFResource } from './lib/resources/iiif';
+
+export { default as CogResource } from './lib/resources/cog';
+export { default as EsriDynamicMapLayerResource } from './lib/resources/esri-dynamic-map-layer';
+export { default as EsriFeatureLayerResource } from './lib/resources/esri-feature-layer';
+export { default as EsriImageMapLayerResource } from './lib/resources/esri-image-map-layer';
+export { default as EsriTiledMapLayerResource } from './lib/resources/esri-tiled-map-layer';
+export { default as GeoJsonResource } from './lib/resources/geojson';
+export { default as IIIFManifestResource } from './lib/resources/iiif-manifest';
+export { default as OpenIndexMapResource } from './lib/resources/openindexmap';
+export { default as PMTilesResource } from './lib/resources/pmtiles';
+export { default as TileJsonResource } from './lib/resources/tilejson';
+export { default as TmsResource } from './lib/resources/tms';
+export { default as WmsResource, type GetFeatureInfoOptions } from './lib/resources/wms';
+export { default as WmtsResource, type Bounds, type WmtsLayer, type WmtsOptions } from './lib/resources/wmts';
+export { default as XyzResource } from './lib/resources/xyz';
+
+// How a resource is drawn. One resource can offer more than one preview, so these are lists.
+export { previewersFor, previewersForResources, type AnyPreviewer } from './lib/previewers/factory';
+export { default as Previewer, type PreviewRenderer } from './lib/previewers/previewer';
+export { default as MapPreviewer } from './lib/previewers/map';
+export { default as RasterPreviewer, type AddRasterSourceObject } from './lib/previewers/raster';
+export { default as VectorPreviewer, type AddVectorSourceObject } from './lib/previewers/vector';
+export { default as InspectableRasterPreviewer } from './lib/previewers/inspectable-raster';
+export { default as EsriRasterPreviewer } from './lib/previewers/esri-raster';
+export { default as TiledVectorPreviewer } from './lib/previewers/tiled-vector';
+
+export { default as CogPreviewer } from './lib/previewers/cog';
+export { default as EsriDynamicMapLayerPreviewer } from './lib/previewers/esri-dynamic-map-layer';
+export { default as EsriFeatureLayerPreviewer } from './lib/previewers/esri-feature-layer';
+export { default as EsriImageMapLayerPreviewer } from './lib/previewers/esri-image-map-layer';
+export { default as EsriTiledMapLayerPreviewer } from './lib/previewers/esri-tiled-map-layer';
+export { default as GeoJsonPreviewer, type AddGeoJsonSourceObject } from './lib/previewers/geojson';
+export { default as ImagePreviewer } from './lib/previewers/image';
+export { default as OpenIndexMapPreviewer } from './lib/previewers/openindexmap';
+export { default as PMTilesRasterPreviewer } from './lib/previewers/pmtiles-raster';
+export { default as PMTilesVectorPreviewer } from './lib/previewers/pmtiles-vector';
+export { default as TileJsonRasterPreviewer } from './lib/previewers/tilejson-raster';
+export { default as TileJsonVectorPreviewer } from './lib/previewers/tilejson-vector';
+export { default as WmsPreviewer } from './lib/previewers/wms';
+export { default as WmtsPreviewer } from './lib/previewers/wmts';
+
+// What a preview is drawn with, and what a failed one reports
+export { default as Theme } from './lib/themes/theme';
+export { default as MapLibreTheme, darkBasemapStyle, lightBasemapStyle, type MapLibreStyle } from './lib/themes/maplibre';
+export { isLayerDrawn, resolveLayerState, type Layer, type LayerControl, type LayerState, type PreviewStyleLayer } from './lib/layers';
+export { fetchOrThrow, recordError, referenceError, HttpError, PreviewError } from './lib/errors';

--- a/src/lib/elements.ts
+++ b/src/lib/elements.ts
@@ -9,3 +9,18 @@ export const getElement = (parent: HTMLElement, selector: string): HTMLElement =
   if (!el) throw new Error(`Could not find child of ${parent.tagName} with selector: ${selector}`);
   return el as HTMLElement;
 };
+
+// The nearest ancestor matching the selector, looking out through any shadow roots we're inside.
+// closest() stops at a shadow boundary, and a component has no way to know how many boundaries lie
+// between it and what it's looking for - or whether that ancestor is there at all.
+export const closestAcrossShadows = (start: Element, selector: string): HTMLElement | undefined => {
+  let node: Element | undefined = start;
+  while (node) {
+    const found = node.closest(selector);
+    if (found) return found as HTMLElement;
+    // Out through one shadow boundary. A light-DOM root is the document, which has no host, and
+    // that is what ends the walk.
+    node = (node.getRootNode() as ShadowRoot).host;
+  }
+  return undefined;
+};

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -18,3 +18,25 @@ registerIconLibrary('default', {
 // The Web Awesome theme, which components link inside their own shadow root rather than at the top
 // of the page: loading it into the document would restyle the host app around us.
 export const webAwesomeStylesheet = (): string => getBasePath('assets/webawesome/styles/themes/default.css');
+
+// Web Awesome activates its palette and semantic color variants on `:root` by default (with `.wa-*`
+// classes only needed to override the defaults). `:root` never matches inside a shadow tree, so we
+// opt into each default explicitly to reproduce what a document-level load would give us: the
+// default palette plus the default hue for every color variant.
+const WA_PALETTE = 'wa-palette-default wa-brand-blue wa-neutral-gray wa-success-green wa-warning-yellow wa-danger-red';
+
+/**
+ * The classes that turn a shadow root into a Web Awesome scope, paired with the stylesheet link
+ * above. Every component that can be used on its own applies both, rather than counting on an
+ * <ogm-viewer> above it: custom properties inherit through shadow boundaries, so the outermost one
+ * in use is the one that has to establish them, and which component that is depends on the embed.
+ *
+ * Applying them more than once down a single tree is harmless - the values are identical, and the
+ * browser fetches the stylesheet once - which is why nobody tries to detect whether an ancestor got
+ * there first. At first paint there is no reliable answer to that question anyway.
+ */
+export const waScope = (theme?: 'light' | 'dark'): string => `${WA_PALETTE} wa-${theme ?? 'light'}`;
+
+// Which theme to draw in when nobody said. Only consulted by a component used on its own;
+// <ogm-viewer> passes its own resolved theme down to everything it renders.
+export const themePreference = (): 'light' | 'dark' => (window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle } from './maplibre';
+
+// A theme reading from an element carrying the given custom properties.
+//
+// The properties go on the element the theme reads rather than on an ancestor: happy-dom resolves a
+// custom property declared on the element itself but does not inherit one down the tree. Reaching in
+// from an ancestor - which is how an embedding app actually sets these - is CSS inheritance doing its
+// job, so it belongs in a browser rather than here.
+const themed = (theme: 'light' | 'dark' | undefined, tokens: Record<string, string> = {}) => {
+  const el = document.createElement('div');
+  Object.entries(tokens).forEach(([name, value]) => el.style.setProperty(name, value));
+  document.body.appendChild(el);
+  return new MapLibreTheme(el, theme);
+};
+
+describe('MapLibreTheme', () => {
+  describe('colors', () => {
+    it('reads our own token for the mode when nothing overrides it', () => {
+      const light = themed('light', { '--wa-color-blue-80': 'rebeccapurple' });
+      const dark = themed('dark', { '--wa-color-blue-50': 'papayawhip' });
+
+      expect(light.getStyle().fillColor).toBe('rebeccapurple');
+      expect(dark.getStyle().fillColor).toBe('papayawhip');
+    });
+
+    it('prefers an --ogm-* override to the token it falls back to', () => {
+      const theme = themed('light', { '--ogm-fill-color': '#8f1414', '--wa-color-blue-80': 'rebeccapurple' });
+
+      expect(theme.getStyle().fillColor).toBe('#8f1414');
+    });
+
+    // An app that names a color has said it wants that color; picking a different one in dark mode
+    // would be picking one it never asked for.
+    it('honors a single override in both modes', () => {
+      const tokens = { '--ogm-stroke-color': '#4a0a0a', '--wa-color-blue-50': 'papayawhip', '--wa-color-blue-80': 'rebeccapurple' };
+
+      expect(themed('light', tokens).getStyle().strokeColor).toBe('#4a0a0a');
+      expect(themed('dark', tokens).getStyle().strokeColor).toBe('#4a0a0a');
+    });
+
+    // Web Awesome documents its palette tokens inline, and Safari leaks the comment into the
+    // computed value, which MapLibre then rejects as an invalid color.
+    it('strips a comment left in a token value', () => {
+      const theme = themed('light', { '--wa-color-blue-80': '#0a3a1d /* oklch(30% 0.08 150) */' });
+
+      expect(theme.getStyle().fillColor).toBe('#0a3a1d');
+    });
+  });
+
+  // MapLibre's text-font names a glyph the basemap style serves, not a CSS font stack, so this one
+  // must not fall through to --wa-font-family-body the way the colors fall through to their tokens.
+  describe('label font', () => {
+    it('defaults to a glyph name rather than a CSS font stack', () => {
+      const theme = themed('light', { '--wa-font-family-body': 'ui-sans-serif, system-ui, sans-serif' });
+
+      expect(theme.getStyle().textFont).toBe('Noto Sans Regular');
+    });
+
+    it('takes an override', () => {
+      expect(themed('light', { '--ogm-font-family': 'Open Sans Regular' }).getStyle().textFont).toBe('Open Sans Regular');
+    });
+  });
+
+  describe('numbers', () => {
+    it('reads an override', () => {
+      expect(themed('light', { '--ogm-text-size': '18' }).getStyle().textSize).toBe(18);
+      expect(themed('light', { '--ogm-fill-opacity': '0.35' }).getStyle().opacity).toBe(0.35);
+    });
+
+    it('keeps the default when the property is unset or unparseable', () => {
+      expect(themed('light').getStyle().textSize).toBe(14);
+      expect(themed('light', { '--ogm-text-size': 'large' }).getStyle().textSize).toBe(14);
+    });
+  });
+
+  describe('basemap', () => {
+    // The component's own answer, not the computed color-scheme: the stylesheet that would set that
+    // is linked inside a shadow root, and may not have loaded when the map is first built.
+    it('follows the theme it was given', () => {
+      expect(themed('dark').getBaseMapStyle()).toBe(darkBasemapStyle);
+      expect(themed('light').getBaseMapStyle()).toBe(lightBasemapStyle);
+    });
+
+    it('falls back to the computed color-scheme when it was given no theme', () => {
+      const el = document.createElement('div');
+      el.style.setProperty('color-scheme', 'dark');
+      document.body.appendChild(el);
+
+      expect(new MapLibreTheme(el).getBaseMapStyle()).toBe(darkBasemapStyle);
+      expect(new MapLibreTheme(document.createElement('div')).getBaseMapStyle()).toBe(lightBasemapStyle);
+    });
+  });
+});

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -29,31 +29,62 @@ export type MapLibreStyle = {
 export const darkBasemapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 export const lightBasemapStyle = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 
+// Default MapLibre `text-font` glyph name. Unlike the rest of our text styling, this can't fall
+// back to a CSS token: `text-font` names a glyph MapLibre requests from the style's glyphs
+// endpoint, not a CSS font stack, so `--wa-font-family-body` (e.g. "ui-sans-serif, system-ui,
+// sans-serif") would be sent to the endpoint literally and rejected by CORS. "Noto Sans Regular"
+// is in every fontstack both CARTO basemap styles above serve glyphs for.
+const defaultGlyphFont = 'Noto Sans Regular';
+
 // Style properties common to all MapLibre-based previewers
 export default class MapLibreTheme extends Theme {
+  /**
+   * How previewed data is drawn. Every value here can be overridden by setting the matching
+   * `--ogm-*` custom property on the component or anything above it - custom properties inherit
+   * through shadow boundaries, so setting them on the embedding page reaches in:
+   *
+   *   ogm-viewer { --ogm-fill-color: #8f1414; --ogm-stroke-color: #4a0a0a; }
+   *
+   * Left alone, each falls back to a Web Awesome token, picked for the current mode. Those are the
+   * library's own palette and move with it; the `--ogm-*` names are the contract, and are the only
+   * ones an embedding app should be naming.
+   *
+   * `--ogm-font-family` is the one exception: it names a MapLibre glyph font (e.g. "Noto Sans
+   * Regular"), not a CSS font stack, so it can't fall back to `--wa-font-family-body` - that's a
+   * CSS stack like "ui-sans-serif, system-ui, sans-serif", and MapLibre would request it verbatim
+   * from the style's glyphs endpoint and get a CORS failure. An app overriding it must give a
+   * glyph name the active basemap style actually serves.
+   */
   getStyle(): MapLibreStyle {
     return {
-      padding: this.readCssProperty('--wa-space-xl'),
-      opacity: 0.8,
-      fillColor: this.dualCssColors('--wa-color-blue-50', '--wa-color-blue-80'),
-      fillHighlightColor: this.dualCssColors('--wa-color-cyan-60', '--wa-color-cyan-80'),
-      fillSelectedColor: this.dualCssColors('--wa-color-green-50', '--wa-color-green-80'),
-      fillInvalidColor: this.dualCssColors('--wa-color-red-50', '--wa-color-red-60'),
-      strokeColor: this.dualCssColors('--wa-color-blue-80', '--wa-color-blue-50'),
-      strokeHighlightColor: this.dualCssColors('--wa-color-cyan-80', '--wa-color-cyan-60'),
-      strokeSelectedColor: this.dualCssColors('--wa-color-green-80', '--wa-color-green-50'),
-      strokeInvalidColor: this.dualCssColors('--wa-color-red-80', '--wa-color-red-30'),
-      textColor: this.dualCssColors('--wa-color-gray-95', '--wa-color-gray-05'),
-      textHaloColor: this.dualCssColors('--wa-color-gray-05', '--wa-color-gray-95'),
-      textFont: this.readCssProperty('--wa-font-family-body'),
-      textSize: 14,
-      fillHighlightOpacity: 0.8,
+      padding: this.readCssProperty('--ogm-padding') || this.readCssProperty('--wa-space-xl'),
+      opacity: this.readCssNumber('--ogm-fill-opacity', 0.8),
+      fillColor: this.themedColor('--ogm-fill-color', '--wa-color-blue-50', '--wa-color-blue-80'),
+      fillHighlightColor: this.themedColor('--ogm-fill-highlight-color', '--wa-color-cyan-60', '--wa-color-cyan-80'),
+      fillSelectedColor: this.themedColor('--ogm-fill-selected-color', '--wa-color-green-50', '--wa-color-green-80'),
+      fillInvalidColor: this.themedColor('--ogm-fill-invalid-color', '--wa-color-red-50', '--wa-color-red-60'),
+      strokeColor: this.themedColor('--ogm-stroke-color', '--wa-color-blue-80', '--wa-color-blue-50'),
+      strokeHighlightColor: this.themedColor('--ogm-stroke-highlight-color', '--wa-color-cyan-80', '--wa-color-cyan-60'),
+      strokeSelectedColor: this.themedColor('--ogm-stroke-selected-color', '--wa-color-green-80', '--wa-color-green-50'),
+      strokeInvalidColor: this.themedColor('--ogm-stroke-invalid-color', '--wa-color-red-80', '--wa-color-red-30'),
+      textColor: this.themedColor('--ogm-text-color', '--wa-color-gray-95', '--wa-color-gray-05'),
+      textHaloColor: this.themedColor('--ogm-text-halo-color', '--wa-color-gray-05', '--wa-color-gray-95'),
+      textFont: this.readCssProperty('--ogm-font-family') || defaultGlyphFont,
+      textSize: this.readCssNumber('--ogm-text-size', 14),
+      fillHighlightOpacity: this.readCssNumber('--ogm-fill-highlight-opacity', 0.8),
     };
   }
 
   // Get the appropriate basemap style URL based on dark mode
   getBaseMapStyle(): string {
     return this.darkMode() ? darkBasemapStyle : lightBasemapStyle;
+  }
+
+  // An embedding app's override if it set one, otherwise our own token for the current mode. One
+  // override covers both modes: an app that names a color has said it wants that color, and
+  // second-guessing it in dark mode would be picking a color it never asked for.
+  themedColor(override: string, darkColor: string, lightColor: string): string {
+    return this.readCssProperty(override) || this.dualCssColors(darkColor, lightColor);
   }
 
   // If dark mode, use the first CSS color, otherwise use the second CSS color

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -2,16 +2,24 @@
 export default abstract class Theme {
   protected element: Element;
 
+  // Which way the component drawing this was told to render, if it was told. Mutable because a
+  // component's theme can change under a preview that is already on screen.
+  theme?: 'light' | 'dark';
+
   // Store a reference to DOM element so we can use it to inspect styles
-  constructor(element: Element) {
+  constructor(element: Element, theme?: 'light' | 'dark') {
     this.element = element;
+    this.theme = theme;
   }
 
   // Returns style properties for this theme
   abstract getStyle(): Record<string, any>;
 
-  // Check if we're in dark mode
+  // Check if we're in dark mode. The component's own answer wins: `color-scheme` comes from the Web
+  // Awesome stylesheet, which is linked into a shadow root and so may not have loaded by the time a
+  // map is first built - and a component used on its own may have no Web Awesome scope above it at all.
   protected darkMode(): boolean {
+    if (this.theme) return this.theme === 'dark';
     return this.readCssProperty('color-scheme') === 'dark';
   }
 
@@ -25,5 +33,12 @@ export default abstract class Theme {
       .getPropertyValue(property)
       .replace(/\/\*.*?\*\//g, '')
       .trim();
+  };
+
+  // A custom property read as a number, for the styles that aren't colors. A property nobody set
+  // reads as the empty string and parses as NaN, which is the signal to keep the default.
+  protected readCssNumber = (property: string, fallback: number): number => {
+    const value = parseFloat(this.readCssProperty(property));
+    return Number.isFinite(value) ? value : fallback;
   };
 }

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,14 +1,27 @@
+// Enough of ElementInternals for Web Awesome's form controls to upgrade. happy-dom implements none
+// of it (checked in 20.9), and <wa-button> reads validity out of it as it connects, so without this
+// every component that renders one throws before its own markup exists to assert on. Nothing here
+// is exercised by a test - it only has to not be undefined. Form behavior is Web Awesome's to test.
+if (!HTMLElement.prototype.attachInternals) {
+  HTMLElement.prototype.attachInternals = function attachInternals(this: HTMLElement) {
+    return {
+      form: null,
+      labels: [] as unknown as NodeList,
+      states: new Set<string>(),
+      validationMessage: '',
+      validity: { valid: true } as ValidityState,
+      willValidate: false,
+      checkValidity: () => true,
+      reportValidity: () => true,
+      setFormValue: () => {},
+      setValidity: () => {},
+    } as unknown as ElementInternals;
+  };
+}
+
 // Register the components under test as custom elements. The custom-elements build has no loader to
-// call: importing a component entry defines that component and everything it renders.
-//
-// Deliberately not ogm-viewer, which would define all eleven: it is the only component that imports
-// the Web Awesome element modules, and pulling those in would upgrade every wa-* element the other
-// components render. That would drag Web Awesome's own shadow DOM - lit marker comments and all -
-// into assertions that are about our markup, and break them on every Web Awesome release. Left
-// undefined, wa-* elements stay inert, which is what these tests were written against.
-//
-// Anything rendering ogm-viewer or ogm-sidebar needs a real browser rather than happy-dom, since
-// Web Awesome's form controls want ElementInternals as they upgrade.
+// call: importing a component entry defines that component and everything it renders - including
+// the wa-* elements the component imports for itself, which do get upgraded here.
 import './dist/components/ogm-alerts.js';
 import './dist/components/ogm-attributes.js';
 import './dist/components/ogm-layers.js';


### PR DESCRIPTION
An app that already has its own chrome should be able to embed just the map. Until now it couldn't, for three independent reasons — this fixes all three, plus exports the library that makes any of it reachable.

Groundwork for [sul-embed#3124](https://github.com/sul-dlss/sul-embed/issues/3124) and for sul-embed replacing its bespoke geo viewer with this one.

## What was in the way

- `<ogm-map>`'s `getContainer()` did `document.querySelector('ogm-viewer')` and **threw** when there wasn't one. It ran before `addControls()` and before every `map.on(...)` binding, so a bare `<ogm-map>` was a dead canvas: no controls, no load handler, no preview.
- All nine Web Awesome element modules were imported by `ogm-viewer.tsx` alone, even though it renders none of them itself. Anywhere else, `wa-*` stayed inert.
- `MapLibreTheme` reads `--wa-color-*` / `--wa-space-xl` / `--wa-font-family-body`, which only exist inside `<ogm-viewer>`'s shadow root. Standalone, MapLibre got empty strings and rejected them.
- The classes weren't exported at all. `src/index.ts` was `export type *` and nothing else.

## Export the library

`src/index.ts` now exports the resources, previewers, factories, record, themes and error types, reachable as `ogm-viewer/lib`.

That file is built into `dist/components/index.js`, which **shares chunks with the component entries** — verified. So a previewer you build by hand is the same kind of object `<ogm-map>` would have built for itself (the four `instanceof InspectableRasterPreviewer` checks still hold), and there's one copy of maplibre-gl rather than two.

`.` still points at `dist/components/ogm-viewer.js` and still defines all eleven elements, so **nothing changes for an app that just wants the whole viewer** — one script tag or one bare import, as before.

Also adds a `prepare` script: `dist/` is gitignored, so `npm i OpenGeoMetadata/ogm-viewer` currently installs an empty package.

## Stand on their own

`getContainer()` walks out through the shadow roots it sits in (new `closestAcrossShadows` helper) instead of asking the document — which would have picked the first viewer on the page whether or not it was the one we're inside — and falls back to the map's own element. It's called from `addControls()` now rather than ahead of the event bindings, so a control that can't be built can't cost us the preview.

Each component imports the `wa-*` elements it renders. Each component that can be an entry point (`ogm-viewer`, `ogm-previews`, `ogm-preview`, `ogm-map`, `ogm-image`, `ogm-alerts`) establishes its own Web Awesome scope — the palette classes plus the stylesheet link, which is what makes the tokens resolve. The internal-only components (`ogm-attributes`, `ogm-layers`, `ogm-menubar`, `ogm-metadata`, `ogm-sidebar`) inherit it, since custom properties cross shadow boundaries.

Applying the scope more than once down a tree is harmless — identical values, one cached stylesheet fetch — so nothing tries to detect whether an ancestor got there first. At first paint there's no reliable answer to that question anyway.

**Attribution is back.** The map had `attributionControl: false` while drawing CARTO basemaps over OpenStreetMap data, both of which require attribution. Compact, so it's a single "i" until clicked.

## Theming API

Every value in the map style can be overridden with an `--ogm-*` custom property, falling back to the Web Awesome token for the current mode when unset. Set them on the element or anything above it:

```css
ogm-viewer {
  --ogm-fill-color: #8f1414;
  --ogm-stroke-color: #4a0a0a;
}
```

Fifteen tokens, documented in the README. One override covers both light and dark: an app that names a color has said it wants that color, and second-guessing it in dark mode would be picking one it never asked for.

`MapLibreTheme` also takes the component's own `theme` rather than reading computed `color-scheme`. That property comes from a stylesheet linked inside a shadow root, which may not have loaded when the map is first built — and standalone there may be no Web Awesome scope above it at all.

### One standing bug this turned up

`--ogm-font-family` can't work like the others. MapLibre's `text-font` names a **glyph** the basemap style serves, not a CSS font stack — and we were handing it `--wa-font-family-body`. So every labelled map fired two failed cross-origin requests:

```
Access to fetch at 'https://tiles.basemaps.cartocdn.com/fonts/ui-sans-serif,%20system-ui,%20sans-serif/0-255.pbf'
  ... has been blocked by CORS policy
Unable to load glyph range 0, 0-255. Rendering codepoint U+005F locally instead.
```

Labels still appeared via local fallback, so this was invisible. It now defaults to `"Noto Sans Regular"` — confirmed served by CARTO's glyph endpoint and used by both the positron and dark-matter styles. Browser check after the fix: **zero failed requests**.

## Testing

`vitest-setup.ts` shims `ElementInternals`, which happy-dom doesn't implement (checked in 20.9) and `<wa-button>` reads as it connects — without it, every component rendering one throws before its own markup exists to assert on. Nothing in the shim is exercised by a test; form behavior is Web Awesome's to test.

The two `ogm-menubar` `toEqualHtml` assertions became query-based, matching every other test file here. They now serialize Web Awesome's internal shadow DOM down to a lit marker hash (`lit$192116541$`) that changes on every release. Rewriting them surfaced `class="menubar undefined"`, from a `&&` inside a template string.

New `src/lib/themes/maplibre.test.tsx` covers the fallback chain, override precedence, the Safari comment-stripping case, the glyph-font default, and basemap selection. **35 files, 456 passed, 1 todo** (was 446), lint clean.

## Verified in a browser

Loading only `dist/components/ogm-preview.js` and `dist/components/index.js`, with **no `<ogm-viewer>` on the page**:

- All seven map controls present — `getContainer()` no longer throws
- Attribution reads "© CARTO, © OpenStreetMap contributors"
- Web Awesome scope established standalone: `--wa-color-surface-default` resolves
- `--ogm-fill-color: #8f1414` set on the light-DOM host actually paints the polygons
- Click-to-inspect works: popup opens, `<ogm-attributes>` renders, `wa-scroller` and both pager `wa-button`s are upgraded — proving the component defines its own Web Awesome elements
- Zero failed network requests

And on `src/index.html`, where a standalone `<ogm-preview>` now sits on the same page as a full `<ogm-viewer>`: the `--ogm-*` override reaches the standalone preview and does **not** leak into the viewer, and the viewer still loads records, tabs and menubar normally.

## Notes

- `.prettierignore` picks up `.claude`, where Claude Code puts worktrees; without it `npm run lint` fails on scratch state.
- Anything that renders `ogm-viewer` or `ogm-sidebar` will need a real browser rather than happy-dom. Neither has a test today.
- Unrelated, found while verifying: `npm test` does a dev build and leaves `dist/components/index2.js` behind, and a later `npm run build` doesn't remove it — so a dist can carry dev artifacts (including the profiling code and sourcemaps) into `npm pack`. A clean `rm -rf dist && npm run build` is correct: 226 files, 798.5 kB, no `st:app:start`, no maps. Worth handling when release automation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)