### PR TITLE
Call a feature nobody named a feature

### DIFF
--- a/src/components/ogm-attributes/ogm-attributes.test.tsx
+++ b/src/components/ogm-attributes/ogm-attributes.test.tsx
@@ -176,7 +176,7 @@ describe('ogm-attributes', () => {
       const { root, waitForChanges } = await render(<ogm-attributes features={UNLABELED}></ogm-attributes>);
 
       expect(pagers(root)).toHaveLength(2);
-      expect(title(root)).toEqual('Feature am002175');
+      expect(title(root)).toEqual('Feature');
 
       await page(root, waitForChanges, 'next');
 

--- a/src/lib/features.test.ts
+++ b/src/lib/features.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@stencil/vitest';
 import type { MapGeoJSONFeature } from 'maplibre-gl';
 
-import { dedupeFeatures } from './features';
+import { dedupeFeatures, getFeatureTitle } from './features';
 
 const SOURCE = 'ark-77981-gmgscj87k49-openindexmap';
 
@@ -77,5 +77,26 @@ describe('dedupeFeatures', () => {
     const three = entry({ id: null as unknown as undefined, properties: { TRACT: '000500' } });
 
     expect(dedupeFeatures([one, two, three])).toEqual([one, two, three]);
+  });
+});
+
+describe('getFeatureTitle', () => {
+  it('calls a feature what the data calls it', () => {
+    expect(getFeatureTitle(entry({ properties: { label: 'SF 20' } }))).toEqual('SF 20');
+  });
+
+  it('calls a feature the data does not name a feature', () => {
+    expect(getFeatureTitle(entry({ id: 12, properties: { TRACT: '000300' } }))).toEqual('Feature');
+  });
+
+  // The bug this row exists to avoid: an /identify response has no features until we ask for them, so
+  // we number the answer to have something to draw the selection from, and the first of them read as
+  // "Feature 0" every time - a number the reader has no way to recognize.
+  it('says nothing of an id nobody put there', () => {
+    expect(getFeatureTitle(entry({ id: 0, properties: { Pixel: '12' } }))).toEqual('Feature');
+  });
+
+  it('has something to call a feature that arrived with no properties at all', () => {
+    expect(getFeatureTitle(entry({ id: undefined, properties: undefined }))).toEqual('Feature');
   });
 });

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -26,12 +26,13 @@ export const dedupeFeatures = (features: readonly MapGeoJSONFeature[]): MapGeoJS
   });
 };
 
-// Derive a title for a feature. If there is an explicit label in the data
-// (e.g. from an OpenIndexMap, where it indicates the sheet name), we use that.
-// Otherwise we fall back to the (potentially auto-generated) feature id, which
-// is guaranteed to be present. Other attributes like "title" are used inconsistently
-// across different data sources, so we don't rely on them.
-export const getFeatureTitle = (feature: MapGeoJSONFeature): string | undefined => {
-  if (feature.properties?.label) return feature.properties.label;
-  return `Feature ${feature.id}`;
-};
+// Derive a title for a feature. An explicit label in the data (e.g. from an OpenIndexMap, where it
+// names the sheet) is what a reader would recognize, so that wins. Other attributes like "title" are
+// used inconsistently across data sources, so we don't rely on them.
+//
+// Failing a label there is nothing to call it, and the id is not a name: it's either one nobody put
+// there - MapLibre numbers a GeoJSON source's features by position, and a server-queried preview has
+// no features until we ask, so those are numbered too, which is why the first of them was always
+// "Feature 0" - or an opaque key like "cugir007741.1". The header already says which of a stack you
+// are looking at, so an unnamed feature is just a feature.
+export const getFeatureTitle = (feature: MapGeoJSONFeature): string => feature.properties?.label || 'Feature';


### PR DESCRIPTION
Closes #159.

The popup titled an unnamed feature with its id, and the id is not a name. Worse for the case in the issue: a server-queried preview has no features until we ask, so we number the answer ourselves and the first one read **Feature 0** every time.

That's not only the identify path. Every id the title could reach is either one nobody put there or an opaque key:

| Preview | Where the id comes from | Title was | Title now |
| --- | --- | --- | --- |
| ESRI Dynamic Map Layer (`/identify`) | `esriIdentifyResultsToFeatures` numbers the rows | `Feature 0` | `Feature` |
| ESRI Image Map Layer (`/identify`) | one pixel, numbered `0` outright | `Feature 0` | `Feature` |
| WMS `GetFeatureInfo` | the server's own key, e.g. `s7st30.2` | `Feature s7st30.2` | `Feature` |
| GeoJSON / ESRI Feature Layer | MapLibre's `generateId`, i.e. position in the file | `Feature 4452` | `Feature` |
| Index map sheet | the sheet's `label` | `SD 18` | `SD 18` |

So the fallback is just `Feature`, which is what the issue suggested. Nothing is lost in a stack: the header already carries `(1/2)` and the pagers, and the table below says which feature this is.

## The judgement call

WMS is the one case where the id came from the data rather than from us, and it goes too. `Feature s7st30.2` is a WFS feature id — stable, and no more a name to a reader than `Feature 0` is. Keeping it would have meant the title showing an id for one kind of preview and not for the others, which is the harder rule to explain. Happy to put it back for that path alone if you'd rather.

The invented ids themselves stay where they are: `dedupeFeatures` identifies by them and the highlight source draws from them. This is only about what the header says.

## Verification

`npm test` (616 unit + 98 component, 4 new) and `npm run lint` are clean.

Clicked through the dev server, reading the rendered `.title` and the features behind it:

- **Glacial Boundaries (ESRI Dynamic Map Layer)** — `Feature`, on a feature still carrying `id: 0`
- **NAIP Imagery (ESRI Image Map Layer)** — `Feature`, same
- **Calaveras Tracts (WMS)** — `Feature (1/2)`, ids `s7st30.2` and `s7st30.18`, highlight and paging as before
- **Neighborhoods (GeoJSON)** — `Feature`, on generated id `4452`
- **Millionth Map (index map)** — `SD 18 (1/7)`, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)