### PR TITLE
Keep a bounding box that crosses the antimeridian in one piece

### DIFF
--- a/src/lib/geometry.test.ts
+++ b/src/lib/geometry.test.ts
@@ -29,6 +29,25 @@ describe('geomToGeoJSON', () => {
     });
   });
 
+  // The whole path a record's bounding box takes: WKT parsing fails on ENVELOPE, so it is read as a
+  // box and squared back off into a ring. Twenty degrees of the Pacific rather than the 340 of
+  // everywhere else.
+  it('should convert an ENVELOPE that crosses the antimeridian to GeoJSON', () => {
+    const geojson = geomToGeoJSON('ENVELOPE(170,-170,10,-10)');
+    expect(geojson).toEqual({
+      type: 'Polygon',
+      coordinates: [
+        [
+          [170, -10],
+          [190, -10],
+          [190, 10],
+          [170, 10],
+          [170, -10],
+        ],
+      ],
+    });
+  });
+
   it('should be undefined for invalid geometry', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const invalidGeom = 'INVALID(-122.6764 45.5165)';
@@ -44,6 +63,15 @@ describe('bboxToBounds', () => {
     const bbox = 'ENVELOPE(-10,-5,5,0)';
     const bounds = bboxToBounds(bbox);
     expect(bounds).toEqual(new LngLatBounds([-10, 0], [-5, 5]));
+  });
+
+  // A box that crosses the antimeridian names its west edge east of its east edge, which is how both
+  // Solr's ENVELOPE syntax and RFC 7946 section 5.2 say to write one. Carried onward past 180 so that
+  // the box stays in one piece: read as it is written, -170 would put the camera on the 340 degrees
+  // of the world the record doesn't cover.
+  it('should carry the east edge past 180 for a box that crosses the antimeridian', () => {
+    const bounds = bboxToBounds('ENVELOPE(170,-170,10,-10)');
+    expect(bounds).toEqual(new LngLatBounds([170, -10], [190, 10]));
   });
 
   it('should be undefined for invalid ENVELOPE strings', () => {
@@ -72,6 +100,26 @@ describe('boundsToGeoJSON', () => {
           [-5, 5],
           [-10, 5],
           [-10, 0],
+        ],
+      ],
+    });
+  });
+
+  // Each vertex is projected on its own, so a ring whose east edge reads as the smaller number is
+  // drawn the long way round: across the rest of the world rather than across the date line. Every
+  // corner a caller may hand us has already been carried past 180 by bboxToBounds, but one built
+  // from a box by hand has not, so the ring is squared off from the edges rather than the corners.
+  it('should draw a box that crosses the antimeridian the short way round', () => {
+    const geojson = boundsToGeoJSON(new LngLatBounds([170, -10], [-170, 10]));
+    expect(geojson).toEqual({
+      type: 'Polygon',
+      coordinates: [
+        [
+          [170, -10],
+          [190, -10],
+          [190, 10],
+          [170, 10],
+          [170, -10],
         ],
       ],
     });

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -7,17 +7,31 @@ export const ENVELOPE_REGEX = /^ENVELOPE\((?<west>[^,]+),(?<east>[^,]+),(?<north
 // EPSG:3857 spans this many meters from the origin on both axes
 const MERCATOR_EXTENT = 20037508.342789244;
 
+// Where a box's east edge is, counted onward from its west edge rather than from Greenwich. A box
+// that crosses the antimeridian is written with its east edge numerically west of its west edge -
+// Solr's ENVELOPE syntax and RFC 7946 section 5.2 both say so - and taken at face value that
+// describes the rest of the world instead: the 295 degrees a map of the Bering Strait doesn't cover.
+// Carrying the east edge past 180 rather than wrapping it back keeps the box in one piece, which is
+// what MapLibre needs both to draw an edge the short way round and to frame a camera on the half of
+// the world the record is actually on. It hands back a longitude outside -180..180, which MapLibre
+// reads everywhere it takes one; only a consumer that has to state a coordinate rather than use it
+// needs to wrap it, and none here does.
+const unwrapEast = (west: number, east: number) => (east < west ? east + 360 : east);
+
 // Convert LngLatBounds to GeoJSON Polygon
 export const boundsToGeoJSON = (bounds: LngLatBounds) => {
+  const [west, south, north] = [bounds.getWest(), bounds.getSouth(), bounds.getNorth()];
+  const east = unwrapEast(west, bounds.getEast());
+
   return {
     type: 'Polygon',
     coordinates: [
       [
-        [bounds.getWest(), bounds.getSouth()],
-        [bounds.getEast(), bounds.getSouth()],
-        [bounds.getEast(), bounds.getNorth()],
-        [bounds.getWest(), bounds.getNorth()],
-        [bounds.getWest(), bounds.getSouth()],
+        [west, south],
+        [east, south],
+        [east, north],
+        [west, north],
+        [west, south],
       ],
     ],
   };
@@ -31,7 +45,7 @@ export const bboxToBounds = (bbox: string) => {
 
   // Convert to numbers and create LngLatBounds
   const { west, east, north, south } = coords.groups!;
-  return new LngLatBounds([parseFloat(west), parseFloat(south)], [parseFloat(east), parseFloat(north)]);
+  return new LngLatBounds([parseFloat(west), parseFloat(south)], [unwrapEast(parseFloat(west), parseFloat(east)), parseFloat(north)]);
 };
 
 // Convert a geographic coordinate to EPSG:3857 (Web Mercator) meters

--- a/src/lib/record.test.ts
+++ b/src/lib/record.test.ts
@@ -166,6 +166,24 @@ describe('OgmRecord', () => {
       });
       expect(record.getBounds()).toEqual(new LngLatBounds([-20, -1], [-15, -5]));
     });
+
+    // A record whose extent crosses the date line writes its west edge east of its east edge. The
+    // camera is framed on these bounds, so read literally they would point it at the rest of the
+    // world - a map of the Bering Strait fitted to the Atlantic.
+    it('should carry the east edge past 180 for a bbox that crosses the antimeridian', () => {
+      const record = new OgmRecord({
+        id: '1',
+        dct_title_s: 'Test Record',
+        gbl_resourceClass_sm: ['Datasets'],
+        dct_accessRights_s: 'Public',
+        dcat_bbox: 'ENVELOPE(153.533333,-142.033333,71.416667,50.733333)',
+        gbl_mdVersion_s: 'Aardvark',
+      });
+
+      const bounds = record.getBounds()!;
+      expect(bounds.getWest()).toEqual(153.533333);
+      expect(bounds.getEast()).toBeCloseTo(217.966667, 6);
+    });
   });
 
   describe('restricted', () => {
@@ -255,6 +273,33 @@ describe('OgmRecord', () => {
             [-15, -5],
             [-20, -5],
             [-20, -1],
+          ],
+        ],
+      });
+    });
+
+    // Same crossing box, drawn rather than framed. This is the shape a reader is shown when nothing
+    // the record points at can go on a map, so getting it the wrong way round tells them the record
+    // covers everywhere it doesn't.
+    it('should return GeoJSON that crosses the antimeridian in one piece', () => {
+      const record = new OgmRecord({
+        id: '2',
+        dct_title_s: 'Test Record Crossing the Date Line',
+        gbl_resourceClass_sm: ['Datasets'],
+        dct_accessRights_s: 'Public',
+        dcat_bbox: 'ENVELOPE(170,-170,10,-10)',
+        gbl_mdVersion_s: 'Aardvark',
+      });
+
+      expect(record.getGeometry()).toEqual({
+        type: 'Polygon',
+        coordinates: [
+          [
+            [170, -10],
+            [190, -10],
+            [190, 10],
+            [170, 10],
+            [170, -10],
           ],
         ],
       });


### PR DESCRIPTION
A record whose extent crosses the date line was drawn and framed as the rest of the world.

## What happens

`ENVELOPE` and RFC 7946 both spell a crossing box with its **west edge east of its east edge**
([RFC 7946 §5.2](https://datatracker.ietf.org/doc/html/rfc7946#section-5.2)). Both places we turn one
into coordinates read it at face value, so a 64° box over the North Pacific became the 295° box over
everywhere else. Two symptoms, one cause:

- **`boundsToGeoJSON`** emitted a ring whose east edge is the smaller number. Every vertex is
  projected on its own, so MapLibre draws that edge the long way round.
- **The camera.** `bboxToBounds` handed `fitBounds` a `LngLatBounds` whose east mercator x lands west
  of its west, so `cameraForBoxAndBearing` sized the box it wasn't given. This one reaches *every*
  previewer of a crossing record, not just the location one.

`unwrapEast` now carries the east edge past 180 instead of wrapping it back, which is the same thing
`WmtsResource#boundsMinzoom` has always done for a layer's own extent.

## Found on

`stanford-hj948rn6493` — a map of the Aleutians and far eastern Siberia, extent
`ENVELOPE(153.533,-142.033,71.417,50.733)`. Note the record in `edu.stanford.purl` states that
envelope the *other* way round, west and east swapped, which is a separate data bug: Cocina at purl
has `west: E153°32′` / `east: W142°02′`, correctly crossing. This change is what makes the correct
spelling render correctly; nothing here can rescue a min/max-sorted one, since a 295° box is a legal
thing for a record to mean.

## Verified

Live, against `ENVELOPE(153.533333,-142.033333,71.416667,50.733333)`:

| | before | after |
| --- | --- | --- |
| camera (XYZ previewer) | lng 0.05, lat 0.70 | **lng −174.25, lat 62.84**, zoom 2.36 |
| location ring east edge | −142.03 | **217.97** |
| resource bounds | `[[-142.03, 50.73], [153.53, 71.42]]` | `[[153.53, 50.73], [217.97, 71.42]]` |

Camera on this branch; the drawn ring on a throwaway merge with #143, since `LocationPreviewer` isn't
on `main` yet. Zero console errors on both. `npx tsc --noEmit`, `npm test` (45 files, 644 tests) and
`npm run lint` all exit 0.

## Not fixed

A **tile source's own `bounds`** still can't cross. MapLibre clamps them to 180 in
`TileBounds#validateBounds` and its `contains()` compares projected x, so the format has no way to say
it. Unwrapping helps even there — a crossing WMTS layer keeps its western half instead of matching no
tile at all — but the eastern half is out of reach without splitting the source in two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
