### PR TITLE
Add a request-transform hook for authenticated content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,30 @@ Here are the supported properties and what they apply to:
 
 By default, the viewer uses styles from [Web Awesome](https://webawesome.com/) that match the current mode (dark or light). Anything you override will be used in both modes.
 
+### Restricted content
+
+For previews of data that need authentication to access, you can set a custom `requestTransform` function to add headers or cookies to the request. It's a DOM property on `<ogm-viewer>` that you can set in JavaScript, like the `recordUrl` property:
+
+```javascript
+viewer.requestTransform = (url, resourceType) => {
+  // If we aren't requesting something from the restricted area, don't do anything
+  if (!url.startsWith('https://geo.my-domain.edu/restricted/')) return undefined;
+
+  // Otherwise, add an Authorization header with a bearer token
+  return { headers: { Authorization: `Bearer ${token}` } };
+};
+```
+
+If you're building a `Resource` by hand instead, pass the same kind of function as its last constructor argument (or to `resourcesFor`, if you're building several from a record):
+
+```javascript
+import { GeoJsonResource } from 'ogm-viewer/lib';
+
+const resource = new GeoJsonResource('my-layer', 'https://example.com/restricted/data.json', undefined, requestTransform);
+```
+
+The `requestTransform` will be applied to all requests made by the viewer for that resource, including metadata and tiles, as well as the requests for the MapLibre basemap.
+
 ### Components
 
 If you're building your own viewer, you can adopt `<ogm-viewer>`'s components individually.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,10 +9,12 @@ import { PreviewError } from "./lib/errors";
 import { MapGeoJSONFeature } from "maplibre-gl";
 import { LayerControl } from "./lib/layers";
 import { AnyPreviewer } from "./lib/previewers/factory";
+import { RequestTransform } from "./lib/request";
 export { PreviewError } from "./lib/errors";
 export { MapGeoJSONFeature } from "maplibre-gl";
 export { LayerControl } from "./lib/layers";
 export { AnyPreviewer } from "./lib/previewers/factory";
+export { RequestTransform } from "./lib/request";
 export namespace Components {
     interface OgmAlerts {
         "error"?: PreviewError;
@@ -84,6 +86,7 @@ export namespace Components {
     }
     interface OgmPreviews {
         "record": OgmRecord;
+        "requestTransform"?: RequestTransform;
         "sidebarPadding": number;
         /**
           * @default themePreference()
@@ -105,6 +108,7 @@ export namespace Components {
         "hideTitle": boolean;
         "loadRecord": (record: OgmRecord) => Promise<void>;
         "recordUrl": string;
+        "requestTransform"?: RequestTransform;
         /**
           * @default themePreference()
          */
@@ -372,6 +376,7 @@ declare namespace LocalJSX {
         "onPreviewsLoaded"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "onPreviewsLoading"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "record"?: OgmRecord;
+        "requestTransform"?: RequestTransform;
         "sidebarPadding"?: number;
         /**
           * @default themePreference()
@@ -392,6 +397,7 @@ declare namespace LocalJSX {
          */
         "hideTitle"?: boolean;
         "recordUrl"?: string;
+        "requestTransform"?: RequestTransform;
         /**
           * @default themePreference()
          */

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
 import maplibregl from 'maplibre-gl';
-import { Protocol as PMTilesProtocol } from 'pmtiles';
 
 import { closestAcrossShadows, findElement, getElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
@@ -11,11 +10,8 @@ import { isLayerDrawn, toLayerControlItems as getLayerControls, type LayerContro
 import LayersControl from '../../lib/layers-control';
 import InspectableRasterPreviewer from '../../lib/previewers/inspectable-raster';
 import type MapPreviewer from '../../lib/previewers/map';
+import { ourResourceType, toMapLibreRequest } from '../../lib/request';
 import MapLibreTheme from '../../lib/themes/maplibre';
-
-// Register PMTiles protocol
-const protocol = new PMTilesProtocol();
-maplibregl.addProtocol('pmtiles', protocol.tile);
 
 // Size in CSS pixels of the window we ask a server about when inspecting. WMS and ArcGIS both
 // locate a click by mapping a pixel grid onto a bbox, which assumes the view is a flat, north-up
@@ -71,6 +67,11 @@ export class OgmMap {
       center: [0, 0],
       zoom: 2,
       minZoom: 2,
+      // Read fresh on every request rather than captured once, so it always reflects whichever
+      // previewer is currently attached - including across onPreviewerChange, with no watcher of
+      // our own needed. Applies to the basemap's own style/glyphs/sprites too, not just this
+      // preview's data; see RequestTransform for why a transform has to account for that itself.
+      transformRequest: (url, resourceType) => toMapLibreRequest(this.previewer?.requestTransform?.(url, ourResourceType(resourceType)), url),
     });
 
     // Bound before the controls go on: a control that can't be built shouldn't cost us the preview

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -8,6 +8,7 @@ import type OgmRecord from '../../lib/record';
 import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import { resourcesFor } from '../../lib/resources/factory';
 import { previewersForResources, type AnyPreviewer } from '../../lib/previewers/factory';
+import type { RequestTransform } from '../../lib/request';
 
 @Component({
   tag: 'ogm-previews',
@@ -17,6 +18,8 @@ import { previewersForResources, type AnyPreviewer } from '../../lib/previewers/
 export class OgmPreviews {
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() record: OgmRecord;
+  // Passed to resourcesFor() when building this record's previews; see Resource.requestTransform.
+  @Prop() requestTransform?: RequestTransform;
   @Prop() sidebarPadding: number;
   @State() previewers: AnyPreviewer[] = [];
   @Event() previewsLoading: EventEmitter<void>;
@@ -49,7 +52,7 @@ export class OgmPreviews {
 
     this.previewsLoading.emit();
     try {
-      const previewers = await previewersForResources(resourcesFor(record));
+      const previewers = await previewersForResources(resourcesFor(record, this.requestTransform));
       // A newer record started building while this one was waiting; that one's answer is the keeper
       if (build === this.pending) this.previewers = previewers;
     } finally {

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Host, Listen, Method, Prop, State, Watch, h } from 
 import OgmRecord from '../../lib/record';
 import { fetchOrThrow, recordError, type PreviewError } from '../../lib/errors';
 import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
+import { resolveRequest, type RequestTransform } from '../../lib/request';
 
 @Component({
   tag: 'ogm-viewer',
@@ -14,6 +15,10 @@ export class OgmViewer {
   @Prop() recordUrl: string;
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() hideTitle: boolean = false;
+  // Applied to the record fetch itself, and passed down to every resource built from it - see
+  // Resource.requestTransform. A DOM property, like previewer on <ogm-preview>: set it before or
+  // alongside recordUrl, since changing it alone doesn't refetch an already-loaded record.
+  @Prop() requestTransform?: RequestTransform;
   @State() record?: OgmRecord;
   @State() error?: PreviewError;
   @State() sidebarOpen: boolean = false;
@@ -77,7 +82,8 @@ export class OgmViewer {
   private async fetchRecord(recordUrl: string): Promise<OgmRecord | undefined> {
     this.error = undefined;
     try {
-      const response = await fetchOrThrow(recordUrl);
+      const { url, init } = resolveRequest(recordUrl, 'metadata', this.requestTransform);
+      const response = await fetchOrThrow(url, init);
       const data = await response.json();
       return new OgmRecord(data);
     } catch (error) {
@@ -100,7 +106,7 @@ export class OgmViewer {
             {this.error ? (
               <ogm-alerts theme={this.theme} error={this.error}></ogm-alerts>
             ) : (
-              <ogm-previews theme={this.theme} record={this.record} sidebar-padding={this.sidebarPadding}></ogm-previews>
+              <ogm-previews theme={this.theme} record={this.record} requestTransform={this.requestTransform} sidebar-padding={this.sidebarPadding}></ogm-previews>
             )}
           </div>
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,11 @@ export type * from './components.d.ts';
 export { default as OgmRecord, OGM_FIELD_NAMES, type GeoBlacklightSchemaAardvark } from './lib/record';
 export { References, REFERENCE_URIS, type LabelledLinks, type ReferenceName, type ReferencesRecord, type ReferenceURI } from './lib/references';
 
+// Applied to every request a Resource makes on its own - and, once its previewer attaches to a
+// map, to MapLibre's own tile and style requests too. Pass one to a Resource's constructor, to
+// `resourcesFor`, or to <ogm-viewer>'s `requestTransform` property.
+export { resolveRequest, type RequestResourceType, type RequestTransform, type TransformedRequest } from './lib/request';
+
 // What a record's references point at. `resourcesFor` is the record-driven path; the classes are
 // there for when you already know what you have.
 export { resourcesFor } from './lib/resources/factory';

--- a/src/lib/esri.ts
+++ b/src/lib/esri.ts
@@ -2,6 +2,7 @@ import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
 import { fetchOrThrow, HttpError } from './errors';
 import { mercatorToLngLat } from './geometry';
+import { resolveRequest, type RequestTransform } from './request';
 
 // ArcGIS identifies Web Mercator by its own well-known ID as often as by the EPSG code, and older
 // services still use the pre-EPSG variants; all four describe the grid MapLibre draws in.
@@ -193,12 +194,13 @@ export const throwOnEsriError = <T>(body: T, url: string): T => {
 };
 
 // Fetch the JSON description of an ArcGIS resource, raising both HTTP and ArcGIS-level failures
-export const fetchEsriJson = async <T = EsriMetadata>(url: string, params: Record<string, string> = {}): Promise<T> => {
+export const fetchEsriJson = async <T = EsriMetadata>(url: string, params: Record<string, string> = {}, requestTransform?: RequestTransform): Promise<T> => {
   const requestUrl = new URL(url);
   Object.entries({ f: 'json', ...params }).forEach(([key, value]) => requestUrl.searchParams.set(key, value));
 
-  const response = await fetchOrThrow(requestUrl.toString());
-  return throwOnEsriError((await response.json()) as T, requestUrl.toString());
+  const { url: resolvedUrl, init } = resolveRequest(requestUrl.toString(), 'metadata', requestTransform);
+  const response = await fetchOrThrow(resolvedUrl, init);
+  return throwOnEsriError((await response.json()) as T, resolvedUrl);
 };
 
 // True if the service publishes the named capability, e.g. 'Query' on a MapServer that can be

--- a/src/lib/previewers/cog.ts
+++ b/src/lib/previewers/cog.ts
@@ -1,5 +1,5 @@
 import maplibregl from 'maplibre-gl';
-import { cogProtocol } from '@geomatico/maplibre-cog-protocol';
+import { cogProtocol, setRequestHeaders } from '@geomatico/maplibre-cog-protocol';
 
 import RasterPreviewer from './raster';
 import type CogResource from '../resources/cog';
@@ -24,8 +24,14 @@ export default class CogPreviewer extends RasterPreviewer {
     return `${this.resource.id}-cog`;
   }
 
-  // COG sources use 'url' instead of 'tiles' and have no scheme
+  // COG sources use 'url' instead of 'tiles' and have no scheme. @geomatico/maplibre-cog-protocol
+  // offers no per-URL auth hook, only a single header set shared by every COG on the page (see
+  // setRequestHeaders) - so a page previewing two authenticated COGs at once can't have both
+  // right at the same time. Re-assert ours immediately before the source that will trigger this
+  // one's tile requests goes on the map, to keep that window as small as it can be.
   protected async createSources(): Promise<AddRasterSourceObject[]> {
+    setRequestHeaders(this.requestTransform?.(this.resource.url, 'tile')?.headers ?? {});
+
     return [
       {
         id: this.getSourceId(),

--- a/src/lib/previewers/previewer.test.ts
+++ b/src/lib/previewers/previewer.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import GeoJsonPreviewer from './geojson';
+import GeoJsonResource from '../resources/geojson';
+import type { RequestTransform } from '../request';
+
+describe('Previewer#requestTransform', () => {
+  it("is undefined when the resource wasn't given one", () => {
+    const previewer = new GeoJsonPreviewer(new GeoJsonResource('id', 'https://example.com/data.json'));
+    expect(previewer.requestTransform).toBeUndefined();
+  });
+
+  it("is the resource's own transform, unchanged - so a component drawing this preview can apply it to requests the resource doesn't make itself", () => {
+    const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' } });
+    const resource = new GeoJsonResource('id', 'https://example.com/data.json', undefined, transform);
+    const previewer = new GeoJsonPreviewer(resource);
+
+    expect(previewer.requestTransform).toBe(transform);
+  });
+});

--- a/src/lib/previewers/previewer.ts
+++ b/src/lib/previewers/previewer.ts
@@ -1,4 +1,5 @@
 import type Resource from '../resources/resource';
+import type { RequestTransform } from '../request';
 
 // Which component draws a preview. A string rather than a class, so ogm-preview can route without
 // an instanceof: a class test only holds when both sides came from the same copy of the module.
@@ -14,6 +15,13 @@ export default abstract class Previewer {
 
   constructor(resource: Resource) {
     this.resource = resource;
+  }
+
+  // The resource's own request transform, if it has one. Exposed here so the component that
+  // draws this preview can apply it to requests the resource doesn't make itself - MapLibre's own
+  // tile fetches, once ogm-map attaches this previewer to a map.
+  get requestTransform(): RequestTransform | undefined {
+    return this.resource.requestTransform;
   }
 
   // Identifies the tab and the panel that show this preview. Every resource of one record carries

--- a/src/lib/request.test.ts
+++ b/src/lib/request.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from '@stencil/vitest';
+import type { ResourceType } from 'maplibre-gl';
+
+import { ourResourceType, resolveRequest, toMapLibreRequest, type RequestTransform } from './request';
+
+const URL = 'https://example.com/data.json';
+
+describe('resolveRequest', () => {
+  it('leaves the request alone when there is no transform', () => {
+    expect(resolveRequest(URL, 'metadata')).toEqual({ url: URL });
+  });
+
+  it('leaves the request alone when the transform declines this url', () => {
+    const transform: RequestTransform = () => undefined;
+    expect(resolveRequest(URL, 'metadata', transform)).toEqual({ url: URL });
+  });
+
+  it('carries headers into RequestInit', () => {
+    const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' } });
+    expect(resolveRequest(URL, 'metadata', transform)).toEqual({ url: URL, init: { headers: { Authorization: 'Bearer token' } } });
+  });
+
+  it('carries credentials into RequestInit', () => {
+    const transform: RequestTransform = () => ({ credentials: 'include' });
+    expect(resolveRequest(URL, 'metadata', transform)).toEqual({ url: URL, init: { credentials: 'include' } });
+  });
+
+  it('lets the transform rewrite the url', () => {
+    const rewritten = 'https://proxy.example.com/data.json';
+    const transform: RequestTransform = () => ({ url: rewritten });
+    expect(resolveRequest(URL, 'metadata', transform)).toEqual({ url: rewritten, init: {} });
+  });
+
+  it('produces an unset RequestInit when the transform changes nothing about the request', () => {
+    const transform: RequestTransform = () => ({});
+    expect(resolveRequest(URL, 'metadata', transform)).toEqual({ url: URL, init: {} });
+  });
+
+  it('tells the transform what kind of request this is', () => {
+    const seen: string[] = [];
+    const transform: RequestTransform = (_url, resourceType) => {
+      seen.push(resourceType);
+      return undefined;
+    };
+
+    resolveRequest(URL, 'tile', transform);
+    expect(seen).toEqual(['tile']);
+  });
+});
+
+describe('ourResourceType', () => {
+  it('treats a MapLibre Tile request as ours', () => {
+    expect(ourResourceType('Tile' as ResourceType)).toEqual('tile');
+  });
+
+  it.each(['Style', 'Source', 'Glyphs', 'SpriteImage', 'SpriteJSON', 'Image', 'Unknown', undefined])(
+    'treats a MapLibre %s request as metadata, same as everything a Resource fetches for itself',
+    maplibreType => {
+      expect(ourResourceType(maplibreType as ResourceType | undefined)).toEqual('metadata');
+    },
+  );
+});
+
+describe('toMapLibreRequest', () => {
+  it('returns undefined - leaving the request untouched - when there is nothing to apply', () => {
+    expect(toMapLibreRequest(undefined, URL)).toBeUndefined();
+  });
+
+  it('defaults the url back to the original when the transform did not set one', () => {
+    expect(toMapLibreRequest({ headers: { 'X-Foo': 'bar' } }, URL)).toEqual({ url: URL, headers: { 'X-Foo': 'bar' }, credentials: undefined });
+  });
+
+  it('passes through a rewritten url', () => {
+    const rewritten = 'https://proxy.example.com/data.json';
+    expect(toMapLibreRequest({ url: rewritten }, URL)).toMatchObject({ url: rewritten });
+  });
+
+  it("drops 'omit' credentials, which MapLibre's own RequestParameters doesn't accept", () => {
+    expect(toMapLibreRequest({ credentials: 'omit' }, URL)?.credentials).toBeUndefined();
+  });
+
+  it.each(['include', 'same-origin'] as const)('passes through %s credentials', credentials => {
+    expect(toMapLibreRequest({ credentials }, URL)?.credentials).toEqual(credentials);
+  });
+});

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,0 +1,63 @@
+import type { RequestParameters, ResourceType } from 'maplibre-gl';
+
+// Distinguishes a metadata request - a JSON/XML document describing a resource - from a tile
+// request - the pixels or vectors of one map tile - so a transform can treat them differently,
+// e.g. attaching an auth header only where a server actually requires one.
+export type RequestResourceType = 'metadata' | 'tile';
+
+// What a RequestTransform can change about a request. Deliberately a subset of MapLibre's own
+// RequestParameters, so the same value can drive both a plain fetch() and, once adapted (see
+// toMapLibreRequest), MapLibre's own transformRequest option.
+export type TransformedRequest = {
+  url?: string;
+  headers?: Record<string, string>;
+  credentials?: RequestCredentials;
+};
+
+/**
+ * Given a URL, decide how the request for it should actually be made - e.g. attaching an
+ * Authorization header, or opting into cookies via `credentials: 'include'`, for a resource that
+ * needs authorization. Returning undefined leaves the request as-is.
+ *
+ * Mirrors MapLibre's own transformRequest, so one function can drive both: a Resource's own
+ * fetches, and - once its previewer attaches to a map - MapLibre's own tile and style requests.
+ * Synchronous, unlike MapLibre's: it has to run inline as the user pans and zooms, so a token or
+ * other credential it needs should already be in hand by the time it's given to a Resource,
+ * rather than fetched on demand here.
+ *
+ * A transform that attaches credentials should still check the URL - MapLibre calls the same
+ * function for a basemap's own style, glyphs and sprites, which are a different, unrelated origin.
+ */
+export type RequestTransform = (url: string, resourceType: RequestResourceType) => TransformedRequest | undefined;
+
+// Apply a RequestTransform, if there is one, producing what fetch() (or fetchOrThrow()) need.
+export function resolveRequest(url: string, resourceType: RequestResourceType, transform?: RequestTransform): { url: string; init?: RequestInit } {
+  const transformed = transform?.(url, resourceType);
+  if (!transformed) return { url };
+
+  const init: RequestInit = {};
+  if (transformed.headers) init.headers = transformed.headers;
+  if (transformed.credentials) init.credentials = transformed.credentials;
+  return { url: transformed.url ?? url, init };
+}
+
+// MapLibre's own request types, reduced to ours. Only 'Tile' is pixel/vector tile data;
+// everything else it asks about - Style, Source, Glyphs, Sprite*, Image - is a document, same as
+// the metadata a Resource fetches for itself.
+export function ourResourceType(maplibreType?: ResourceType): RequestResourceType {
+  return maplibreType === 'Tile' ? 'tile' : 'metadata';
+}
+
+// Adapt a RequestTransform's result into the shape MapLibre's transformRequest option wants. Used
+// by ogm-map, which applies the same transform a previewer's resource uses for its own requests to
+// every request MapLibre makes on its own - see MapPreviewer.requestTransform.
+export function toMapLibreRequest(transformed: TransformedRequest | undefined, url: string): RequestParameters | undefined {
+  if (!transformed) return undefined;
+
+  return {
+    url: transformed.url ?? url,
+    headers: transformed.headers,
+    // MapLibre doesn't accept 'omit' - it's the default, so there's nothing to pass through for it.
+    credentials: transformed.credentials === 'omit' ? undefined : transformed.credentials,
+  };
+}

--- a/src/lib/resources/esri-feature-layer.ts
+++ b/src/lib/resources/esri-feature-layer.ts
@@ -4,6 +4,7 @@ import type { LngLatBoundsLike } from 'maplibre-gl';
 import GeoJsonResource from './geojson';
 import type { ResourceKind } from './resource';
 import { esriExtentToBounds, esriQueryFeaturesToGeoJSON, fetchEsriJson, type EsriMetadata, type EsriQueryFeature } from '../esri';
+import type { RequestTransform } from '../request';
 
 // How many features to ask for at once when the service doesn't say. ArcGIS caps this itself, and
 // reports its own cap, but a layer description can leave the number out.
@@ -35,8 +36,8 @@ export default class EsriFeatureLayerResource extends GeoJsonResource {
   // Memoized features, assembled from however many pages it took to read them
   private featureCollection: GeoJSON.FeatureCollection;
 
-  constructor(id: string, url: string, bounds?: LngLatBoundsLike) {
-    super(id, url, bounds);
+  constructor(id: string, url: string, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
+    super(id, url, bounds, requestTransform);
     this.layerUrl = url.replace(/\/+$/, '');
   }
 
@@ -97,7 +98,7 @@ export default class EsriFeatureLayerResource extends GeoJsonResource {
 
   // Fetch and memoize the layer description
   protected async getMetadata(): Promise<EsriMetadata> {
-    if (!this.metadata) this.metadata = await fetchEsriJson(this.layerUrl);
+    if (!this.metadata) this.metadata = await fetchEsriJson(this.layerUrl, {}, this.requestTransform);
     return this.metadata;
   }
 
@@ -105,18 +106,22 @@ export default class EsriFeatureLayerResource extends GeoJsonResource {
   private async getPage(offset: number, pageSize: number) {
     const geojson = await this.supportsGeoJson();
 
-    const response = await fetchEsriJson<EsriQueryResponse>(`${this.layerUrl}/query`, {
-      where: '1=1',
-      outFields: '*',
-      returnGeometry: 'true',
+    const response = await fetchEsriJson<EsriQueryResponse>(
+      `${this.layerUrl}/query`,
+      {
+        where: '1=1',
+        outFields: '*',
+        returnGeometry: 'true',
 
-      // MapLibre sources are always in degrees, so have the service reproject rather than doing it
-      // ourselves - it knows the layer's own coordinate system, whatever it happens to be
-      outSR: '4326',
-      resultOffset: String(offset),
-      resultRecordCount: String(pageSize),
-      f: geojson ? 'geojson' : 'json',
-    });
+        // MapLibre sources are always in degrees, so have the service reproject rather than doing it
+        // ourselves - it knows the layer's own coordinate system, whatever it happens to be
+        outSR: '4326',
+        resultOffset: String(offset),
+        resultRecordCount: String(pageSize),
+        f: geojson ? 'geojson' : 'json',
+      },
+      this.requestTransform,
+    );
 
     // The flag appears at the top level of an Esri JSON response and in either place in a GeoJSON
     // one, depending on the ArcGIS version

--- a/src/lib/resources/esri-image-map-layer.ts
+++ b/src/lib/resources/esri-image-map-layer.ts
@@ -39,16 +39,20 @@ export default class EsriImageMapLayerResource extends EsriResource {
   async inspect(window: PixelWindow): Promise<GeoJSON.Feature[]> {
     const { x, y } = pixelWindowCenter(window);
 
-    const result = await fetchEsriJson<EsriPixelIdentifyResult>(`${this.serviceUrl}/identify`, {
-      geometry: JSON.stringify({ x, y, spatialReference: { wkid: 3857 } }),
-      geometryType: 'esriGeometryPoint',
+    const result = await fetchEsriJson<EsriPixelIdentifyResult>(
+      `${this.serviceUrl}/identify`,
+      {
+        geometry: JSON.stringify({ x, y, spatialReference: { wkid: 3857 } }),
+        geometryType: 'esriGeometryPoint',
 
-      // The geometry would just be the point we asked about, and listing every source image that
-      // went into the mosaic is a slow question to ask for a popup
-      returnGeometry: 'false',
-      returnCatalogItems: 'false',
-      f: 'json',
-    });
+        // The geometry would just be the point we asked about, and listing every source image that
+        // went into the mosaic is a slow question to ask for a popup
+        returnGeometry: 'false',
+        returnCatalogItems: 'false',
+        f: 'json',
+      },
+      this.requestTransform,
+    );
 
     const { value } = result;
     if (value === undefined || value === null || value === '' || value === NO_DATA) return [];

--- a/src/lib/resources/esri-map-server.ts
+++ b/src/lib/resources/esri-map-server.ts
@@ -18,7 +18,7 @@ export default abstract class EsriMapServerResource extends EsriResource {
 
   // Ask the service which features it drew at the middle of the window
   async inspect(window: PixelWindow): Promise<GeoJSON.Feature[]> {
-    const response = await fetchEsriJson<{ results?: EsriIdentifyResult[] }>(`${this.serviceUrl}/identify`, this.identifyParams(window));
+    const response = await fetchEsriJson<{ results?: EsriIdentifyResult[] }>(`${this.serviceUrl}/identify`, this.identifyParams(window), this.requestTransform);
     return esriIdentifyResultsToFeatures(response.results);
   }
 

--- a/src/lib/resources/esri.ts
+++ b/src/lib/resources/esri.ts
@@ -3,6 +3,7 @@ import type { LngLatBoundsLike } from 'maplibre-gl';
 import RasterResource from './raster';
 import { esriExtentToBounds, fetchEsriJson, splitEsriLayerUrl, type EsriMetadata } from '../esri';
 import type { PixelWindow } from '../geometry';
+import type { RequestTransform } from '../request';
 
 // ArcGIS draws an export image at whatever size we ask for, so this is just the size of the tiles
 // MapLibre stitches them into. 256 keeps each request cheap enough to redraw while panning.
@@ -32,8 +33,8 @@ export default abstract class EsriResource extends RasterResource {
   // Memoized service description, fetched from the REST endpoint
   private metadata: EsriMetadata;
 
-  constructor(id: string, url: string, bounds?: LngLatBoundsLike) {
-    super(id, url, bounds);
+  constructor(id: string, url: string, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
+    super(id, url, bounds, requestTransform);
     const { serviceUrl, layerId } = splitEsriLayerUrl(url);
     this.serviceUrl = serviceUrl;
     this.layerId = layerId;
@@ -76,7 +77,7 @@ export default abstract class EsriResource extends RasterResource {
 
   // Fetch and memoize the service description
   protected async getMetadata(): Promise<EsriMetadata> {
-    if (!this.metadata) this.metadata = await fetchEsriJson(this.serviceUrl);
+    if (!this.metadata) this.metadata = await fetchEsriJson(this.serviceUrl, {}, this.requestTransform);
     return this.metadata;
   }
 

--- a/src/lib/resources/factory.test.ts
+++ b/src/lib/resources/factory.test.ts
@@ -108,4 +108,32 @@ describe('resourcesFor', () => {
       expect(await resource.getBounds()).toBeUndefined();
     });
   });
+
+  // Threaded to every resource kind the same way bounds is; each resource's own tests cover what
+  // it does with it, so one representative of each constructor shape is enough here.
+  describe('requestTransform', () => {
+    const transform = () => undefined;
+
+    it('hands a plain resource its transform', () => {
+      const reference = { 'http://geojson.org/geojson-spec.html': 'https://example.com/data.json' };
+      const [resource] = resourcesFor(buildRecord(reference), transform);
+
+      expect(resource.requestTransform).toBe(transform);
+    });
+
+    it('hands a WxS resource its transform', () => {
+      const reference = { 'http://www.opengis.net/def/serviceType/ogc/wms': 'https://example.com/geoserver/wms' };
+      const record = buildRecord(reference, { gbl_wxsIdentifier_s: 's7sq63' });
+      const [resource] = resourcesFor(record, transform);
+
+      expect(resource.requestTransform).toBe(transform);
+    });
+
+    it('leaves it undefined when the caller does not pass one', () => {
+      const reference = { 'http://geojson.org/geojson-spec.html': 'https://example.com/data.json' };
+      const [resource] = resourcesFor(buildRecord(reference));
+
+      expect(resource.requestTransform).toBeUndefined();
+    });
+  });
 });

--- a/src/lib/resources/factory.ts
+++ b/src/lib/resources/factory.ts
@@ -1,4 +1,5 @@
 import type OgmRecord from '../record';
+import type { RequestTransform } from '../request';
 import type Resource from './resource';
 
 import CogResource from './cog';
@@ -21,28 +22,28 @@ import XyzResource from './xyz';
  * Every previewable resource a record's references point at, in the order they're offered to the
  * user - this list is the tab order.
  */
-export function resourcesFor(record: OgmRecord): Resource[] {
+export function resourcesFor(record: OgmRecord, requestTransform?: RequestTransform): Resource[] {
   const { id, references, wxsIdentifier } = record;
   const bounds = record.getBounds();
   const resources: Resource[] = [];
 
-  if (references.iiifImageUrl) resources.push(new IIIFResource(id, references.iiifImageUrl, bounds));
-  if (references.iiifManifestUrl) resources.push(new IIIFManifestResource(id, references.iiifManifestUrl, bounds));
-  if (references.pmtilesUrl) resources.push(new PMTilesResource(id, references.pmtilesUrl, bounds));
-  if (references.tilejsonUrl) resources.push(new TileJsonResource(id, references.tilejsonUrl, bounds));
-  if (references.indexMapUrl) resources.push(new OpenIndexMapResource(id, references.indexMapUrl, bounds));
-  if (references.geojsonUrl) resources.push(new GeoJsonResource(id, references.geojsonUrl, bounds));
-  if (references.esriFeatureLayerUrl) resources.push(new EsriFeatureLayerResource(id, references.esriFeatureLayerUrl, bounds));
-  if (references.cogUrl) resources.push(new CogResource(id, references.cogUrl, bounds));
-  if (references.tmsUrl) resources.push(new TmsResource(id, references.tmsUrl, bounds));
-  if (references.xyzUrl) resources.push(new XyzResource(id, references.xyzUrl, bounds));
-  if (references.esriTiledMapLayerUrl) resources.push(new EsriTiledMapLayerResource(id, references.esriTiledMapLayerUrl, bounds));
-  if (references.esriDynamicMapLayerUrl) resources.push(new EsriDynamicMapLayerResource(id, references.esriDynamicMapLayerUrl, bounds));
-  if (references.esriImageMapLayerUrl) resources.push(new EsriImageMapLayerResource(id, references.esriImageMapLayerUrl, bounds));
+  if (references.iiifImageUrl) resources.push(new IIIFResource(id, references.iiifImageUrl, bounds, requestTransform));
+  if (references.iiifManifestUrl) resources.push(new IIIFManifestResource(id, references.iiifManifestUrl, bounds, requestTransform));
+  if (references.pmtilesUrl) resources.push(new PMTilesResource(id, references.pmtilesUrl, bounds, requestTransform));
+  if (references.tilejsonUrl) resources.push(new TileJsonResource(id, references.tilejsonUrl, bounds, requestTransform));
+  if (references.indexMapUrl) resources.push(new OpenIndexMapResource(id, references.indexMapUrl, bounds, requestTransform));
+  if (references.geojsonUrl) resources.push(new GeoJsonResource(id, references.geojsonUrl, bounds, requestTransform));
+  if (references.esriFeatureLayerUrl) resources.push(new EsriFeatureLayerResource(id, references.esriFeatureLayerUrl, bounds, requestTransform));
+  if (references.cogUrl) resources.push(new CogResource(id, references.cogUrl, bounds, requestTransform));
+  if (references.tmsUrl) resources.push(new TmsResource(id, references.tmsUrl, bounds, requestTransform));
+  if (references.xyzUrl) resources.push(new XyzResource(id, references.xyzUrl, bounds, requestTransform));
+  if (references.esriTiledMapLayerUrl) resources.push(new EsriTiledMapLayerResource(id, references.esriTiledMapLayerUrl, bounds, requestTransform));
+  if (references.esriDynamicMapLayerUrl) resources.push(new EsriDynamicMapLayerResource(id, references.esriDynamicMapLayerUrl, bounds, requestTransform));
+  if (references.esriImageMapLayerUrl) resources.push(new EsriImageMapLayerResource(id, references.esriImageMapLayerUrl, bounds, requestTransform));
 
   // A WxS endpoint is a catalogue; without an identifier we don't know which layer of it to ask for
-  if (references.wmtsUrl && wxsIdentifier) resources.push(new WmtsResource(id, references.wmtsUrl, { layerIds: [wxsIdentifier] }, bounds));
-  if (references.wmsUrl && wxsIdentifier) resources.push(new WmsResource(id, references.wmsUrl, { layerIds: [wxsIdentifier] }, bounds));
+  if (references.wmtsUrl && wxsIdentifier) resources.push(new WmtsResource(id, references.wmtsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
+  if (references.wmsUrl && wxsIdentifier) resources.push(new WmsResource(id, references.wmsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
 
   return resources;
 }

--- a/src/lib/resources/geojson.ts
+++ b/src/lib/resources/geojson.ts
@@ -4,6 +4,7 @@ import type { LngLatBoundsLike } from 'maplibre-gl';
 import VectorResource from './vector';
 import type { ResourceKind } from './resource';
 import { fetchOrThrow } from '../errors';
+import { resolveRequest } from '../request';
 
 export default class GeoJsonResource extends VectorResource {
   readonly kind: ResourceKind = 'geojson';
@@ -14,7 +15,8 @@ export default class GeoJsonResource extends VectorResource {
   // Fetch and memoize data
   protected async getData() {
     if (!this.data) {
-      const resp = await fetchOrThrow(this.url);
+      const { url, init } = resolveRequest(this.url, 'metadata', this.requestTransform);
+      const resp = await fetchOrThrow(url, init);
       this.data = await resp.json();
     }
     return this.data;

--- a/src/lib/resources/iiif-manifest.test.ts
+++ b/src/lib/resources/iiif-manifest.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
 
 import IIIFManifestResource from './iiif-manifest';
+import type { RequestTransform } from '../request';
 
 const MANIFEST_URL = 'http://example.com/manifest.json';
 
 // A source always points at a manifest URL; the manifest itself is fetched lazily
-const createSource = () => new IIIFManifestResource('test-id', MANIFEST_URL);
+const createSource = (requestTransform?: RequestTransform) => new IIIFManifestResource('test-id', MANIFEST_URL, undefined, requestTransform);
 
 // A minimal IIIF v2 manifest with a single image
 const v2Manifest = {
@@ -119,6 +120,15 @@ describe('IIIFManifestResource', () => {
     it('should throw if the manifest does not match the IIIF spec', async () => {
       vi.spyOn(global, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify({ unexpected: 'structure' })));
       await expect(createSource().getIIIFImageUrls()).rejects.toThrow();
+    });
+
+    it('applies a requestTransform to the manifest fetch', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(new Response(JSON.stringify(v2Manifest)));
+      const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' }, credentials: 'include' });
+
+      await createSource(transform).getIIIFImageUrls();
+
+      expect(fetchSpy.mock.calls[0]).toEqual([MANIFEST_URL, { headers: { Authorization: 'Bearer token' }, credentials: 'include' }]);
     });
   });
 });

--- a/src/lib/resources/iiif-manifest.ts
+++ b/src/lib/resources/iiif-manifest.ts
@@ -4,6 +4,7 @@ import iiif2 from '@iiif/presentation-2';
 import IIIFResource from './iiif';
 import type { ResourceKind } from './resource';
 import { fetchOrThrow } from '../errors';
+import { resolveRequest } from '../request';
 
 // A manifest containing multiple IIIF image URLs for preview
 export default class IIIFManifestResource extends IIIFResource {
@@ -30,7 +31,8 @@ export default class IIIFManifestResource extends IIIFResource {
   // Attempt to fetch and parse the IIIF manifest, if any
   protected async fetchManifest(): Promise<iiif2.Manifest | iiif3.Manifest | undefined> {
     if (this.manifest) return this.manifest;
-    const response = await fetchOrThrow(this.url);
+    const { url, init } = resolveRequest(this.url, 'metadata', this.requestTransform);
+    const response = await fetchOrThrow(url, init);
     const manifest = await response.json();
     this.manifest = manifest;
     return manifest;

--- a/src/lib/resources/pmtiles.test.ts
+++ b/src/lib/resources/pmtiles.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
+import { Protocol } from 'pmtiles';
+
+import PMTilesResource from './pmtiles';
+import type { RequestTransform } from '../request';
+
+const URL = 'https://example.com/tiles.pmtiles';
+
+// The archive is private; reach in the way wms.test.ts already does for a protected method,
+// rather than widening the field just for this.
+const archiveOf = (resource: PMTilesResource) => (resource as any).archive;
+
+describe('PMTilesResource', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('has no custom headers or credentials without a transform', () => {
+    const source = archiveOf(new PMTilesResource('id', URL)).source;
+
+    expect(source.getKey()).toEqual(URL);
+    expect([...source.customHeaders.entries()]).toEqual([]);
+    expect(source.credentials).toBeUndefined();
+  });
+
+  it('carries headers from a transform into the archive source', () => {
+    const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' } });
+    const source = archiveOf(new PMTilesResource('id', URL, undefined, transform)).source;
+
+    expect(source.customHeaders.get('Authorization')).toEqual('Bearer token');
+  });
+
+  it('carries credentials from a transform into the archive source', () => {
+    const transform: RequestTransform = () => ({ credentials: 'include' });
+    const source = archiveOf(new PMTilesResource('id', URL, undefined, transform)).source;
+
+    expect(source.credentials).toEqual('include');
+  });
+
+  it("drops 'omit' credentials rather than passing them to FetchSource, which doesn't accept them", () => {
+    const transform: RequestTransform = () => ({ credentials: 'omit' });
+    const source = archiveOf(new PMTilesResource('id', URL, undefined, transform)).source;
+
+    expect(source.credentials).toBeUndefined();
+  });
+
+  it('asks the transform for a tile request, not a metadata one - the archive serves both from the same source', () => {
+    const seen: string[] = [];
+    const transform: RequestTransform = (_url, resourceType) => {
+      seen.push(resourceType);
+      return undefined;
+    };
+
+    new PMTilesResource('id', URL, undefined, transform);
+    expect(seen).toEqual(['tile']);
+  });
+
+  // The protocol handler looks archives up by the exact URL getMapLibreSourceUrl() embeds in the
+  // pmtiles:// source, so a rewritten URL would make this instance unreachable from a tile request.
+  it('keeps the plain resource url in the pmtiles:// source even when the transform rewrote it', () => {
+    const transform: RequestTransform = () => ({ url: 'https://proxy.example.com/tiles.pmtiles', headers: { Authorization: 'Bearer token' } });
+    const resource = new PMTilesResource('id', URL, undefined, transform);
+
+    expect(resource.getMapLibreSourceUrl()).toEqual(`pmtiles://${URL}`);
+    expect(archiveOf(resource).source.getKey()).toEqual(URL);
+  });
+
+  it('registers the archive with the shared protocol, so a tile request reuses it rather than opening a second, unauthenticated one', () => {
+    const addSpy = vi.spyOn(Protocol.prototype, 'add');
+    const resource = new PMTilesResource('id', URL);
+
+    expect(addSpy).toHaveBeenCalledWith(archiveOf(resource));
+  });
+});

--- a/src/lib/resources/pmtiles.ts
+++ b/src/lib/resources/pmtiles.ts
@@ -1,9 +1,10 @@
 // Adapted from https://github.com/protomaps/PMTiles/blob/main/app/src/tileset.ts
 
-import { PMTiles, TileType, Header } from 'pmtiles';
+import { FetchSource, PMTiles, Protocol, TileType, Header } from 'pmtiles';
+import maplibregl, { type LngLatBoundsLike } from 'maplibre-gl';
 
 import Resource, { type ResourceKind } from './resource';
-import { type LngLatBoundsLike } from 'maplibre-gl';
+import type { RequestTransform } from '../request';
 
 // A single vector layer in a PMTiles tileset
 interface VectorLayer {
@@ -15,6 +16,11 @@ interface Metadata {
   type?: string;
   vector_layers: VectorLayer[];
 }
+
+// Shared by every PMTiles archive on the page - a MapLibre protocol handler is registered once,
+// globally, for the 'pmtiles://' scheme, however many resources or maps use it.
+const protocol = new Protocol();
+maplibregl.addProtocol('pmtiles', protocol.tile);
 
 // Vector or raster tileset stored in a PMTiles archive at a URL
 export default class PMTilesResource extends Resource {
@@ -28,9 +34,21 @@ export default class PMTilesResource extends Resource {
   private header: Header;
 
   // Store a reference so we can open the archive for metadata inspection
-  constructor(id: string, url: string, bounds?: LngLatBoundsLike) {
-    super(id, url, bounds);
-    this.archive = new PMTiles(url);
+  constructor(id: string, url: string, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
+    super(id, url, bounds, requestTransform);
+
+    const transformed = requestTransform?.(url, 'tile');
+    const headers = transformed?.headers ? new Headers(transformed.headers) : undefined;
+    // A transform that rewrote the URL is ignored here: the protocol handler above looks archives
+    // up by the exact URL getMapLibreSourceUrl() embeds in the pmtiles:// source, so this instance
+    // has to be keyed by this.url to ever be found once a map asks for tiles from it.
+    const source = headers || transformed?.credentials ? new FetchSource(url, headers, credentialsFor(transformed?.credentials)) : url;
+    this.archive = new PMTiles(source);
+
+    // Registering unconditionally, not just for authenticated archives, means the protocol
+    // handler reuses this instance for tile reads instead of lazily opening its own second,
+    // unauthenticated PMTiles - sharing one header/tile cache either way.
+    protocol.add(this.archive);
   }
 
   label() {
@@ -106,4 +124,10 @@ export default class PMTilesResource extends Resource {
     if (await this.isVector()) return 'vector' as const;
     return 'raster' as const;
   }
+}
+
+// Narrow a RequestTransform's credentials to what FetchSource accepts. 'omit' is the default -
+// don't send cookies - so there's nothing for FetchSource to do differently for it.
+function credentialsFor(credentials?: RequestCredentials): 'same-origin' | 'include' | undefined {
+  return credentials === 'omit' ? undefined : credentials;
 }

--- a/src/lib/resources/resource.ts
+++ b/src/lib/resources/resource.ts
@@ -1,5 +1,7 @@
 import type { LngLatBoundsLike } from 'maplibre-gl';
 
+import { resolveRequest, type RequestTransform } from '../request';
+
 // Names the kind of data a resource holds. Previewers are chosen by matching on this string rather
 // than with `instanceof`: a class test only holds when both sides came from the same copy of the
 // module, and it forces every subclass to be tested ahead of its parent to be reachable at all.
@@ -34,11 +36,16 @@ export default abstract class Resource {
   // Unique ID for this resource
   id: string;
 
+  // Applied to every request this resource's own code makes and, once a previewer attaches it to
+  // a map, to MapLibre's own requests too - see MapPreviewer.requestTransform.
+  readonly requestTransform?: RequestTransform;
+
   // Store the source URL
-  constructor(id: string, url: string, bounds?: LngLatBoundsLike) {
+  constructor(id: string, url: string, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
     this.id = id;
     this.url = url;
     this.bounds = bounds;
+    this.requestTransform = requestTransform;
   }
 
   // Used to label the tabs for switching between previews, e.g.
@@ -49,7 +56,9 @@ export default abstract class Resource {
   // Check that the URL is valid and accessible
   async test() {
     try {
-      const response = await fetch(this.url, {
+      const { url, init } = resolveRequest(this.url, 'metadata', this.requestTransform);
+      const response = await fetch(url, {
+        ...init,
         method: 'HEAD',
         signal: AbortSignal.timeout(8000),
       });

--- a/src/lib/resources/tilejson.ts
+++ b/src/lib/resources/tilejson.ts
@@ -1,4 +1,5 @@
 import { fetchOrThrow } from '../errors';
+import { resolveRequest } from '../request';
 import MapResource from './map';
 import type { ResourceKind } from './resource';
 
@@ -29,7 +30,8 @@ export default class TileJsonResource extends MapResource {
   // Fetch and memoize metadata
   protected async getMetadata() {
     if (!this.metadata) {
-      const resp = await fetchOrThrow(this.url);
+      const { url, init } = resolveRequest(this.url, 'metadata', this.requestTransform);
+      const resp = await fetchOrThrow(url, init);
       this.metadata = await resp.json();
     }
     return this.metadata;

--- a/src/lib/resources/wms.test.ts
+++ b/src/lib/resources/wms.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment happy-dom */
-import { describe, it, expect } from '@stencil/vitest';
+import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
 import WmsResource from './wms';
+import type { RequestTransform } from '../request';
 
 // The GetMap and GetFeatureInfo URLs are built by protected methods, so expose them for testing.
 // A capabilities document is read in rather than fetched, so nothing here touches the network.
@@ -177,5 +178,29 @@ describe('WmsSource#getInfoFormat', () => {
     await source.url_for(options);
 
     expect(reads).toEqual(1);
+  });
+});
+
+describe('WmsSource#requestTransform', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('applies to the GetFeatureInfo request', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'));
+    const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' } });
+    const source = new WmsResource('s7st30', ENDPOINT, { layerIds: [], infoFormat: 'application/json' }, undefined, transform);
+
+    await source.inspect(options);
+
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('GetFeatureInfo'), { headers: { Authorization: 'Bearer token' } });
+  });
+
+  it('applies to the GetCapabilities request the format negotiation makes', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(capabilities(GEOSERVER_FORMATS)));
+    const transform: RequestTransform = () => ({ headers: { Authorization: 'Bearer token' } });
+    const source = new WmsResource('s7st30', ENDPOINT, { layerIds: [] }, undefined, transform);
+
+    await source.inspect(options);
+
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('GetCapabilities'), { headers: { Authorization: 'Bearer token' } });
   });
 });

--- a/src/lib/resources/wms.ts
+++ b/src/lib/resources/wms.ts
@@ -2,6 +2,7 @@ import { type LngLatBoundsLike } from 'maplibre-gl';
 import RasterResource from './raster';
 import type { ResourceKind } from './resource';
 import type { PixelWindow } from '../geometry';
+import { resolveRequest, type RequestTransform } from '../request';
 
 // Base params for WMS GetMap requests, which return raster tiles
 type WmsOptions = {
@@ -54,8 +55,8 @@ export default class WmsResource extends RasterResource {
   // Memoized metadata via GetCapabilities request
   private metadata: Document;
 
-  constructor(id: string, url: string, options: WmsOptions, bounds?: LngLatBoundsLike) {
-    super(id, url, bounds);
+  constructor(id: string, url: string, options: WmsOptions, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
+    super(id, url, bounds, requestTransform);
     this.options = { ...defaultWmsOptions, ...options };
 
     // Assume we're using one layer with the given ID if no layer IDs are provided
@@ -71,7 +72,8 @@ export default class WmsResource extends RasterResource {
   // Fetch and memoize WMS GetCapabilities XML document
   protected async getMetadata() {
     if (!this.metadata) {
-      const resp = await fetch(this.capabilitiesUrl);
+      const { url, init } = resolveRequest(this.capabilitiesUrl, 'metadata', this.requestTransform);
+      const resp = await fetch(url, init);
       const text = await resp.text();
       this.metadata = new DOMParser().parseFromString(text, 'application/xml');
     }
@@ -92,7 +94,8 @@ export default class WmsResource extends RasterResource {
   }
 
   async inspect(options: GetFeatureInfoOptions) {
-    return await fetch(await this.inspectUrl(options));
+    const { url, init } = resolveRequest(await this.inspectUrl(options), 'metadata', this.requestTransform);
+    return await fetch(url, init);
   }
 
   // The info format to ask GetFeatureInfo for. A server rejects the whole request over a format it

--- a/src/lib/resources/wmts.ts
+++ b/src/lib/resources/wmts.ts
@@ -1,6 +1,7 @@
 import { LngLatBounds, type LngLatBoundsLike, type RasterSourceSpecification } from 'maplibre-gl';
 import RasterResource from './raster';
 import type { ResourceKind } from './resource';
+import { resolveRequest, type RequestTransform } from '../request';
 
 export type WmtsOptions = {
   layerIds: string[];
@@ -76,8 +77,8 @@ export default class WmtsResource extends RasterResource {
   // Memoized metadata via GetCapabilities request
   private metadata: Document;
 
-  constructor(id: string, url: string, options: WmtsOptions, bounds?: LngLatBoundsLike) {
-    super(id, url, bounds);
+  constructor(id: string, url: string, options: WmtsOptions, bounds?: LngLatBoundsLike, requestTransform?: RequestTransform) {
+    super(id, url, bounds, requestTransform);
     this.options = options;
 
     // Assume we're using one layer with the given ID if no layer IDs are provided
@@ -93,7 +94,8 @@ export default class WmtsResource extends RasterResource {
   // Fetch and memoize WMTS GetCapabilities XML document
   protected async getMetadata() {
     if (!this.metadata) {
-      const resp = await fetch(this.url);
+      const { url, init } = resolveRequest(this.url, 'metadata', this.requestTransform);
+      const resp = await fetch(url, init);
       const text = await resp.text();
       this.metadata = new DOMParser().parseFromString(text, 'application/xml');
     }


### PR DESCRIPTION
## Summary

U4 from the sul-embed migration plan: a hook so a consumer can attach an `Authorization` header, or opt into credentialed (cookie-carrying) requests, for content that needs authorization - the last upstream primitive sul-embed's own restricted-content flow will need.

- New `RequestTransform = (url, resourceType: 'metadata' | 'tile') => TransformedRequest | undefined`, in `src/lib/request.ts`. Deliberately **synchronous** - it runs inline on every request, including ones MapLibre fires directly as the user pans - and mirrors MapLibre's own `transformRequest` closely enough that `toMapLibreRequest()`/`ourResourceType()` adapt one into the other.
- Threaded through the constructor of every `Resource` (not a mutable setter - matches how a real auth flow already has to reconstruct a fresh Resource once credentials are known), `resourcesFor(record, requestTransform?)`, and a new `requestTransform` DOM property on `<ogm-viewer>` (same pattern as `previewer` on `<ogm-preview>`).
- Reaches all seven request sites the plan identified: the five `fetchOrThrow` call sites, the three bare-`fetch` call sites (`Resource.test()`, WMS, WMTS), and - new - `ogm-map`'s `Map` constructor, which had **no** `transformRequest` at all before this, so every MapLibre-issued tile/style/glyph/sprite request went untransformed.
- **PMTiles**: relocated the module-scope `Protocol`/`addProtocol('pmtiles', …)` registration out of `ogm-map.tsx` into `pmtiles.ts`, next to the resource that needs it. `PMTilesResource` now builds a `FetchSource(url, headers, credentials)` when the transform yields either, and registers it with the shared protocol **unconditionally** - which also fixes a pre-existing inefficiency where the protocol's lazy tile-fetch path opened its own second, uncoordinated `PMTiles` instance for the same URL. One real constraint: the protocol keys archives by the exact URL embedded in the `pmtiles://` source, so a transform that rewrites the URL is honored for headers/credentials but ignored for the URL itself.
- **COG**: `@geomatico/maplibre-cog-protocol` has no per-URL auth hook, only a page-global `setRequestHeaders(headers)`. Wired it in (reset on every `createSources()` call so one COG's headers can't leak into another's by default), but this is a real, documented limitation - two authenticated COGs active at once can't both be right. `CogPreviewer` is already slated for replacement by the deck.gl path (U5+U6) for the non-Web-Mercator case that motivates it, so didn't invest further here.

## Test plan

- [x] `npm run lint` - clean
- [x] `npm test` - 493 passed, 1 todo, exit 0
- [x] New `lib/request.test.ts`, a `Previewer#requestTransform` test, a `PMTilesResource` test (spies on `Protocol.prototype.add` and inspects the real `FetchSource`, no module mocking - kept consistent with the rest of the suite), and transform-reaches-`fetch` cases added to `wms.test.ts` and `iiif-manifest.test.ts`
- [x] Verified live: WMS raster tiles, PMTiles vector tiles (206 Range responses from Princeton's archive), and a public COG (206 Range responses) all rendered with zero console errors and zero unexpected failed requests after relocating the PMTiles protocol registration and adding `transformRequest`