### PR TITLE
Draw where a record is when its data can't be drawn

### DIFF
--- a/assets/records/download-only.json
+++ b/assets/records/download-only.json
@@ -1,0 +1,14 @@
+{
+  "id": "stanford-download-only",
+  "dct_title_s": "Nepal Administrative Boundaries, 2011 (Download Only)",
+  "dct_description_sm": [
+    "A record with nothing this viewer can draw: its only reference is a download. The map falls back to where the record says it is, so a reader still learns what part of the world it covers. Its locn_geometry is used in preference to its dcat_bbox - compare the shape drawn against the envelope in the metadata, which claims a good deal of India and Tibet as well."
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "gbl_resourceClass_sm": ["Datasets"],
+  "dcat_bbox": "ENVELOPE(80.05, 88.2, 30.45, 26.35)",
+  "locn_geometry": "POLYGON((80.05 28.8, 81.0 30.2, 82.5 30.05, 84.2 29.3, 85.8 28.3, 87.1 27.85, 88.2 27.9, 88.15 26.85, 86.7 26.45, 85.0 26.75, 83.3 27.35, 81.6 28.0, 80.05 28.8))",
+  "dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://example.com/nepal-boundaries.zip\"}",
+  "gbl_mdVersion_s": "Aardvark"
+}

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -322,6 +322,13 @@ export class OgmMap {
 
   // Use the crosshair cursor if there's something to inspect
   protected handleHover(event: maplibregl.MapMouseEvent) {
+    // A preview with nothing to answer with never offers. Checked before the raster case below, which
+    // is a question about how to ask rather than whether to.
+    if (this.previewer && !this.previewer.inspectable) {
+      this.map.getCanvas().style.cursor = '';
+      return;
+    }
+
     // A server-drawn preview has no client-side features to test the cursor against, so offer to
     // inspect anywhere as long as the server will answer at all - and as long as any of it is still
     // drawn, since a hidden layer has nothing to be asked about
@@ -367,6 +374,10 @@ export class OgmMap {
   // Delegate to server for raster inspection, or query directly for vector
   protected async handleInspection(point: maplibregl.Point): Promise<maplibregl.MapGeoJSONFeature[]> {
     if (!this.previewer) return [];
+
+    // Drawn, but not about anything: a location has one shape and no properties behind it, so a
+    // query would return a feature and the popup would open on an empty table.
+    if (!this.previewer.inspectable) return [];
 
     if (this.previewer instanceof InspectableRasterPreviewer) {
       if (!this.previewer.canInspect || !this.previewer.anyLayerVisible) return [];

--- a/src/index.html
+++ b/src/index.html
@@ -215,6 +215,7 @@
           NY & NJ (IIIF Image)
         </button>
         <button data-record-url="./build/assets/records/georeferenced-manifest.json">NW Europe (Georeferenced IIIF Manifest, Image + Map)</button>
+        <button data-record-url="./build/assets/records/download-only.json">Nepal (Nothing Previewable, Location Only)</button>
       </div>
       <div class="record-input">
         <label for="recordUrl">Enter an OpenGeoMetadata record URL:</label>

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ export { default as EsriImageMapLayerResource } from './lib/resources/esri-image
 export { default as EsriTiledMapLayerResource } from './lib/resources/esri-tiled-map-layer';
 export { default as GeoJsonResource } from './lib/resources/geojson';
 export { default as IIIFManifestResource } from './lib/resources/iiif-manifest';
+// Where a record is, when what it holds can't be drawn - the one resource built from a shape rather
+// than a URL. Reach for it directly to hold a place on the map while authentication is pending.
+export { default as LocationResource } from './lib/resources/location';
 export { default as OpenIndexMapResource } from './lib/resources/openindexmap';
 export { default as PMTilesResource } from './lib/resources/pmtiles';
 export { default as TileJsonResource } from './lib/resources/tilejson';
@@ -79,6 +82,7 @@ export { default as EsriImageMapLayerPreviewer } from './lib/previewers/esri-ima
 export { default as EsriTiledMapLayerPreviewer } from './lib/previewers/esri-tiled-map-layer';
 export { default as GeoJsonPreviewer, type AddGeoJsonSourceObject } from './lib/previewers/geojson';
 export { default as ImagePreviewer } from './lib/previewers/image';
+export { default as LocationPreviewer } from './lib/previewers/location';
 export { default as OpenIndexMapPreviewer } from './lib/previewers/openindexmap';
 export { default as PMTilesRasterPreviewer } from './lib/previewers/pmtiles-raster';
 export { default as PMTilesVectorPreviewer } from './lib/previewers/pmtiles-vector';

--- a/src/lib/previewers/factory.test.ts
+++ b/src/lib/previewers/factory.test.ts
@@ -13,6 +13,7 @@ import EsriImageMapLayerPreviewer from './esri-image-map-layer';
 import EsriTiledMapLayerPreviewer from './esri-tiled-map-layer';
 import GeoJsonPreviewer from './geojson';
 import ImagePreviewer from './image';
+import LocationPreviewer from './location';
 import OpenIndexMapPreviewer from './openindexmap';
 import PMTilesRasterPreviewer from './pmtiles-raster';
 import PMTilesVectorPreviewer from './pmtiles-vector';
@@ -34,6 +35,7 @@ const resourceOfKind = (kind: string, extra: object = {}) => ({ kind, id: 'test-
 const SYNCHRONOUS: [ResourceKind, new (...args: never[]) => unknown][] = [
   ['iiif-image', ImagePreviewer],
   ['geojson', GeoJsonPreviewer],
+  ['location', LocationPreviewer],
   ['openindexmap', OpenIndexMapPreviewer],
   ['esri-feature-layer', EsriFeatureLayerPreviewer],
   ['esri-dynamic-map-layer', EsriDynamicMapLayerPreviewer],

--- a/src/lib/previewers/factory.test.ts
+++ b/src/lib/previewers/factory.test.ts
@@ -178,4 +178,46 @@ describe('previewersForResources', () => {
   it('offers nothing for a record with no resources', async () => {
     expect(await previewersForResources([])).toEqual([]);
   });
+
+  // Where the record is, offered by resourcesFor whenever nothing it points at is certainly a map.
+  // Whether that held is only knowable here, once a manifest has been asked whether it's
+  // georeferenced - so this is where it's kept or dropped. See ogm-viewer#81.
+  describe('a location among the resources', () => {
+    const location = () => resourceOfKind('location');
+    const manifest = (isGeoreferenced: boolean) => resourceOfKind('iiif-manifest', { isGeoreferenced: async () => isGeoreferenced });
+
+    it('says where a scan is when it carries nothing to place it by', async () => {
+      const previewers = await previewersForResources([manifest(false), location()]);
+
+      expect(previewers.map(previewer => previewer.constructor)).toEqual([ImagePreviewer, LocationPreviewer]);
+      // The scan to page through, and a map saying where it is: the pair issue #81 asked for
+      expect(previewers.map(previewer => previewer.renderer)).toEqual(['image', 'map']);
+    });
+
+    it('drops it once the scan turns out to be placeable after all', async () => {
+      const previewers = await previewersForResources([manifest(true), location()]);
+
+      expect(previewers.map(previewer => previewer.constructor)).toEqual([ImagePreviewer, GeoreferencePreviewer]);
+    });
+
+    it('drops it when the record draws its own data on a map', async () => {
+      const previewers = await previewersForResources([resourceOfKind('wms'), location()]);
+
+      expect(previewers.map(previewer => previewer.constructor)).toEqual([WmsPreviewer]);
+    });
+
+    // A tab saying where a thing is belongs after the thing, whatever order the resources arrived in
+    it('comes last however it was listed', async () => {
+      const previewers = await previewersForResources([location(), resourceOfKind('iiif-image')]);
+
+      expect(previewers.map(previewer => previewer.constructor)).toEqual([ImagePreviewer, LocationPreviewer]);
+    });
+
+    // Held back, not filtered out: a record with nothing else still gets its one tab
+    it('is shown on its own when it is all there is', async () => {
+      const previewers = await previewersForResources([location()]);
+
+      expect(previewers.map(previewer => previewer.constructor)).toEqual([LocationPreviewer]);
+    });
+  });
 });

--- a/src/lib/previewers/factory.ts
+++ b/src/lib/previewers/factory.ts
@@ -12,6 +12,7 @@ import EsriImageMapLayerPreviewer from './esri-image-map-layer';
 import EsriTiledMapLayerPreviewer from './esri-tiled-map-layer';
 import GeoJsonPreviewer from './geojson';
 import ImagePreviewer from './image';
+import LocationPreviewer from './location';
 import OpenIndexMapPreviewer from './openindexmap';
 import PMTilesRasterPreviewer from './pmtiles-raster';
 import PMTilesVectorPreviewer from './pmtiles-vector';
@@ -83,6 +84,9 @@ const BUILDERS: Record<ResourceKind, PreviewerBuilder> = {
   },
 
   'geojson': resource => [new GeoJsonPreviewer(resource)],
+  // Not built from a reference: this is the one resource a record makes out of its own metadata,
+  // when nothing it points at can be drawn. See resourcesFor.
+  'location': resource => [new LocationPreviewer(resource)],
   'openindexmap': resource => [new OpenIndexMapPreviewer(resource)],
   'esri-feature-layer': resource => [new EsriFeatureLayerPreviewer(resource)],
   'esri-dynamic-map-layer': resource => [new EsriDynamicMapLayerPreviewer(resource)],

--- a/src/lib/previewers/factory.ts
+++ b/src/lib/previewers/factory.ts
@@ -85,7 +85,8 @@ const BUILDERS: Record<ResourceKind, PreviewerBuilder> = {
 
   'geojson': resource => [new GeoJsonPreviewer(resource)],
   // Not built from a reference: this is the one resource a record makes out of its own metadata,
-  // when nothing it points at can be drawn. See resourcesFor.
+  // when nothing it points at can be drawn on a map. Whether that's so is decided in
+  // previewersForResources, not here. See also resourcesFor.
   'location': resource => [new LocationPreviewer(resource)],
   'openindexmap': resource => [new OpenIndexMapPreviewer(resource)],
   'esri-feature-layer': resource => [new EsriFeatureLayerPreviewer(resource)],
@@ -130,12 +131,27 @@ export async function previewersFor(resource: Resource): Promise<AnyPreviewer[]>
   return await builder(resource);
 }
 
+// Whether a resource is the record's own account of where it is, rather than something the record
+// points at. The one resource whose preview depends on the others, so the one held back below.
+const isLocation = (resource: Resource) => resource.kind === 'location';
+
 /**
  * Every preview a list of resources offers, in the order they were given - which is the tab order.
  * Never rejects: this is awaited before the tabs are rendered, where a rejection would leave the
  * whole record without a preview rather than the one reference that failed.
+ *
+ * A location is the exception to that order, and goes last. It says where the record is, which is
+ * worth a tab only when nothing else drew a map - a scan with no georeferencing to place it, or a
+ * record with nothing previewable at all. Settled here rather than where the resources were built,
+ * because a manifest is a map only if it turns out to be georeferenced and finding that out means
+ * fetching it.
  */
 export async function previewersForResources(resources: Resource[]): Promise<AnyPreviewer[]> {
-  const previewers = await Promise.all(resources.map(resource => previewersFor(resource)));
-  return previewers.flat();
+  const previewers = (await Promise.all(resources.filter(resource => !isLocation(resource)).map(resource => previewersFor(resource)))).flat();
+
+  // Something already draws the data on a map, so an outline of where that data is adds nothing
+  if (previewers.some(previewer => previewer.renderer === 'map')) return previewers;
+
+  const locations = await Promise.all(resources.filter(isLocation).map(resource => previewersFor(resource)));
+  return [...previewers, ...locations.flat()];
 }

--- a/src/lib/previewers/inspectable-raster.ts
+++ b/src/lib/previewers/inspectable-raster.ts
@@ -13,10 +13,13 @@ const NO_FEATURES: GeoJSON.FeatureCollection = { type: 'FeatureCollection', feat
 export default abstract class InspectableRasterPreviewer extends RasterPreviewer {
   // Whether the server will actually answer a question about a click. Some won't - a tile cache
   // holds only pictures - and we don't know which until we've asked, so this settles during preview.
-  private inspectable = false;
+  //
+  // A narrower question than Previewer.inspectable, which asks whether this kind of preview has
+  // anything to be asked about in the first place. These tiles always do; the service may not.
+  private serviceAnswers = false;
 
   get canInspect(): boolean {
-    return this.inspectable;
+    return this.serviceAnswers;
   }
 
   // Add the highlight source ahead of the layers that draw from it
@@ -28,7 +31,7 @@ export default abstract class InspectableRasterPreviewer extends RasterPreviewer
 
     // A service that won't say whether it can be inspected is treated as though it can't, rather
     // than failing a preview whose tiles drew perfectly well
-    this.inspectable = await this.checkInspectable().catch(error => {
+    this.serviceAnswers = await this.checkInspectable().catch(error => {
       console.warn(`Could not determine whether ${this.resource.url} can be inspected:`, error);
       return false;
     });

--- a/src/lib/previewers/location.test.ts
+++ b/src/lib/previewers/location.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import LocationPreviewer from './location';
+import GeoJsonPreviewer from './geojson';
+import LocationResource from '../resources/location';
+import GeoJsonResource from '../resources/geojson';
+import type { MapLibreStyle } from '../themes/maplibre';
+
+// Just enough of a MapLibre map to record what the previewer adds
+class FakeMap {
+  sources = new Map<string, any>();
+  layers = new Map<string, any>();
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+  addSource(id: string, spec: any) {
+    this.sources.set(id, spec);
+  }
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+  addLayer(layer: any) {
+    // MapLibre refuses a layer whose source hasn't been added yet
+    if (!this.sources.has(layer.source)) throw new Error(`No source ${layer.source} for layer ${layer.id}`);
+    this.layers.set(layer.id, layer);
+  }
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+  setPaintProperty(id: string, name: string, value: unknown) {
+    const layer = this.layers.get(id);
+    if (!layer) throw new Error(`No layer ${id} to paint`);
+    layer.paint = { ...layer.paint, [name]: value };
+  }
+  setLayoutProperty(id: string, name: string, value: unknown) {
+    const layer = this.layers.get(id);
+    if (!layer) throw new Error(`No layer ${id} to lay out`);
+    layer.layout = { ...layer.layout, [name]: value };
+  }
+}
+
+const style = {
+  opacity: 0.8,
+  fillColor: '#00f',
+  strokeColor: '#009',
+  textColor: '#000',
+  textFont: 'Noto Sans Regular',
+  textSize: 12,
+  fillHighlightOpacity: 0.8,
+} as MapLibreStyle;
+
+const ID = 'stanford-bb021mm7809';
+const FILL = `${ID}-location-fill`;
+const OUTLINE = `${ID}-location-outline`;
+
+// Uganda, roughly: the bounding box sul-embed hands over for a restricted record
+const BOUNDS: [[number, number], [number, number]] = [
+  [29.57, -1.47],
+  [35.0, 4.23],
+];
+
+// A shape that is emphatically not its own envelope, for the cases about preferring one
+const COASTLINE: GeoJSON.Geometry = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 0],
+      [10, 0],
+      [10, 1],
+      [1, 1],
+      [1, 10],
+      [0, 10],
+      [0, 0],
+    ],
+  ],
+};
+
+const preview = async (location: GeoJSON.Geometry | [[number, number], [number, number]]) => {
+  const map = new FakeMap();
+  const previewer = new LocationPreviewer(new LocationResource(ID, location)).attach(map as unknown as maplibregl.Map, style);
+  await previewer.preview();
+  return { map, previewer };
+};
+
+describe('LocationResource', () => {
+  // The only resource with nowhere to go. The base class would HEAD its empty URL and report the
+  // record broken, which is the opposite of what this is for.
+  it('is always reachable, having nothing to reach', async () => {
+    const resource = new LocationResource(ID, BOUNDS);
+
+    expect(resource.url).toEqual('');
+    expect(await resource.test()).toBe(true);
+  });
+
+  it('makes a box out of bounds it is handed', async () => {
+    const resource = new LocationResource(ID, BOUNDS);
+    const geometry = resource.getGeometry() as GeoJSON.Polygon;
+
+    expect(geometry.type).toEqual('Polygon');
+    // Closed ring, five points for four corners
+    expect(geometry.coordinates[0]).toHaveLength(5);
+    expect(geometry.coordinates[0][0]).toEqual(geometry.coordinates[0][4]);
+  });
+
+  // The reason a geometry is worth accepting at all: squaring this off would claim the whole
+  // quadrant when the record covers two arms of it.
+  it('keeps a shape it is handed rather than squaring it off', async () => {
+    const resource = new LocationResource(ID, COASTLINE);
+
+    expect(resource.getGeometry()).toEqual(COASTLINE);
+    // Still points the camera at the whole thing
+    expect(await resource.getBounds()).toEqual([
+      [0, 0],
+      [10, 10],
+    ]);
+  });
+
+  it('points the camera at the box when given one', async () => {
+    expect(await new LocationResource(ID, BOUNDS).getBounds()).toEqual([
+      [29.57, -1.47],
+      [35, 4.23],
+    ]);
+  });
+});
+
+describe('LocationPreviewer#preview', () => {
+  it('hands MapLibre the shape itself rather than a URL to fetch', async () => {
+    const { map, previewer } = await preview(COASTLINE);
+    const source = map.sources.get(`${ID}-location`);
+
+    expect(source.type).toEqual('geojson');
+    expect(source.data.geometry).toEqual(COASTLINE);
+    expect(previewer.sourceIds).toEqual([`${ID}-location`]);
+  });
+
+  it('draws the extent as an outline with a wash inside it', async () => {
+    const { map } = await preview(BOUNDS);
+
+    expect([...map.layers.keys()]).toEqual([FILL, OUTLINE]);
+    expect(map.layers.get(OUTLINE).paint['line-color']).toEqual(style.strokeColor);
+    expect(map.layers.get(OUTLINE).paint['line-opacity']).toEqual(style.opacity);
+    expect(map.layers.get(FILL).paint['fill-color']).toEqual(style.fillColor);
+    // Held under the outline, so the extent reads as a note about the map and not as data on it
+    expect(map.layers.get(FILL).paint['fill-opacity']).toBeLessThan(style.opacity);
+  });
+
+  // One thing the reader can turn off, not two. The outline and the wash are how an extent is drawn.
+  it('offers the extent as a single row in the layer panel', async () => {
+    const { previewer } = await preview(BOUNDS);
+
+    expect(previewer.previewLayers).toHaveLength(1);
+    expect(previewer.previewLayers[0].title).toEqual('Location');
+    expect(previewer.previewLayers[0].styleLayers.map(layer => layer.id)).toEqual([FILL, OUTLINE]);
+  });
+
+  it('removes what it added when cleared', async () => {
+    const { map, previewer } = await preview(BOUNDS);
+    await previewer.clearPreview();
+
+    expect(map.sources.size).toEqual(0);
+    expect(map.layers.size).toEqual(0);
+  });
+});
+
+describe('LocationPreviewer inspection', () => {
+  // The whole point of this being its own previewer rather than a GeoJSON one over a hand-built
+  // document: <ogm-map> asks the previewer before it queries, and a box with no properties behind it
+  // would otherwise open an attributes popup on an empty table.
+  it('says it has nothing to be asked about', async () => {
+    const { previewer } = await preview(BOUNDS);
+
+    expect(previewer.inspectable).toBe(false);
+  });
+
+  it('is the only previewer that says so', async () => {
+    const geojson = new GeoJsonPreviewer(new GeoJsonResource(ID, 'https://example.com/data.json'));
+
+    expect(geojson.inspectable).toBe(true);
+  });
+
+  // Not achieved by hiding the layers: they are drawn, listed and dimmable like any others. Only
+  // the answer to "can this be asked" differs, which is why it isn't PreviewStyleLayer.internal -
+  // that would also take the row out of the panel and the layer out of the opacity slider's reach.
+  it('still reports its layers as drawn and dimmable', async () => {
+    const { map, previewer } = await preview(BOUNDS);
+
+    expect(previewer.visibleLayerIds).toEqual([FILL, OUTLINE]);
+    expect(previewer.anyLayerVisible).toBe(true);
+
+    previewer.applyLayerState(new Map([[`${ID}-location`, { visible: true, opacity: 0.5 }]]));
+    expect(map.layers.get(OUTLINE).paint['line-opacity']).toEqual(0.5);
+    expect(map.layers.get(FILL).paint['fill-opacity']).toBeLessThan(0.5);
+  });
+
+  it('hides both layers together when switched off', async () => {
+    const { map, previewer } = await preview(BOUNDS);
+    previewer.applyLayerState(new Map([[`${ID}-location`, { visible: false, opacity: 0.8 }]]));
+
+    expect(map.layers.get(FILL).layout.visibility).toEqual('none');
+    expect(map.layers.get(OUTLINE).layout.visibility).toEqual('none');
+    expect(previewer.visibleLayerIds).toEqual([]);
+  });
+});

--- a/src/lib/previewers/location.ts
+++ b/src/lib/previewers/location.ts
@@ -1,0 +1,94 @@
+import type { FillLayerSpecification, GeoJSONSourceSpecification, LayerSpecification, LineLayerSpecification } from 'maplibre-gl';
+
+import MapPreviewer from './map';
+import type { PreviewStyleLayer } from '../layers';
+import type LocationResource from '../resources/location';
+
+// MapLibre doesn't bundle the id with the source, but we need to
+type AddGeoJsonSourceObject = GeoJSONSourceSpecification & { id: string };
+
+// How much of the layer's opacity the fill gets. The outline is what says where the record is; the
+// fill is there so a small extent is still findable on a busy basemap, and at full strength it would
+// read as data drawn over the map rather than a note about it.
+const FILL_OPACITY = 0.2;
+
+/**
+ * A record's extent, drawn as a frame rather than as data. What goes on the map when the data itself
+ * can't: see LocationResource.
+ *
+ * Deliberately the plainest previewer here. It has one shape, no features worth naming, and no
+ * server behind it, so there is nothing to inspect, nothing to fail, and no reason to hold the map
+ * flat - a location reads on a globe as well as anywhere.
+ */
+export default class LocationPreviewer extends MapPreviewer {
+  declare protected resource: LocationResource;
+
+  // There is one shape here and it carries no properties, so a click has nothing to ask about. Left
+  // to itself, <ogm-map> would open an attributes popup on an empty table - which is what happens if
+  // a caller draws an extent through GeoJsonPreviewer instead of this.
+  readonly inspectable = false;
+
+  protected getSourceId(): string {
+    return `${this.resource.id}-location`;
+  }
+
+  protected async createSources(): Promise<AddGeoJsonSourceObject[]> {
+    return [
+      {
+        id: this.getSourceId(),
+        type: 'geojson',
+        data: { type: 'Feature', properties: {}, geometry: this.resource.getGeometry() },
+      },
+    ];
+  }
+
+  protected async createLayers(): Promise<LayerSpecification[]> {
+    const layers = [this.createFillLayer(), this.createOutlineLayer()];
+
+    // One row in the layer panel, not two: an outline and the wash inside it are how an extent is
+    // drawn, not two things a reader chose to put on the map. Listed at all so it can be turned off
+    // - it may be the only thing up, but it is also the only thing in the way of the basemap.
+    this.previewLayers.push({
+      id: this.getSourceId(),
+      title: this.resource.label(),
+      defaultOpacity: this.style.opacity,
+      styleLayers: layers.map(layer => ({ id: layer.id, type: layer.type }) as PreviewStyleLayer),
+    });
+
+    return layers;
+  }
+
+  // Hold the fill below the outline at every setting, rather than only at the default. A reader
+  // dragging the opacity slider is asking to see more of the basemap, which is the fill's business
+  // and not the outline's.
+  protected applyOpacity(styleLayer: PreviewStyleLayer, opacity: number) {
+    super.applyOpacity(styleLayer, styleLayer.type === 'fill' ? opacity * FILL_OPACITY : opacity);
+  }
+
+  private createFillLayer(): FillLayerSpecification {
+    return {
+      id: `${this.getSourceId()}-fill`,
+      type: 'fill' as const,
+      source: this.getSourceId(),
+      layout: { visibility: 'visible' as const },
+      paint: {
+        'fill-color': this.style.fillColor,
+        'fill-opacity': this.style.opacity * FILL_OPACITY,
+      },
+    };
+  }
+
+  private createOutlineLayer(): LineLayerSpecification {
+    return {
+      id: `${this.getSourceId()}-outline`,
+      type: 'line' as const,
+      source: this.getSourceId(),
+      layout: { visibility: 'visible' as const },
+      paint: {
+        'line-color': this.style.strokeColor,
+        'line-width': 2,
+        'line-opacity': this.style.opacity,
+      },
+    };
+  }
+}

--- a/src/lib/previewers/previewer.ts
+++ b/src/lib/previewers/previewer.ts
@@ -13,6 +13,14 @@ export default abstract class Previewer {
   // The component that draws this preview
   abstract readonly renderer: PreviewRenderer;
 
+  // Whether a click on this preview has anything to answer with. True for all but the one preview
+  // that draws something other than the data - a record's extent, when the data itself can't be
+  // shown - where every layer is drawn and none of it carries a property worth reading. A flag on
+  // the preview rather than on its style layers because it describes the whole preview, and because
+  // PreviewStyleLayer's `internal` already means something narrower: not listed in the layer panel,
+  // and not dimmed by the opacity slider, neither of which is wanted here.
+  readonly inspectable: boolean = true;
+
   protected resource: Resource;
 
   constructor(resource: Resource) {

--- a/src/lib/resources/factory.test.ts
+++ b/src/lib/resources/factory.test.ts
@@ -82,9 +82,9 @@ describe('resourcesFor', () => {
     expect(resourcesFor(buildRecord({ 'http://schema.org/downloadUrl': 'https://example.com/data.zip' }))).toEqual([]);
   });
 
-  // Nothing here can be drawn, but where the record is can be, and that is most of what a reader
-  // came to a map for. Better than an empty viewer.
-  describe('a record with nothing previewable but somewhere to point', () => {
+  // None of this can go on a map, but where the record is can, and that is most of what a reader came
+  // to a map for. Better than an empty viewer.
+  describe('a record with nothing to put on a map but somewhere to point', () => {
     const unpreviewable = { 'http://schema.org/downloadUrl': 'https://example.com/data.zip' };
 
     it('falls back to the location', async () => {
@@ -112,8 +112,21 @@ describe('resourcesFor', () => {
       expect((resource.getGeometry() as GeoJSON.Polygon).coordinates[0]).toHaveLength(7);
     });
 
-    // Only when there is nothing else. A record whose data draws has no use for an outline of itself.
-    it('is not offered alongside a preview', () => {
+    // A scan goes on a map only when it also says where on the earth it belongs. An image never does;
+    // a manifest sometimes does, and the only way to find out is to fetch it - so the location is
+    // offered here and previewersForResources takes it back if a map turns up. See ogm-viewer#81.
+    it.each([
+      ['http://iiif.io/api/image', 'iiif-image'],
+      ['http://iiif.io/api/presentation#manifest', 'iiif-manifest'],
+    ])('offers it alongside the %s reference, which may have nothing to place it by', (uri, kind) => {
+      const record = buildRecord({ [uri]: 'https://example.com/iiif' }, { dcat_bbox: 'ENVELOPE(0,10,10,0)' });
+
+      expect(resourcesFor(record).map(resource => resource.kind)).toEqual([kind, 'location']);
+    });
+
+    // Only when there is nothing else on the map. A record whose own data draws has no use for an
+    // outline of where that data is.
+    it('is not offered alongside a preview that is a map either way', () => {
       const record = buildRecord({ 'http://geojson.org/geojson-spec.html': 'https://example.com/data.json' }, { dcat_bbox: 'ENVELOPE(0,10,10,0)' });
 
       expect(resourcesFor(record).map(resource => resource.kind)).toEqual(['geojson']);

--- a/src/lib/resources/factory.test.ts
+++ b/src/lib/resources/factory.test.ts
@@ -14,6 +14,7 @@ import EsriTiledMapLayerResource from './esri-tiled-map-layer';
 import GeoJsonResource from './geojson';
 import IIIFResource from './iiif';
 import IIIFManifestResource from './iiif-manifest';
+import LocationResource from './location';
 import OpenIndexMapResource from './openindexmap';
 import PMTilesResource from './pmtiles';
 import TileJsonResource from './tilejson';
@@ -79,6 +80,48 @@ describe('resourcesFor', () => {
 
   it('offers nothing for a record with no previewable references', () => {
     expect(resourcesFor(buildRecord({ 'http://schema.org/downloadUrl': 'https://example.com/data.zip' }))).toEqual([]);
+  });
+
+  // Nothing here can be drawn, but where the record is can be, and that is most of what a reader
+  // came to a map for. Better than an empty viewer.
+  describe('a record with nothing previewable but somewhere to point', () => {
+    const unpreviewable = { 'http://schema.org/downloadUrl': 'https://example.com/data.zip' };
+
+    it('falls back to the location', async () => {
+      const record = buildRecord(unpreviewable, { dcat_bbox: 'ENVELOPE(-120.6,-120.0,38.5,38.0)' });
+      const [resource, ...rest] = resourcesFor(record);
+
+      expect(resource).toBeInstanceOf(LocationResource);
+      expect(resource.kind).toEqual('location');
+      expect(rest).toEqual([]);
+      expect(await resource.getBounds()).toEqual([
+        [-120.6, 38],
+        [-120, 38.5],
+      ]);
+    });
+
+    // An envelope around a coastline claims the sea as well. locn_geometry is the better answer
+    // wherever a record carries one, which is why the resource takes a shape and not a box.
+    it('prefers the record geometry to its bounding box', () => {
+      const record = buildRecord(unpreviewable, {
+        dcat_bbox: 'ENVELOPE(0,10,10,0)',
+        locn_geometry: 'POLYGON((0 0, 10 0, 10 1, 1 1, 1 10, 0 10, 0 0))',
+      });
+      const [resource] = resourcesFor(record) as [LocationResource];
+
+      expect((resource.getGeometry() as GeoJSON.Polygon).coordinates[0]).toHaveLength(7);
+    });
+
+    // Only when there is nothing else. A record whose data draws has no use for an outline of itself.
+    it('is not offered alongside a preview', () => {
+      const record = buildRecord({ 'http://geojson.org/geojson-spec.html': 'https://example.com/data.json' }, { dcat_bbox: 'ENVELOPE(0,10,10,0)' });
+
+      expect(resourcesFor(record).map(resource => resource.kind)).toEqual(['geojson']);
+    });
+
+    it('is not offered when the record says nothing about where it is', () => {
+      expect(resourcesFor(buildRecord(unpreviewable))).toEqual([]);
+    });
   });
 
   // A WxS endpoint is a catalogue, so without an identifier we don't know what to ask it for

--- a/src/lib/resources/factory.ts
+++ b/src/lib/resources/factory.ts
@@ -1,6 +1,7 @@
 import type OgmRecord from '../record';
 import type { RequestTransform } from '../request';
 import type Resource from './resource';
+import type { ResourceKind } from './resource';
 
 import CogResource from './cog';
 import EsriDynamicMapLayerResource from './esri-dynamic-map-layer';
@@ -18,6 +19,12 @@ import TmsResource from './tms';
 import WmsResource from './wms';
 import WmtsResource from './wmts';
 import XyzResource from './xyz';
+
+// The kinds whose preview might turn out not to be a map. A scan is drawn on one only when it also
+// says where on the earth it belongs, and that can't be settled here: a IIIF image never carries
+// georeferencing, and a manifest only carries it sometimes, discoverable only by fetching it.
+// Everything else below is a map by construction.
+const MAY_NOT_DRAW_A_MAP: ResourceKind[] = ['iiif-image', 'iiif-manifest'];
 
 /**
  * Every previewable resource a record's references point at, in the order they're offered to the
@@ -49,15 +56,17 @@ export function resourcesFor(record: OgmRecord, requestTransform?: RequestTransf
   if (references.wmtsUrl && wxsIdentifier) resources.push(new WmtsResource(id, references.wmtsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
   if (references.wmsUrl && wxsIdentifier) resources.push(new WmsResource(id, references.wmsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
 
-  // Nothing here can be drawn, so say where the thing is instead. A reader who can't see the data
-  // still learns what part of the world it covers, which is most of what they came to a map for, and
-  // it beats an empty viewer. Its geometry rather than its bounding box: getGeometry() prefers
+  // Where the record says it is, for when nothing above will put it on a map - either because none
+  // of it can be drawn at all, or because all of it is a scan with nothing to place it by. A reader
+  // who can't see the data on a map still learns what part of the world it covers, which is most of
+  // what they came to a map for. Its geometry rather than its bounding box: getGeometry() prefers
   // locn_geometry, which may describe a coastline or an archipelago that an envelope would claim far
   // more of the map than the record actually covers.
   //
-  // Last, and only when nothing else was made: a record with a preview has no use for this, and one
-  // with neither a preview nor a geometry has nothing to offer either way.
-  if (resources.length === 0) {
+  // Offered rather than decided, and last so that it is the last tab: whether a manifest is
+  // georeferenced is only known once it has been read, so previewersForResources settles it and drops
+  // this again if a map did turn up. A record with no geometry has nothing to offer either way.
+  if (resources.every(resource => MAY_NOT_DRAW_A_MAP.includes(resource.kind))) {
     const geometry = record.getGeometry();
     if (geometry) resources.push(new LocationResource(id, geometry as GeoJSON.Geometry));
   }

--- a/src/lib/resources/factory.ts
+++ b/src/lib/resources/factory.ts
@@ -10,6 +10,7 @@ import EsriTiledMapLayerResource from './esri-tiled-map-layer';
 import GeoJsonResource from './geojson';
 import IIIFResource from './iiif';
 import IIIFManifestResource from './iiif-manifest';
+import LocationResource from './location';
 import OpenIndexMapResource from './openindexmap';
 import PMTilesResource from './pmtiles';
 import TileJsonResource from './tilejson';
@@ -47,6 +48,19 @@ export function resourcesFor(record: OgmRecord, requestTransform?: RequestTransf
   // A WxS endpoint is a catalogue; without an identifier we don't know which layer of it to ask for
   if (references.wmtsUrl && wxsIdentifier) resources.push(new WmtsResource(id, references.wmtsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
   if (references.wmsUrl && wxsIdentifier) resources.push(new WmsResource(id, references.wmsUrl, { layerIds: [wxsIdentifier] }, bounds, requestTransform));
+
+  // Nothing here can be drawn, so say where the thing is instead. A reader who can't see the data
+  // still learns what part of the world it covers, which is most of what they came to a map for, and
+  // it beats an empty viewer. Its geometry rather than its bounding box: getGeometry() prefers
+  // locn_geometry, which may describe a coastline or an archipelago that an envelope would claim far
+  // more of the map than the record actually covers.
+  //
+  // Last, and only when nothing else was made: a record with a preview has no use for this, and one
+  // with neither a preview nor a geometry has nothing to offer either way.
+  if (resources.length === 0) {
+    const geometry = record.getGeometry();
+    if (geometry) resources.push(new LocationResource(id, geometry as GeoJSON.Geometry));
+  }
 
   return resources;
 }

--- a/src/lib/resources/location.ts
+++ b/src/lib/resources/location.ts
@@ -1,0 +1,64 @@
+import geojsonExtent from '@mapbox/geojson-extent';
+import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
+
+import Resource, { type ResourceKind } from './resource';
+import { boundsToGeoJSON } from '../geometry';
+
+// Whether a caller handed us a shape or a box to make one from. A GeoJSON geometry is the only one
+// of the two that names its own type; every form of LngLatBoundsLike is an array, or an object with
+// corners rather than coordinates.
+const isGeometry = (location: GeoJSON.Geometry | LngLatBoundsLike): location is GeoJSON.Geometry =>
+  typeof location === 'object' && location !== null && 'type' in location && 'coordinates' in location;
+
+/**
+ * Where a record is, for when what it holds can't be drawn - it sits behind authentication, or
+ * nothing here can read the format, or the preview was tried and failed. Knowing roughly what part
+ * of the world a thing covers is worth a great deal on its own, and is most of what a reader wants
+ * from a map they can't yet see.
+ *
+ * The one resource that fetches nothing: the shape is handed over at construction rather than read
+ * from a URL, so this draws immediately and can't fail. A geometry is preferred over a bounding box
+ * where a caller has one - a record's `locn_geometry` may describe an archipelago or a coastline,
+ * and squaring that off to its envelope claims coverage it doesn't have.
+ */
+export default class LocationResource extends Resource {
+  readonly kind: ResourceKind = 'location';
+
+  // The shape to draw, in lng/lat
+  private geometry: GeoJSON.Geometry;
+
+  constructor(id: string, location: GeoJSON.Geometry | LngLatBoundsLike) {
+    const geometry = isGeometry(location) ? location : (boundsToGeoJSON(LngLatBounds.convert(location)) as GeoJSON.Geometry);
+    // No URL, because there is nothing to go and get. Resource.url is a string rather than an
+    // optional one because every other resource has somewhere to point and reads it without asking,
+    // and widening it for this one would put a `?? ''` at each of those sites instead of here.
+    super(id, '', extentOf(geometry));
+    this.geometry = geometry;
+  }
+
+  label(): string {
+    return 'Location';
+  }
+
+  // Nothing to reach, so nothing that could be unreachable. The base class would HEAD the empty
+  // URL above and call this resource broken.
+  async test(): Promise<boolean> {
+    return true;
+  }
+
+  // The shape itself, for the previewer to put on the map
+  getGeometry(): GeoJSON.Geometry {
+    return this.geometry;
+  }
+}
+
+// Where to point the map to see the whole shape. Worked out here rather than left to the previewer
+// so that a caller who passed a geometry gets the same camera behaviour as one who passed a box.
+const extentOf = (geometry: GeoJSON.Geometry): LngLatBoundsLike | undefined => {
+  const extent = geojsonExtent({ type: 'Feature', properties: {}, geometry });
+  if (!extent) return undefined;
+  return [
+    [extent[0], extent[1]],
+    [extent[2], extent[3]],
+  ];
+};

--- a/src/lib/resources/location.ts
+++ b/src/lib/resources/location.ts
@@ -11,10 +11,10 @@ const isGeometry = (location: GeoJSON.Geometry | LngLatBoundsLike): location is 
   typeof location === 'object' && location !== null && 'type' in location && 'coordinates' in location;
 
 /**
- * Where a record is, for when what it holds can't be drawn - it sits behind authentication, or
- * nothing here can read the format, or the preview was tried and failed. Knowing roughly what part
- * of the world a thing covers is worth a great deal on its own, and is most of what a reader wants
- * from a map they can't yet see.
+ * Where a record is, for when what it holds can't be drawn on a map - it sits behind authentication,
+ * or nothing here can read the format, or it is a scan with no georeferencing to place it by, or the
+ * preview was tried and failed. Knowing roughly what part of the world a thing covers is worth a
+ * great deal on its own, and is most of what a reader wants from a map they can't yet see.
  *
  * The one resource that fetches nothing: the shape is handed over at construction rather than read
  * from a URL, so this draws immediately and can't fail. A geometry is preferred over a bounding box

--- a/src/lib/resources/resource.ts
+++ b/src/lib/resources/resource.ts
@@ -14,6 +14,7 @@ export type ResourceKind =
   | 'geojson'
   | 'iiif-image'
   | 'iiif-manifest'
+  | 'location'
   | 'openindexmap'
   | 'pmtiles'
   | 'tilejson'


### PR DESCRIPTION
Closes #36. Closes #81, by the alternate means proposed in its own discussion — a "location" preview rather than an inset map.

A reader who can't see the data still learns what part of the world it covers, which is most of what they came to a map for — and it beats an empty viewer. Four cases reach it: the data sits behind authentication, nothing here reads the format, the preview was tried and failed, or the only thing to show is a scan with no georeferencing to place it.

<!-- screenshot: the Nepal demo record, outline + wash, one "Location" tab -->

## What's here

**`LocationResource`** — the only resource that fetches nothing. The shape is handed over at construction rather than read from a URL, so it draws immediately and can't fail. It takes a GeoJSON geometry *or* a `LngLatBoundsLike`, and prefers the geometry: `resourcesFor` hands it the record's own `getGeometry()`, because `locn_geometry` may describe a coastline or an archipelago and squaring that off to its envelope claims coverage the record doesn't have. The demo record shows the difference — Nepal's envelope takes in a good deal of India and Tibet.

**`LocationPreviewer`** — an outline with a faint wash inside it, held under the outline at every opacity setting so it reads as a note about the map rather than data drawn on it. One row in the layer panel, not two.

**`resourcesFor` falls back to it** when nothing a record's references produce will go on a map, and only then — a record whose own data draws has no use for an outline of where that data is.

## The IIIF case (#81)

A record whose only preview is a scan gets nothing on a map, so it gets a **second tab** instead. The tab strip reads `IIIF Manifest | Location`, image first.

Which records those are can't be settled in one place. A IIIF image never carries georeferencing; a manifest only sometimes does, and finding out means fetching it. So the decision is split at the two factories:

- `resourcesFor` **offers** a location whenever nothing it built is *certainly* a map — every resource is `iiif-image` or `iiif-manifest`, or there are none at all.
- `previewersForResources` is the first place the georeferencing answer has arrived, so it **keeps or drops** it: if any other preview came back with `renderer === 'map'`, the location adds nothing and goes.

It's held to the end of the list either way, so the scan is still the first tab whatever order the resources arrived in.

## Why not a GeoJSON previewer over a hand-built document

That's what a consumer reaches for otherwise (sul-embed does today), and it inherits three things it shouldn't: it's labelled **"GeoJSON"**, it's styled as data, and it's **clickable** — one shape carrying no properties, so `<ogm-map>` opens an attributes popup on an empty table.

That last one is why `Previewer` gains **`inspectable`**. It's a flag on the preview rather than on its style layers: `PreviewStyleLayer.internal` already means something narrower — not listed in the layer panel, not dimmed by the opacity slider — and neither is wanted here. The extent *is* drawn, listed, and dimmable. Only "can this be asked about" differs.

`InspectableRasterPreviewer`'s private field of the same name becomes `serviceAnswers`, which is the narrower question it was always asking: these tiles can always be inspected, but the service behind them may not answer. `canInspect` is unchanged.

## Not here, deliberately

The `authenticated=true` attribute from the issue discussion. It only means something for the record-driven path, where the component picks previewers itself — a consumer building previewers by hand just assigns a different one, which `@Watch('previewer')` already tears down cleanly. And a single boolean can't carry the case that prompted this: in sul-embed restriction is per-*file*, not per-record, and the handshake is multi-step. Worth its own issue.

## Verification

`npm run lint` and `npm test` both exit 0 — **663 tests, up from 635**.

In a browser, four records covering each branch:

| Record | Tabs |
| --- | --- |
| `Nepal (Nothing Previewable)` | `Location` |
| `Isles (IIIF v2 Manifest)` | `IIIF Manifest \| Location` |
| `NY & NJ (IIIF Image)` | `IIIF Image \| Location` |
| `NW Europe (Georeferenced)` | `IIIF Manifest \| Georeferenced map` — **no Location** |

Also confirmed:

- the outline draws from Nepal's 13-point `locn_geometry`, not its 5-point envelope; Isles draws its five islands as a `MultiPolygon` rather than one box over the Channel and the Irish Sea
- the layer panel offers exactly one row, `{title: "Location", visible: true, opacity: 0.8}`; the fill lands at `0.16` under a `0.8` outline
- a click inside the shape opens nothing, while `queryRenderedFeatures` at the same point returns `1` — so it's the guard doing the work, not an empty map, and the cursor stays default on hover
- no console errors from the location preview on a clean load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
