### PR TITLE
Make feature popup titles more consistent

### DIFF
--- a/src/components/ogm-attributes/ogm-attributes.test.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.test.tsx
@@ -176,7 +176,7 @@ describe('ogm-attributes', () => {
       const { root, waitForChanges } = await render(<ogm-attributes features={UNLABELED}></ogm-attributes>);
 
       expect(pagers(root)).toHaveLength(2);
-      expect(title(root)).toEqual('');
+      expect(title(root)).toEqual('Feature am002175');
 
       await page(root, waitForChanges, 'next');
 
@@ -283,19 +283,6 @@ describe('ogm-attributes', () => {
         expect(tabs(root).map(tab => tab.getAttribute('panel'))).toEqual(['image', 'attributes']);
       });
 
-      // With nothing to call it and no stack to page through there is no header, and the strip lands
-      // where MapLibre draws its own close button - measured over the last 20px of the second tab.
-      // The stylesheet is told which case this is because it can't tell: a :first-child test picks up
-      // the <style> element Stencil puts in the shadow root of a dev build.
-      it('keeps clear of the close button when it is the top of the popup', async () => {
-        const nameless = sheet({ recId: 'am002175', thumbUrl: SHEET.properties.thumbUrl });
-
-        const { root } = await renderSheet([nameless]);
-
-        expect(shadow(root).querySelector('.header')).toBeNull();
-        expect(shadow(root).querySelector('wa-tab-group')?.classList.contains('topmost')).toBe(true);
-      });
-
       it('takes the whole row when a header is already clearing the close button', async () => {
         const { root } = await renderSheet([SHEET]);
 
@@ -393,7 +380,7 @@ describe('ogm-attributes', () => {
 
         await page(root, waitForChanges, 'next');
 
-        expect(title(root)).toEqual('San Jose');
+        expect(title(root)).toEqual('SB 25');
         expect(count(root)).toEqual('(2/2)');
       });
     });

--- a/src/components/ogm-attributes/ogm-attributes.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.tsx
@@ -128,7 +128,6 @@ export class OgmAttributes {
   private renderHeader(feature: MapGeoJSONFeature) {
     const multiple = this.features.length > 1;
     const title = getFeatureTitle(feature);
-    if (!multiple && !title) return;
 
     return (
       <div class="header">
@@ -137,7 +136,6 @@ export class OgmAttributes {
             <wa-icon name="arrow-left" label="Previous feature" canvas="auto"></wa-icon>
           </wa-button>
         )}
-        {/* Rendered even with nothing to say, so the controls stay at the ends of the row */}
         <div class="title">{title}</div>
         {multiple && (
           <div class="count">

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -26,17 +26,12 @@ export const dedupeFeatures = (features: readonly MapGeoJSONFeature[]): MapGeoJS
   });
 };
 
-// Preference order for feature properties used to render the popup title
-// when inspecting the feature. These are just commonly used names for
-// properties, we prefer an explicit 'title' but will take anything
-// reasonable that we find. More descriptive is better.
-const TITLE_KEYS = ['title', 'name', 'label', 'id'] as const;
-
-// Derive a title for a feature from its properties, using the first match
-// from TITLE_KEYS in the order listed above. Used by the attributes popup.
+// Derive a title for a feature. If there is an explicit label in the data
+// (e.g. from an OpenIndexMap, where it indicates the sheet name), we use that.
+// Otherwise we fall back to the (potentially auto-generated) feature id, which
+// is guaranteed to be present. Other attributes like "title" are used inconsistently
+// across different data sources, so we don't rely on them.
 export const getFeatureTitle = (feature: MapGeoJSONFeature): string | undefined => {
-  const originalKeys = Object.keys(feature.properties || {});
-  if (originalKeys.length === 0) return;
-  const key = TITLE_KEYS.map(k => originalKeys.find(ok => ok.toLowerCase() === k)).find(Boolean);
-  if (key) return feature.properties?.[key];
+  if (feature.properties?.label) return feature.properties.label;
+  return `Feature ${feature.id}`;
 };


### PR DESCRIPTION
Use the feature ID if there's no title, and use the map sheet
name or label if there is one.

Closes #150
