### PR TITLE
Start a new record's previews on their first tab

### DIFF
--- a/src/components/ogm-previews/ogm-previews.test.tsx
+++ b/src/components/ogm-previews/ogm-previews.test.tsx
@@ -28,18 +28,21 @@ const buildRecord = (previewable: boolean) =>
       : {}),
   });
 
-const renderPreviews = async (record?: OgmRecord, previewers?: AnyPreviewer[]) => {
+// The element itself, for a test that goes on to hand it a second record
+const mountPreviews = async (record?: OgmRecord, previewers?: AnyPreviewer[]) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   // The mounted <ogm-map> logs a swallowed WebGL init error; keep test output clean
   const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
   await stencilRender(<ogm-previews record={record} previewers={previewers}></ogm-previews>, container);
-  const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
+  const el = container.firstElementChild as HTMLElement & { record?: OgmRecord; componentOnReady?: () => Promise<unknown> };
   await el.componentOnReady?.();
   await flush();
   consoleError.mockRestore();
-  return el.shadowRoot as ShadowRoot;
+  return el;
 };
+
+const renderPreviews = async (record?: OgmRecord, previewers?: AnyPreviewer[]) => (await mountPreviews(record, previewers)).shadowRoot as ShadowRoot;
 
 // Previews built by hand rather than worked out from a record - and built in this test's own module
 // realm, not the one the components came from, which is exactly the position an application putting
@@ -75,16 +78,34 @@ const renderPreviewChild = async (record: OgmRecord) => {
   return preview.shadowRoot as ShadowRoot;
 };
 
-// A minimal Aardvark record whose only reference is the given previewable one
-const buildRecordWith = (references: Record<string, string>) =>
+// A minimal Aardvark record whose only references are the given previewable ones
+const buildRecordWith = (references: Record<string, string>, id = 'test-record') =>
   new OgmRecord({
-    id: 'test-record',
+    id,
     dct_title_s: 'Test Record',
     gbl_resourceClass_sm: ['Datasets'],
     dct_accessRights_s: 'Public',
     gbl_mdVersion_s: 'Aardvark',
     dct_references_s: JSON.stringify(references),
   });
+
+// Which preview each tab claims to have chosen, and which one is actually on show
+const highlighted = (shadowRoot: ShadowRoot) =>
+  Array.from(shadowRoot.querySelectorAll('wa-tab'))
+    .filter(tab => tab.active)
+    .map(tab => tab.panel);
+const showing = (shadowRoot: ShadowRoot) =>
+  Array.from(shadowRoot.querySelectorAll('wa-tab-panel'))
+    .filter(panel => panel.active)
+    .map(panel => panel.name);
+
+// Stand in for the user picking a tab. wa-tab-group does this itself in a browser, through a click
+// handler that wants layout this DOM doesn't do, so the state such a click leaves behind is set by
+// hand here - that state is exactly what a later render has to clear.
+const openTab = (shadowRoot: ShadowRoot, index: number) => {
+  Array.from(shadowRoot.querySelectorAll('wa-tab')).forEach((tab, idx) => (tab.active = idx === index));
+  Array.from(shadowRoot.querySelectorAll('wa-tab-panel')).forEach((panel, idx) => (panel.active = idx === index));
+};
 
 describe('ogm-previews', () => {
   it('renders a tab for a record supplied at initial render', async () => {
@@ -133,6 +154,37 @@ describe('ogm-previews', () => {
     expect(tabs.map(tab => tab.textContent?.trim())).toEqual(['IIIF Image', 'GeoJSON']);
     expect(tabs.map(tab => tab.getAttribute('panel'))).toEqual(panels.map(panel => panel.getAttribute('name')));
     expect(shadowRoot.querySelectorAll('ogm-preview')).toHaveLength(2);
+  });
+
+  // A change of record is a change of previews, and the strip has to start over on the first of
+  // them. wa-tab-group tracks which tab is active itself, in a property no render of ours writes,
+  // so a strip left standing across the change went on pointing at the tab the user had picked -
+  // the second of a record that offers other previews there, or none at all.
+  it('starts the new record on its first preview, whichever tab was open on the last one', async () => {
+    const el = await mountPreviews(
+      buildRecordWith({
+        'http://iiif.io/api/image': 'https://example.com/iiif/info.json',
+        'https://openindexmaps.org': 'https://example.com/index.geojson',
+        'http://geojson.org/geojson-spec.html': 'https://example.com/data.json',
+        'https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames': 'https://example.com/{z}/{x}/{y}.png',
+      }),
+    );
+    const shadowRoot = el.shadowRoot as ShadowRoot;
+    openTab(shadowRoot, 1);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const loaded = new Promise(resolve => el.addEventListener('previewsLoaded', resolve, { once: true }));
+    el.record = buildRecordWith(
+      { 'http://iiif.io/api/image': 'https://example.com/other/info.json', 'http://geojson.org/geojson-spec.html': 'https://example.com/other.json' },
+      'other-record',
+    );
+    await loaded;
+    await flush();
+    consoleError.mockRestore();
+
+    expect(showing(shadowRoot)).toEqual(['other-record-iiif-image-image']);
+    // Nothing left drawn as the chosen tab but for the preview actually on show
+    expect(highlighted(shadowRoot).filter(panel => !showing(shadowRoot).includes(panel))).toEqual([]);
   });
 
   // For an application that has the data already and doesn't want the record-driven path. The tab

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -73,7 +73,15 @@ export class OgmPreviews {
     }
   }
 
-  // Render as tabs for switching between previews
+  // Render as tabs for switching between previews.
+  //
+  // Keyed by which preview each element draws, not by where it sits. Position is the wrong identity
+  // twice over: a tab and its panel are siblings inside the group, so numbering both from zero gave
+  // it two children under every key and the diff went on to reuse a tab where a panel belonged. And
+  // wa-tab-group tracks which tab is active itself, in a property no render of ours writes, so a
+  // group left standing across a change of previews keeps pointing at whichever tab the user had
+  // picked - the third one of a record that now offers two. Keying the group by the whole set
+  // replaces it outright when the previews change, which is the only way to clear that.
   render() {
     const tabs = this.tabs;
     if (!tabs.length) return;
@@ -81,14 +89,14 @@ export class OgmPreviews {
     return (
       <Host class={waScope(this.theme)}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <wa-tab-group>
-          {tabs.map((previewer, idx) => (
-            <wa-tab key={idx} panel={previewer.previewId}>
+        <wa-tab-group key={tabs.map(previewer => previewer.previewId).join()}>
+          {tabs.map(previewer => (
+            <wa-tab key={`tab-${previewer.previewId}`} panel={previewer.previewId}>
               {previewer.label()}
             </wa-tab>
           ))}
           {tabs.map((previewer, idx) => (
-            <wa-tab-panel key={idx} name={previewer.previewId} active={idx === 0}>
+            <wa-tab-panel key={`panel-${previewer.previewId}`} name={previewer.previewId} active={idx === 0}>
               <ogm-preview theme={this.theme} previewer={previewer} sidebar-padding={this.sidebarPadding}></ogm-preview>
             </wa-tab-panel>
           ))}


### PR DESCRIPTION
Open an index map fixture, switch to its index map tab, then load another record: the tab strip and
the panel it shows disagree. With Dalian followed by Siberia, the Location tab is drawn as the chosen
one while the image preview is what's actually on show.

## What was wrong

Two causes, both of keying the strip by position.

A tab and its panel are siblings inside the one `wa-tab-group`, and both lists numbered from zero, so
the group had two children under every key. Going from Dalian's four previews to Siberia's two, the
diff matched the wrong ones: Dalian's second tab was reused as Siberia's Location tab with the
group's active flag still on it, its index map panel became the location panel with that panel's flag
still set, and the image got a new panel, also active. Two panels showing at once, under a highlight
belonging to neither.

And `wa-tab-group` tracks which tab is active itself, in properties no render of ours writes, so a
group left standing across a change of previews goes on pointing at whichever tab the user had
picked - the third one of a record that now offers two. Unique keys alone don't reach that.

## What changed

Each tab and panel is keyed by the preview it draws, and the group by the whole set - which replaces
it outright when the previews change and lets it pick its first tab afresh. A render that leaves the
set alone (a theme toggle, a sidebar resize) keys the same, so the user stays on the tab they chose.

The relocation the botched diff did also disconnected live `ogm-map` elements mid-render, so
maplibre's teardown threw `Cannot read properties of undefined (reading 'destroy')` on every record
change. That's gone with it.

## Notes for review

Verified in the browser against the demo fixtures: the reported Dalian -> Siberia case, Siberia ->
Dalian, NW Europe (a georeferenced manifest, two previews of one resource), Nepal (location only),
and a theme toggle and sidebar toggle while parked on a later tab. In every case exactly one tab is
highlighted and it names the panel on show.

The regression test sets up the state a tab click leaves behind by hand rather than clicking:
`wa-tab-group`'s click handling wants layout happy-dom doesn't do, so a real click there moves
nothing. That's commented at `openTab`. The test fails on the old render (two active panels) and
passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)