### PR TITLE
Leave the theme's padding around every preview

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Here are the supported properties and what they apply to:
 | `--ogm-fill-opacity`           | Initial opacity of drawn data                        |
 | `--ogm-fill-highlight-opacity` | Opacity of a highlighted feature                     |
 | `--ogm-bounds-opacity`         | Initial opacity of a bounding box or index map       |
-| `--ogm-padding`                | Gap kept between the data and the map edge (pixels)  |
+| `--ogm-padding`                | Gap kept between the data and the view edge (pixels) |
 
 By default, the viewer uses styles from [Web Awesome](https://webawesome.com/) that match the current mode (dark or light). Anything you override will be used in both modes.
 

--- a/src/components/ogm-image/ogm-image.test.tsx
+++ b/src/components/ogm-image/ogm-image.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, h, vi, beforeEach, afterEach } from '@stencil/vitest';
+
+// Rendered with Stencil's low-level render for the same reason <ogm-map>'s tests are: componentDidLoad
+// throws here, since OpenSeadragon can't build a viewer without a canvas to draw on, and the wrapper
+// would re-throw it. What's left is a mounted component with no viewer of its own, which is the state
+// an <ogm-image> is in for real until componentDidLoad has run.
+import { render as stencilRender } from '@stencil/core';
+
+// Enough of an OpenSeadragon viewer to set the room around a scan on, and to be taken down afterwards
+const fakeViewer = () => ({ viewport: { setMargins: vi.fn() }, destroy: vi.fn() });
+
+const containers: HTMLElement[] = [];
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  containers.splice(0).forEach(container => container.remove());
+  consoleError.mockRestore();
+});
+
+const renderImage = async () => {
+  const container = document.createElement('div');
+  containers.push(container);
+  document.body.appendChild(container);
+  await stencilRender(<ogm-image></ogm-image>, container);
+  const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown> };
+  await el.componentOnReady?.();
+  consoleError.mockClear();
+  return { container, el };
+};
+
+const marginsOf = (el: HTMLElement) => (el as unknown as { viewer: ReturnType<typeof fakeViewer> }).viewer.viewport.setMargins;
+const applyPadding = (el: HTMLElement) => (el as unknown as { onPaddingChange: () => Promise<void> }).onPaddingChange();
+
+describe('ogm-image', () => {
+  // Left to itself OpenSeadragon fits a scan flush against the edges of the viewer, so the edges of
+  // the sheet - which is often what a reader is looking for - are the first thing lost
+  it('keeps the theme’s gap on every edge of a scan', async () => {
+    const { el } = await renderImage();
+    el.style.setProperty('--ogm-padding', '50');
+    Object.assign(el, { viewer: fakeViewer() });
+
+    await applyPadding(el);
+
+    expect(marginsOf(el)).toHaveBeenCalledWith({ top: 50, bottom: 50, right: 50, left: 50 });
+  });
+
+  // OpenSeadragon replaces the whole set of margins with whatever it's handed, so the left edge has to
+  // carry both the gap and the sidebar rather than the sidebar alone
+  it('adds what the sidebar covers to the gap on the left', async () => {
+    const { el } = await renderImage();
+    el.style.setProperty('--ogm-padding', '50');
+    Object.assign(el, { viewer: fakeViewer(), padding: 400 });
+
+    await applyPadding(el);
+
+    expect(marginsOf(el)).toHaveBeenCalledWith({ top: 50, bottom: 50, right: 50, left: 450 });
+  });
+});

--- a/src/components/ogm-image/ogm-image.tsx
+++ b/src/components/ogm-image/ogm-image.tsx
@@ -8,6 +8,7 @@ import { getElement, findElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
 import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
 import type ImagePreviewer from '../../lib/previewers/image';
+import Theme from '../../lib/themes/theme';
 
 @Component({
   tag: 'ogm-image',
@@ -26,13 +27,20 @@ export class OgmImage {
   // OpenSeadragon viewer instance
   private viewer: Viewer;
 
+  // Where the gap left around a scan comes from, the same place a map's comes from
+  private imageTheme: Theme;
+
   // Guards against reporting more than one error per load attempt
   private errorReported: boolean = false;
 
   // Set up OpenSeadragon viewer on load
   async componentDidLoad() {
+    this.imageTheme = new Theme(this.el, this.theme);
     this.viewer = new Viewer({
       element: getElement(this.el, '#openseadragon'),
+      // Given to the viewer rather than set afterwards: OpenSeadragon works out where "home" is from
+      // the margins in place when an image opens, and setMargins() doesn't refit one already open.
+      viewportMargins: this.margins(),
       prefixUrl: 'https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.2/images/',
       visibilityRatio: 1,
       sequenceMode: true,
@@ -73,12 +81,22 @@ export class OgmImage {
 
   @Watch('padding')
   async onPaddingChange() {
+    if (!this.viewer) return;
+
     // Move the filmstrip if there is one
     const filmstrip = findElement(this.el, '.referencestrip');
     if (filmstrip) filmstrip.style.setProperty('margin-left', `${this.padding}px`);
 
     // Move the viewer viewport
-    return await this.viewer.viewport.setMargins({ left: this.padding });
+    return this.viewer.viewport.setMargins(this.margins());
+  }
+
+  // The room to leave around a scan: the theme's gap on every edge, and on the left whatever the
+  // sidebar is covering as well. All four edges every time, because OpenSeadragon replaces the whole
+  // set with what it's given rather than merging it, so a margin left out is a margin set to zero.
+  private margins() {
+    const padding = this.imageTheme.getPadding();
+    return { top: padding, bottom: padding, right: padding, left: padding + this.padding };
   }
 
   // Draw the current preview into the viewer. Reading a manifest is a fetch, so this is where a

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -20,6 +20,23 @@ const feature = {
 // Enough of a MapLibre map for a selection to be drawn on, and to be taken down afterwards
 const fakeMap = () => ({ setFeatureState: vi.fn(), remove: vi.fn() });
 
+// Enough of one to fit bounds on: it can work out a camera for them, it can be moved, and it reports
+// the move as having finished, which is what fitMapBounds waits for before resolving.
+const fittableMap = () => ({
+  cameraForBounds: vi.fn(() => ({ center: [0, 0], zoom: 4 })),
+  fitBounds: vi.fn(),
+  easeTo: vi.fn(),
+  once: vi.fn((_event: string, listener: () => void) => listener()),
+  remove: vi.fn(),
+});
+
+const bounds = [
+  [0, 0],
+  [1, 1],
+];
+
+const fitTo = (el: HTMLElement, mapBounds: number[][]) => (el as unknown as { fitMapBounds: (bounds: number[][]) => Promise<void> }).fitMapBounds(mapBounds);
+
 const containers: HTMLElement[] = [];
 let consoleError: ReturnType<typeof vi.spyOn>;
 
@@ -85,6 +102,30 @@ describe('ogm-map', () => {
     selectInOwnPopup(el);
 
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  // Left to itself MapLibre fits bounds to the very edges of the canvas, which puts a record's own
+  // edges - an index map's outermost sheets, a bounding box's corners - half off the map
+  it('keeps the theme’s gap between the bounds it fits and the edge of the map', async () => {
+    const { el } = await renderMap();
+    el.style.setProperty('--ogm-padding', '50');
+    Object.assign(el, { map: fittableMap() });
+
+    await fitTo(el, bounds);
+
+    expect((el as unknown as { map: ReturnType<typeof fittableMap> }).map.fitBounds).toHaveBeenCalledWith(bounds, { padding: 50 });
+  });
+
+  // What the sidebar covers is the map's own padding, which MapLibre already takes off the space it
+  // fits into. Asking for it here as well would fit the preview into a viewport that much narrower.
+  it('leaves the room the sidebar takes out of what it asks for', async () => {
+    const { el } = await renderMap();
+    el.style.setProperty('--ogm-padding', '50');
+    Object.assign(el, { map: fittableMap(), padding: 400 });
+
+    await fitTo(el, bounds);
+
+    expect((el as unknown as { map: ReturnType<typeof fittableMap> }).map.fitBounds).toHaveBeenCalledWith(bounds, { padding: 50 });
   });
 
   // The popup is built by hand rather than rendered, so it outlives the component's own markup

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -231,16 +231,21 @@ export class OgmMap {
 
   // Fit the map to the given bounds; resolve once the move finishes
   async fitMapBounds(bounds: maplibregl.LngLatBoundsLike) {
-    if (!this.map.cameraForBounds(bounds)) return;
+    // The theme's gap, on all four edges, so a record's own edges read as edges instead of running
+    // off the canvas. Only the theme's: what the sidebar covers is the map's own padding (see
+    // onPaddingChange), and MapLibre already takes that off the space it fits bounds into.
+    const padding = this.mapTheme.getPadding();
+    if (!this.map.cameraForBounds(bounds, { padding })) return;
     return new Promise<void>(resolve => {
       this.map.once('moveend', () => resolve());
-      this.map.fitBounds(bounds);
+      this.map.fitBounds(bounds, { padding });
     });
   }
 
   // When padding is changed, move the map over to make room for the sidebar
   @Watch('padding')
   async onPaddingChange() {
+    if (!this.map) return;
     return await this.easeMapTo({ padding: { left: this.padding } });
   }
 

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -4,7 +4,6 @@ import Theme from './theme';
 
 export type MapLibreStyle = {
   // Generic properties used for all data
-  padding: string;
   opacity: number;
   // CSS colors used for polygons & circles
   fillColor: string;
@@ -61,7 +60,6 @@ export default class MapLibreTheme extends Theme {
    */
   getStyle(): MapLibreStyle {
     return {
-      padding: this.readCssProperty('--ogm-padding') || this.readCssProperty('--wa-space-xl'),
       opacity: this.readCssNumber('--ogm-fill-opacity', 0.8),
       fillColor: this.themedColor('--ogm-fill-color', '--wa-color-blue-50', '--wa-color-blue-80'),
       fillHighlightColor: this.themedColor('--ogm-fill-highlight-color', '--wa-color-cyan-60', '--wa-color-cyan-80'),

--- a/src/lib/themes/theme.test.tsx
+++ b/src/lib/themes/theme.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import Theme from './theme';
+
+// A theme reading from an element carrying the given custom properties; see maplibre.test.tsx for
+// why the properties go on the element itself rather than on an ancestor.
+const themed = (tokens: Record<string, string> = {}) => {
+  const el = document.createElement('div');
+  Object.entries(tokens).forEach(([name, value]) => el.style.setProperty(name, value));
+  document.body.appendChild(el);
+  return new Theme(el);
+};
+
+describe('Theme', () => {
+  describe('padding', () => {
+    it('reads an override', () => {
+      expect(themed({ '--ogm-padding': '64' }).getPadding()).toBe(64);
+    });
+
+    // Both renderers hand this to a camera, so it has to be a pixel count either way
+    it('keeps the default when the property is unset or unparseable', () => {
+      expect(themed().getPadding()).toBe(32);
+      expect(themed({ '--ogm-padding': 'var(--wa-space-xl)' }).getPadding()).toBe(32);
+    });
+
+    // An app that asks for no gap has asked for something, so it isn't read as having asked for nothing
+    it('honors an override of zero', () => {
+      expect(themed({ '--ogm-padding': '0' }).getPadding()).toBe(0);
+    });
+  });
+});

--- a/src/lib/themes/theme.ts
+++ b/src/lib/themes/theme.ts
@@ -1,5 +1,13 @@
-// Extracts style values from the DOM/CSS for use in previewers
-export default abstract class Theme {
+// How much room to leave around a preview when nothing names an amount, in CSS pixels. A number
+// rather than a Web Awesome token, unlike the colors: `--wa-space-xl` computes to `calc(1 * 2rem)`,
+// and what reads this wants a pixel count to hand a camera, not a length to resolve. 32 is what
+// that token comes out to at the default space scale.
+const defaultPadding = 32;
+
+// Extracts style values from the DOM/CSS for use in previewers. Usable on its own, for a renderer
+// that wants nothing beyond what every renderer reads: <ogm-image> only needs the padding, and
+// OpenSeadragon has no style document of its own for a subclass to describe.
+export default class Theme {
   protected element: Element;
 
   // Which way the component drawing this was told to render, if it was told. Mutable because a
@@ -12,8 +20,12 @@ export default abstract class Theme {
     this.theme = theme;
   }
 
-  // Returns style properties for this theme
-  abstract getStyle(): Record<string, any>;
+  // How much room to leave between what a preview draws and the edge of the view, in CSS pixels.
+  // Read by whatever points the view - a map fitting a record's bounds, an image viewer fitting a
+  // scan - so that a preview's own edges can be seen as edges rather than running off the view.
+  getPadding(): number {
+    return this.readCssNumber('--ogm-padding', defaultPadding);
+  }
 
   // Check if we're in dark mode. The component's own answer wins: `color-scheme` comes from the Web
   // Awesome stylesheet, which is linked into a shadow root and so may not have loaded by the time a

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -24,6 +24,7 @@ if (!HTMLElement.prototype.attachInternals) {
 // the wa-* elements the component imports for itself, which do get upgraded here.
 import './dist/components/ogm-alerts.js';
 import './dist/components/ogm-attributes.js';
+import './dist/components/ogm-image.js';
 import './dist/components/ogm-layers.js';
 import './dist/components/ogm-map.js';
 import './dist/components/ogm-menubar.js';


### PR DESCRIPTION
Closes #146.

`--ogm-padding` has been in the theme (and documented in the readme) since themes were extracted, and nothing has ever read it. MapLibre's `fitBounds()` defaults to no padding, so a map zoomed right up to the edges of a record's bounds; OpenSeadragon fits a scan flush against the edges of the viewer. An index map lost its outermost sheets to the canvas edge, a bounding box its corners, and a scan its margins.

### What changed

- The value moves off `MapLibreStyle` onto `Theme`. It says how the view is pointed rather than how data is drawn, and both renderers need it — so it lives where both can read it, and `Theme` no longer declares an abstract `getStyle()`, which lets `<ogm-image>` use it directly (OpenSeadragon has no style document for a subclass to describe).
- It's now a pixel count rather than a CSS length. `--wa-space-xl` computes to `calc(1 * 2rem)`, which isn't something a camera can be handed, so the fallback is the 32px that token resolves to at the default space scale — the same shape as `--ogm-text-size`, which the readme already documents in pixels.
- `<ogm-map>` passes it to `cameraForBounds`/`fitBounds`. The sidebar stays out of that ask: what it covers is the map's own padding, which MapLibre already takes off the space it fits bounds into, so asking for it twice would fit the preview into a viewport that much narrower.
- `<ogm-image>` sets it as viewport margins, given to the viewer at construction because OpenSeadragon decides where "home" is from the margins in place when an image opens. There the left margin carries the gap *and* the sidebar, and all four edges are set every time, since `setMargins()` replaces the whole set rather than merging it.

### Verification

Measured in a real browser against the Peatland index map and the Siberia IIIF manifest — the gap, in CSS pixels, between the preview's own edges and the edge of the view:

| | before | after |
| --- | --- | --- |
| index map (top/bottom) | 12 / 13 | 40 / 41 |
| IIIF scan (top/bottom) | 0 / 0 | 32 / 32 |

The map's 40 rather than 32 is the globe's curvature between the bounds' corner and its edge; `--ogm-padding: 80` moves it to 84, and setting it to 0 gives the old flush behavior back. With the sidebar open the map is fit into `{left: 432, right: 32}` and the scan into margins of `{left: 432, top/right/bottom: 32}` — the sidebar's 400 counted once, not twice. Maps in inactive tab panels (zero-sized canvases) still fit without MapLibre's "cannot fit within canvas" warning.

New tests cover the theme's read of the property, both renderers' wiring, and the sidebar composition for each. `npm test` (683 tests) and `npm run lint` pass against a production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)