### PR TITLE
Let a popup's selection reach only the map it belongs to

### DIFF
--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, h, vi, beforeEach, afterEach } from '@stencil/vitest';
+import type { MapGeoJSONFeature } from 'maplibre-gl';
+
+// Render with Stencil's low-level render rather than @stencil/vitest's `render` wrapper, for the same
+// reason ogm-preview's tests do: the wrapper re-throws lifecycle errors, and componentDidLoad throws
+// here when MapLibre can't get a WebGL context. That failure is useful - it leaves the component
+// mounted and listening with no map of its own, which is the state a freshly mounted <ogm-map> is in
+// for real until componentDidLoad has run, and the state a selection used to crash it in.
+import { render as stencilRender } from '@stencil/core';
+
+const feature = {
+  type: 'Feature',
+  id: 'sheet.1',
+  source: 'a-preview',
+  sourceLayer: undefined,
+  geometry: { type: 'Polygon', coordinates: [] },
+  properties: { label: 'SB 24' },
+} as unknown as MapGeoJSONFeature;
+
+// Enough of a MapLibre map for a selection to be drawn on, and to be taken down afterwards
+const fakeMap = () => ({ setFeatureState: vi.fn(), remove: vi.fn() });
+
+const containers: HTMLElement[] = [];
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+// Stencil catches what a host listener throws and reports it through console.error rather than
+// letting it reach the page, so that is what a crash in one looks like from here.
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  containers.splice(0).forEach(container => container.remove());
+  consoleError.mockRestore();
+});
+
+const renderMap = async () => {
+  const container = document.createElement('div');
+  containers.push(container);
+  document.body.appendChild(container);
+  await stencilRender(<ogm-map></ogm-map>, container);
+  const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
+  await el.componentOnReady?.();
+  // Anything componentDidLoad reported on the way up is the WebGL gap, not what's under test
+  consoleError.mockClear();
+  return { container, el };
+};
+
+const selection = () => new CustomEvent('featureSelected', { detail: feature, bubbles: true, composed: true });
+
+// MapLibre builds the popup inside the map's container, so a selection made in one starts inside the
+// map's shadow root and crosses out of it. Standing in for the popup rather than opening one, since
+// there is no map here to open it on.
+const selectInOwnPopup = (el: HTMLElement) => {
+  const popup = document.createElement('div');
+  (el.shadowRoot as ShadowRoot).appendChild(popup);
+  popup.dispatchEvent(selection());
+};
+
+describe('ogm-map', () => {
+  it('highlights a feature selected in its own popup', async () => {
+    const { el } = await renderMap();
+    const map = fakeMap();
+    Object.assign(el, { map });
+
+    selectInOwnPopup(el);
+
+    expect(map.setFeatureState).toHaveBeenCalledWith({ source: 'a-preview', id: 'sheet.1', sourceLayer: undefined }, { selected: true });
+  });
+
+  // Every preview of a record has a map of its own, and they all sit in the same document
+  it('leaves a selection made in another map’s popup alone', async () => {
+    const { el } = await renderMap();
+    const map = fakeMap();
+    Object.assign(el, { map });
+
+    document.body.dispatchEvent(selection());
+
+    expect(map.setFeatureState).not.toHaveBeenCalled();
+  });
+
+  it('ignores a feature selection before it has a map to draw it on', async () => {
+    const { el } = await renderMap();
+
+    selectInOwnPopup(el);
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  // The popup is built by hand rather than rendered, so it outlives the component's own markup
+  it('ignores a feature selection after it has been removed from the DOM', async () => {
+    const { container, el } = await renderMap();
+    container.removeChild(el);
+
+    selectInOwnPopup(el);
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -99,8 +99,12 @@ export class OgmMap {
     this.attributesEl.features = [];
   }
 
-  // Clean up the map to prevent warnings/errors when removed from the DOM
+  // Clean up the map to prevent warnings/errors when removed from the DOM. The popup comes down
+  // first: MapLibre closes it for us on the way out, and closing it ends an inspection, which reaches
+  // back into the map to clear the highlight and hands the features back to whoever is listening. All
+  // of that wants a map that is still there, so it happens before the map goes rather than during it.
   disconnectedCallback() {
+    this.destroyPopup();
     if (this.map) this.map.remove();
   }
 
@@ -387,9 +391,14 @@ export class OgmMap {
     };
   }
 
-  // Listen to selection events from the popup and highlight the selected feature
-  @Listen('featureSelected', { target: 'body' })
+  // Listen to selection events from the popup and highlight the selected feature. Ours to hear
+  // because MapLibre builds the popup inside the map's own container, which is in our shadow root,
+  // so the event passes through us on its way out - and through no other map. Listened for on the
+  // document instead, as it once was, every <ogm-map> on the page would answer for every popup: a
+  // record change replaces them all at once, and the ones that had not built their maps yet threw.
+  @Listen('featureSelected')
   handleFeatureSelected(event: CustomEvent<maplibregl.MapGeoJSONFeature>) {
+    if (!this.map) return;
     this.selectFeature(event.detail);
   }
 
@@ -400,8 +409,7 @@ export class OgmMap {
       return;
     }
     if (!this.selectedFeature) return;
-    const { source, id, sourceLayer } = this.selectedFeature;
-    this.map.setFeatureState({ source, id, sourceLayer }, { selected: false });
+    this.setFeatureState(this.selectedFeature, { selected: false });
     this.selectedFeature = undefined;
   }
 
@@ -415,22 +423,29 @@ export class OgmMap {
     }
     this.clearFeatureSelection();
     this.selectedFeature = feature;
-    this.map.setFeatureState({ source: feature.source, id: feature.id, sourceLayer: feature.sourceLayer }, { selected: true });
+    this.setFeatureState(feature, { selected: true });
   }
 
   // Set styling of a single feature to hovered state
   protected hoverFeature(feature: maplibregl.MapGeoJSONFeature) {
     this.clearHoveredFeature();
     this.hoveredFeature = feature;
-    this.map.setFeatureState({ source: feature.source, id: feature.id, sourceLayer: feature.sourceLayer }, { hover: true });
+    this.setFeatureState(feature, { hover: true });
   }
 
   // Clear the hovered feature state
   protected clearHoveredFeature() {
-    if (this.hoveredFeature) {
-      this.map.setFeatureState({ source: this.hoveredFeature.source, id: this.hoveredFeature.id, sourceLayer: this.hoveredFeature.sourceLayer }, { hover: false });
-      this.hoveredFeature = undefined;
-    }
+    if (!this.hoveredFeature) return;
+    this.setFeatureState(this.hoveredFeature, { hover: false });
+    this.hoveredFeature = undefined;
+  }
+
+  // Restyle one of the preview's own features. Every path into here starts outside the map - a
+  // pointer event, a layer control, the popup - and the map is not there for all of that time: it
+  // is built in componentDidLoad and taken down in disconnectedCallback. Nothing to restyle then.
+  private setFeatureState(feature: maplibregl.MapGeoJSONFeature, state: { hover?: boolean; selected?: boolean }) {
+    if (!this.map) return;
+    this.map.setFeatureState({ source: feature.source, id: feature.id, sourceLayer: feature.sourceLayer }, state);
   }
 
   // Create a new popup and set its content and location

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -25,6 +25,7 @@ if (!HTMLElement.prototype.attachInternals) {
 import './dist/components/ogm-alerts.js';
 import './dist/components/ogm-attributes.js';
 import './dist/components/ogm-layers.js';
+import './dist/components/ogm-map.js';
 import './dist/components/ogm-menubar.js';
 import './dist/components/ogm-metadata.js';
 import './dist/components/ogm-preview.js';


### PR DESCRIPTION
Opening an inspection popup on a map and then loading a different record threw one `TypeError: Cannot read properties of undefined (reading 'setFeatureState')` from `ogm-map`. Harmless today — the map is going away regardless — but it is a real unguarded teardown race, and it pollutes the console.

## Cause

`featureSelected` was listened for with `@Listen('featureSelected', { target: 'body' })`, so **every** `<ogm-map>` on the page answered for **every** popup. A record change replaces every preview at once, and tracing one in the demo confirmed the shape:

```
map.disconnectedCallback { id: 2 }   ← Peatland's three maps
map.disconnectedCallback { id: 3 }
map.disconnectedCallback { id: 1 }
map.componentDidLoad     { id: 4 }   ← Neighborhoods' replacement, only now building its map
```

The panels are not reused — all three maps come down, and the replacement is connected and listening well before `componentDidLoad` has built its map. A selection handed back as one map went away landed on another whose `this.map` was still `undefined`.

## Fix

The popup is **not** outside our subtree, which is what the `body` binding seems to have assumed. MapLibre creates it with `DOM.create('div', 'maplibregl-popup', this._map.getContainer())`, and our container is `#map` inside `ogm-map`'s shadow root; Stencil's events are `composed`, so it passes through the host on its way out.

- **`@Listen('featureSelected')`** — scoped to the host. Reaches the map that owns the popup and no other.
- **One guarded `setFeatureState`** — the four call sites now go through a single private method that checks there is a map, for the paths that don't come through the popup (`clearHoveredFeature` is reachable from `commitLayerState`, driven by layer-control events). It also drops the repeated destructuring.
- **`disconnectedCallback` closes the popup first** — ending an inspection clears the highlight and hands the features back, so it wants a map that is still there.

Scoping also fixes a quieter wrong: with three map previews open, a click in one tab was asking the other two to restyle a feature of a source they don't have. MapLibre answers that with an error event rather than a throw, and `handleMapError` filters it out by source id, so nobody ever saw it.

## Verification

Verified against the running app, with a real `<ogm-attributes>` placed where MapLibre puts the popup — inside map 0's `#map` container — and paged with a real click, recording `setFeatureState` on all three maps:

```
map 0 (owns the popup): [{ source: 'probe-source', id: 2, state: { selected: true } }]
map 1:                  []
map 2:                  []
```

Both halves: the owning map still gets the selection, the siblings no longer do.

`src/components/ogm-map/ogm-map.test.tsx` is new. `componentDidLoad` throws in the test DOM for want of WebGL, which leaves exactly the mounted-but-mapless component a selection used to crash — the same trick `ogm-preview`'s tests already lean on. Four cases:

| test | fails without |
|---|---|
| highlights a feature selected in its own popup | (guards the scoping change against silently breaking highlighting) |
| leaves a selection made in another map's popup alone | the host scoping |
| ignores a feature selection before it has a map to draw it on | the `setFeatureState` guard |
| ignores a feature selection after it has been removed from the DOM | the `setFeatureState` guard |

I re-ran each with the fix reverted to confirm they actually catch it; the crash regressions report the exact reported `TypeError`. `vitest-setup.ts` now registers `ogm-map`.

`npx stencil-test`: 587 passed. `npm run lint`: clean.

## For the reviewer

- **I could not complete the original click-through end to end.** My environment's TLS to the data hosts degraded partway through (`geowebservices.stanford.edu` → `ERR_CERT_DATE_INVALID`, other fetches stalling), so the index-map polygons never drew and there was nothing to click. I reproduced the console error before the fix and verified the event path after it by the probe above, but a manual pass on the original steps is still worth doing.
- **`featureSelected` still bubbles out to the document.** I did not add `stopPropagation`, since embedders may rely on hearing it. Easy to add if that is not a concern.
- The reported cause named `@Watch('features')` resetting `currentIndex` as the emitter. That path can't actually emit: the watcher sets `currentIndex = 0` *after* `features` is already `[]`, so `this.features[0]` is `undefined` and the emit is skipped. The emits that reach a map are the ones carrying a live feature — paging, and the popup handoff during teardown. The fix covers the exposure either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)