### PR TITLE
Say so when a COG's tiles can't be drawn

### DIFF
--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -165,6 +165,16 @@ export class OgmMap {
     // that can change without the style document being rebuilt
     this.applyViewConstraints();
 
+    // A preview that paints with its own WebGL - deck.gl's COG overlay - has no MapLibre source to
+    // report on, and only finds out it can't be drawn once its tiles start arriving, after preview()
+    // below has resolved. Give it the same alert a failed load gets. Bound to the previewer it came
+    // from rather than to whichever is current, so a tile of the record we just left can't report
+    // against the one that replaced it.
+    const previewer = this.previewer;
+    previewer.onError = error => {
+      if (this.previewer === previewer) this.reportError(error);
+    };
+
     try {
       // The style is only known now: it comes out of the theme, and the theme can change under a
       // preview that is already on screen

--- a/src/lib/previewers/cog-deck.test.ts
+++ b/src/lib/previewers/cog-deck.test.ts
@@ -234,6 +234,71 @@ describe('DeckCogPreviewer', () => {
     });
   });
 
+  // deck.gl only finds out a COG can't be drawn once its tiles start arriving, which is after
+  // preview() has resolved - so before this the map stayed empty and the reason only reached the
+  // console. See https://github.com/OpenGeoMetadata/ogm-viewer/issues/158, where a band-separate COG
+  // failed every tile this way.
+  describe('a tile that fails', () => {
+    // One error per prop call, since deck.gl reports each failed tile separately
+    const failTile = (previewer: TestDeckCogPreviewer, error: unknown = new Error('Band-separate images not yet implemented.')) =>
+      previewer.overlay.lastLayers[0].props.onTileError(error);
+
+    const drawTile = (previewer: TestDeckCogPreviewer) => previewer.overlay.lastLayers[0].props.onTileLoad({});
+
+    it('fails the preview when nothing has been drawn', async () => {
+      const { previewer } = previewFor();
+      const reported: unknown[] = [];
+      previewer.onError = error => reported.push(error);
+      await previewer.preview();
+
+      failTile(previewer);
+
+      expect(reported).toEqual([new Error('Band-separate images not yet implemented.')]);
+    });
+
+    // A COG can be sparse by design, and a hole in a preview the user can see is not worth replacing
+    // that preview with an error
+    it('is left alone once some of the COG is on screen', async () => {
+      const { previewer } = previewFor();
+      const reported: unknown[] = [];
+      previewer.onError = error => reported.push(error);
+      await previewer.preview();
+
+      drawTile(previewer);
+      failTile(previewer);
+
+      expect(reported).toEqual([]);
+    });
+
+    // deck.gl drops a cancelled tile before calling back, but a decoder that notices the abort itself
+    // can still throw one - and a pan that abandons its reads is not a failed preview
+    it('ignores an aborted read', async () => {
+      const { previewer } = previewFor();
+      const reported: unknown[] = [];
+      previewer.onError = error => reported.push(error);
+      await previewer.preview();
+
+      failTile(previewer, new DOMException('The user aborted a request.', 'AbortError'));
+
+      expect(reported).toEqual([]);
+    });
+
+    // A fresh load attempt starts over: the tiles of the last one are gone from the overlay
+    it('fails again after the preview is drawn a second time', async () => {
+      const { map, previewer } = previewFor();
+      const reported: unknown[] = [];
+      previewer.onError = error => reported.push(error);
+      await previewer.preview();
+      drawTile(previewer);
+
+      previewer.attach(map as unknown as maplibregl.Map, style);
+      await previewer.preview();
+      failTile(previewer);
+
+      expect(reported).toHaveLength(1);
+    });
+  });
+
   it('takes its layer off the overlay when cleared', async () => {
     const { previewer } = previewFor();
     await previewer.preview();

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -48,12 +48,18 @@ export default class DeckCogPreviewer extends MapPreviewer {
   // open file instead of reading its header again.
   protected geotiff: GeoTIFF | undefined;
 
+  // Whether any tile of this COG has been drawn, which is what tells a COG that can't be drawn at
+  // all from one tile of it that couldn't. Reset per attach, alongside everything else a fresh load
+  // attempt starts over. See reportTileError.
+  protected anyTileDrawn = false;
+
   attach(map: maplibregl.Map, style: MapLibreStyle): this {
     super.attach(map, style);
     this.deckOverlay = this.getDeckOverlay();
     this.decoderPool ??= this.createDecoderPool();
     this.drawnState = { visible: true, opacity: style.opacity };
     this.geotiffBoundsLoaded = new Promise(resolve => (this.resolveGeotiffBounds = resolve));
+    this.anyTileDrawn = false;
     return this;
   }
 
@@ -130,9 +136,33 @@ export default class DeckCogPreviewer extends MapPreviewer {
           [east, north],
         ]);
       },
+      onTileLoad: () => (this.anyTileDrawn = true),
+      onTileError: (error: unknown) => this.reportTileError(error),
       parameters: { depthCompare: 'always', cullMode: 'back' },
       pool: this.decoderPool,
     });
+  }
+
+  // A COG can only fail once its tiles start arriving, which is after preview() has resolved - so a
+  // file deck.gl refuses to draw used to leave the map empty with the reason only in the console.
+  // deck.gl reports each such tile here; overriding it also takes over from its own handler, which
+  // logs every one of them.
+  //
+  // Only the first failure of a COG that has drawn nothing is worth an alert. A COG can be sparse by
+  // design, and a tile that failed among tiles that didn't means a hole in a preview the user can
+  // see rather than a preview that isn't there - not worth replacing with an error. deck.gl drops a
+  // cancelled tile before calling back, so a pan that abandons its reads never arrives here at all,
+  // but a decoder that notices the abort itself can still throw one.
+  protected reportTileError(error: unknown) {
+    if ((error as { name?: unknown } | null)?.name === 'AbortError') return;
+
+    if (this.anyTileDrawn) {
+      console.warn(`Could not draw a tile of ${this.url}:`, error);
+      return;
+    }
+
+    console.error(`Error drawing ${this.url}:`, error);
+    this.onError?.(error);
   }
 
   // Disable the web worker decoder pool; it appears to error because it can't find /worker.js.

--- a/src/lib/previewers/map.ts
+++ b/src/lib/previewers/map.ts
@@ -42,6 +42,14 @@ export default abstract class MapPreviewer extends Previewer {
   protected style: MapLibreStyle;
   protected map: maplibregl.Map;
 
+  // Where a failure that arrives after preview() has already resolved goes. Everything MapLibre
+  // draws itself reports one on the map, which ogm-map is already listening to; a preview that
+  // paints with its own WebGL has no such channel, so it is handed one. Set by whoever draws this
+  // preview, and only worth reporting for the failures that mean the preview isn't there - see
+  // DeckCogPreviewer, which has tiles arriving one at a time and most of a viewport's worth of
+  // failures to say nothing about.
+  onError?: (error: unknown) => void;
+
   // Stored state for added MapLibre sources and layers to allow for cleanup
   sourceIds: string[] = [];
   layerIds: string[] = [];


### PR DESCRIPTION
Every other preview reports a failure through `<ogm-preview>`'s alert. A COG drawn by deck.gl had one path there — a file that refused to be opened, which rejects `preview()` — and nothing for the failures that arrive after that. Tiles come in one at a time, and deck.gl reports one it couldn't build by calling `onTileError` rather than by rejecting anything. Left unhandled, its own handler logs the tile and the map stays empty: a record zoomed to the right place with no layer on it and no reason given.

That's what #158 looks like from the outside. Diagnosis of the file in that issue, for the record:

| | |
|---|---|
| CRS | EPSG:3857 |
| Bands | 4 × Byte, photometric RGB, band 4 `ColorInterp=Alpha`, `ExtraSamples=2` |
| Interleave | **`BAND` / `PlanarConfiguration=2`** ← the trigger |
| Compression | JPEG, including the alpha band |
| Transparency | a real 4th alpha band, no internal TIFF mask |

Transparency isn't the problem; interleaving is. `@developmentseed/deck.gl-geotiff` throws `Band-separate images not yet implemented.` for that layout, so every tile fails the same way. **The fix for that file is upstream — developmentseed/deck.gl-raster#635, open and green.** This PR is the other half: the viewer having something to say when a COG can't be drawn, whatever the reason.

## What changed

- **`MapPreviewer.onError`** — where a failure that arrives after `preview()` has resolved goes. Nothing MapLibre draws needs it; it fires those on the map itself, which `<ogm-map>` has listened to since alerts existed. This is for the previews that paint with their own WebGL and have no such channel.
- **`<ogm-map>`** binds it to the same `reportError()` a failed load takes, so a viewport's worth of failing tiles produces one alert rather than forty — that dedupe already existed. Bound to the previewer it came from rather than to whichever is current, so a tile of the record the user just left can't report against the one that replaced it.
- **`DeckCogPreviewer`** takes `onTileError` and `onTileLoad`.

## Two judgement calls

**Only the first failure of a COG that has drawn nothing reaches the alert.** A COG can be sparse by design, and the alert covers the map completely — so a tile that failed among tiles that didn't would replace a working preview with an error about a hole in it. Those are logged and left alone. Without this the change would be a regression for sparse COGs.

**Aborted reads are dropped.** deck.gl discards a cancelled tile before calling back, so a pan that abandons its reads never arrives here; but a decoder that notices the abort itself can still throw one, and that isn't a failed preview.

## What the user sees

The message is deck.gl's own, through `referenceError`:

> **The Cloud Optimized GeoTIFF preview couldn't be read**
> Band-separate images not yet implemented.
> `https://geobtaa-assets-prod.s3.us-east-2.amazonaws.com/store/asset/04d-02/mdu-057027-0001-croputm31_cog.tif`

Cryptic for this case in particular. Translating it would mean matching on an upstream string that developmentseed/deck.gl-raster#635 deletes, so it stays as it is — happy to add a mapping in `errors.ts` if you'd rather.

## Testing

Four cases in `cog-deck.test.ts` covering all of the above: reports when nothing has drawn, stays quiet once some of the COG is on screen, ignores an `AbortError`, and reports again after a second load attempt. Full suite green (612 unit, 98 component) and `npm run lint` clean.

Checked in the browser against the record from #158 — one alert, not one per tile — and against the Tibet COG, which still draws with no alert and clears the previous one.

Note that #158 stays open until the upstream fix ships and we bump `@developmentseed/deck.gl-geotiff` and `@developmentseed/geotiff` (we're on 0.7.0; that PR targets 0.8.0-beta.2, so expect other API changes in the bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
