### PR TITLE
Establish the palette inside the shadow root that reads it

### DIFF
--- a/src/components/ogm-alerts/ogm-alerts.tsx
+++ b/src/components/ogm-alerts/ogm-alerts.tsx
@@ -17,13 +17,16 @@ export class OgmAlerts {
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() error?: PreviewError;
 
+  // The callout takes its colors from the scope on .alerts rather than from the one on the Host: a
+  // plain class selector in the stylesheet linked here can't match the host of its own shadow root.
+  // The Host's copy is still what the parent's stylesheet matches, which is what colors :host below.
   render() {
     if (!this.error) return null;
 
     return (
       <Host class={waScope(this.theme)}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <div class="alerts" role="alert" aria-live="assertive">
+        <div class={`alerts ${waScope(this.theme)}`} role="alert" aria-live="assertive">
           <wa-callout variant="danger" appearance="filled-outlined" class="alert">
             <wa-icon slot="icon" name="exclamation-triangle-fill" canvas="auto"></wa-icon>
             <div class="content">

--- a/src/components/ogm-image/ogm-image.test.tsx
+++ b/src/components/ogm-image/ogm-image.test.tsx
@@ -35,12 +35,21 @@ const renderImage = async () => {
 const marginsOf = (el: HTMLElement) => (el as unknown as { viewer: ReturnType<typeof fakeViewer> }).viewer.viewport.setMargins;
 const applyPadding = (el: HTMLElement) => (el as unknown as { onPaddingChange: () => Promise<void> }).onPaddingChange();
 
+// Set a property the theme reads, on the element it reads from - the scope inside the shadow root, not
+// the host. Same reason Theme's own tests declare them on the element under test: happy-dom resolves a
+// custom property set on that element but doesn't inherit one down the tree, and reaching in from the
+// host - which is how an embedding page actually sets these - is inheritance doing its job.
+const setThemeProperty = (el: HTMLElement, property: string, value: string) => {
+  const scope = (el.shadowRoot as ShadowRoot).querySelector('#openseadragon') as HTMLElement;
+  scope.style.setProperty(property, value);
+};
+
 describe('ogm-image', () => {
   // Left to itself OpenSeadragon fits a scan flush against the edges of the viewer, so the edges of
   // the sheet - which is often what a reader is looking for - are the first thing lost
   it('keeps the theme’s gap on every edge of a scan', async () => {
     const { el } = await renderImage();
-    el.style.setProperty('--ogm-padding', '50');
+    setThemeProperty(el, '--ogm-padding', '50');
     Object.assign(el, { viewer: fakeViewer() });
 
     await applyPadding(el);
@@ -52,7 +61,7 @@ describe('ogm-image', () => {
   // carry both the gap and the sidebar rather than the sidebar alone
   it('adds what the sidebar covers to the gap on the left', async () => {
     const { el } = await renderImage();
-    el.style.setProperty('--ogm-padding', '50');
+    setThemeProperty(el, '--ogm-padding', '50');
     Object.assign(el, { viewer: fakeViewer(), padding: 400 });
 
     await applyPadding(el);

--- a/src/components/ogm-image/ogm-image.tsx
+++ b/src/components/ogm-image/ogm-image.tsx
@@ -35,9 +35,14 @@ export class OgmImage {
 
   // Set up OpenSeadragon viewer on load
   async componentDidLoad() {
-    this.imageTheme = new Theme(this.el, this.theme);
+    // #openseadragon rather than the host for the same reason <ogm-map> reads from its container: it
+    // is the element carrying the Web Awesome scope, and the host has no colors on it to read. What
+    // this one reads is only --ogm-padding, which comes from outside either way, but a Theme pointed
+    // at the host is the shape of the bug that left a standalone map drawing in empty colors.
+    const scope = getElement(this.el, '#openseadragon');
+    this.imageTheme = new Theme(scope, this.theme);
     this.viewer = new Viewer({
-      element: getElement(this.el, '#openseadragon'),
+      element: scope,
       // Given to the viewer rather than set afterwards: OpenSeadragon works out where "home" is from
       // the margins in place when an image opens, and setMargins() doesn't refit one already open.
       viewportMargins: this.margins(),
@@ -124,11 +129,14 @@ export class OgmImage {
     this.previewError.emit(referenceError(error, this.previewer.label(), this.previewer.url));
   }
 
+  // The scope goes on #openseadragon as well as on the Host: the palette is established by plain
+  // class selectors, which the stylesheet linked here can't match against its own shadow host. The
+  // controls below and the viewer's own background read from it.
   render() {
     return (
       <Host class={waScope(this.theme)}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <div id="openseadragon">
+        <div id="openseadragon" class={waScope(this.theme)}>
           <div class="controls">
             <wa-button class="zoom-in" size="s" appearance="filled-outlined" pill>
               <wa-icon name="zoom-in" label="Zoom In" canvas="auto"></wa-icon>

--- a/src/components/ogm-map/ogm-map.css
+++ b/src/components/ogm-map/ogm-map.css
@@ -14,6 +14,13 @@
   --ogm-control-size: 29px;
 }
 
+/* Holds the map and the layer panel, and carries the Web Awesome scope for both; see ogm-map.tsx's
+   render. No positioning of its own - it fills the host exactly, so the panel below still resolves
+   its offsets against the same box either way. */
+.container {
+  height: 100%;
+}
+
 #map {
   width: 100%;
   height: 100%;

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -37,6 +37,15 @@ const bounds = [
 
 const fitTo = (el: HTMLElement, mapBounds: number[][]) => (el as unknown as { fitMapBounds: (bounds: number[][]) => Promise<void> }).fitMapBounds(mapBounds);
 
+// Set a property the theme reads, on the element it reads from - the scope inside the shadow root,
+// not the host. Same reason MapLibreTheme's own tests declare them on the element under test: happy-dom
+// resolves a custom property set on that element but doesn't inherit one down the tree, and reaching in
+// from the host - which is how an embedding page actually sets these - is inheritance doing its job.
+const setThemeProperty = (el: HTMLElement, property: string, value: string) => {
+  const scope = (el.shadowRoot as ShadowRoot).querySelector('.container') as HTMLElement;
+  scope.style.setProperty(property, value);
+};
+
 const containers: HTMLElement[] = [];
 let consoleError: ReturnType<typeof vi.spyOn>;
 
@@ -104,11 +113,25 @@ describe('ogm-map', () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  // A map used on its own has to establish the Web Awesome palette for itself, and the classes that do
+  // it are matched by the stylesheet in its own shadow root - which can't match the host of that root.
+  // On the Host alone they establish nothing, and the theme reads every color as the empty string.
+  it('establishes the Web Awesome scope on an element inside its own shadow root', async () => {
+    const { el } = await renderMap();
+    const root = el.shadowRoot as ShadowRoot;
+
+    const scope = root.querySelector('.container') as HTMLElement;
+
+    expect(scope.classList.contains('wa-palette-default')).toBe(true);
+    // Everything drawn has to be under it, the layer panel as much as the map
+    expect(scope.querySelector('#map')).toBeTruthy();
+  });
+
   // Left to itself MapLibre fits bounds to the very edges of the canvas, which puts a record's own
   // edges - an index map's outermost sheets, a bounding box's corners - half off the map
   it('keeps the theme’s gap between the bounds it fits and the edge of the map', async () => {
     const { el } = await renderMap();
-    el.style.setProperty('--ogm-padding', '50');
+    setThemeProperty(el, '--ogm-padding', '50');
     Object.assign(el, { map: fittableMap() });
 
     await fitTo(el, bounds);
@@ -120,7 +143,7 @@ describe('ogm-map', () => {
   // fits into. Asking for it here as well would fit the preview into a viewport that much narrower.
   it('leaves the room the sidebar takes out of what it asks for', async () => {
     const { el } = await renderMap();
-    el.style.setProperty('--ogm-padding', '50');
+    setThemeProperty(el, '--ogm-padding', '50');
     Object.assign(el, { map: fittableMap(), padding: 400 });
 
     await fitTo(el, bounds);

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -4,7 +4,7 @@ import maplibregl from 'maplibre-gl';
 import { closestAcrossShadows, findElement, getElement } from '../../lib/elements';
 import { referenceError, type PreviewError } from '../../lib/errors';
 import GlobeControl from '../../lib/globe-control';
-import { themePreference, waScope, webAwesomeStylesheet } from '../../lib/init';
+import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
 import { dedupeFeatures } from '../../lib/features';
 import { mercatorBbox, type PixelWindow } from '../../lib/geometry';
 import { isLayerDrawn, toLayerControlItems as getLayerControls, type LayerControl, type LayerState } from '../../lib/layers';
@@ -54,6 +54,8 @@ export class OgmMap {
   // MapLibre map instance and popup instance for feature info display
   protected map: maplibregl.Map;
   protected mapTheme: MapLibreTheme;
+  // Resolves once the theme's colors can be read; see webAwesomeReady and loadPreview
+  protected themeReady: Promise<void>;
   protected popup: maplibregl.Popup | undefined = undefined;
   // Watches the popup's contents for a change of size; see createPopup
   protected popupResize: ResizeObserver | undefined = undefined;
@@ -63,7 +65,14 @@ export class OgmMap {
 
   // Set up the mapLibre map and event bindings on load
   componentDidLoad() {
-    this.mapTheme = new MapLibreTheme(this.el, this.theme);
+    // The theme reads from the element carrying the Web Awesome scope, not from the host: see render
+    // for why the host has no colors on it to read. Everything MapLibre draws is inside this element,
+    // so an --ogm-* override set on the host or on the embedding page still reaches it by inheritance.
+    const scope = getElement(this.el, '.container');
+    this.mapTheme = new MapLibreTheme(scope, this.theme);
+    // Asked for here, in the same task that rendered the link, and awaited in loadPreview
+    this.themeReady = webAwesomeReady(getElement(this.el, 'link'), scope);
+
     this.map = new maplibregl.Map({
       container: getElement(this.el, '#map'),
       // The basemaps are CARTO's, over OpenStreetMap data; both require attribution. Compact so it
@@ -176,6 +185,13 @@ export class OgmMap {
     };
 
     try {
+      // Nothing below can be drawn until the colors it would be drawn in can be read, and the
+      // stylesheet they come from is linked into our own shadow root - on a first load it may still
+      // be arriving. Waiting on the MapLibre 'load' event that brought us here is not the same thing:
+      // that waits for a round trip to a tile server, which usually but not always takes longer, and
+      // the redraw after a theme change starts from 'style.load', which is earlier still.
+      await this.themeReady;
+
       // The style is only known now: it comes out of the theme, and the theme can change under a
       // preview that is already on screen
       this.previewer.attach(this.map, this.mapTheme.getStyle());
@@ -513,15 +529,19 @@ export class OgmMap {
   // opens it is one. MapLibre owns the children of #map, so anything Stencil renders in there is
   // fighting it for the same DOM - the reason ogm-attributes has to be built by hand.
   //
-  // The theme class stays on #map, not the Host: the dark-mode rules in ogm-map.css select MapLibre
-  // chrome as descendants of it, and a class on the host element isn't matched by `.wa-dark` from
-  // inside the shadow root.
+  // Everything is wrapped in .container because that is where the Web Awesome scope has to go: the
+  // classes waScope() applies are matched by the stylesheet linked above, and a plain class selector
+  // in a shadow root's stylesheet never matches the host of that root. On the Host alone they would
+  // establish nothing, which is what a bare <ogm-map> used to draw with - every color empty. The
+  // panel needs them as much as the map does, and it isn't inside #map, so the scope goes above both.
   render() {
     return (
       <Host class={waScope(this.theme)}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <div id="map" class={`wa-${this.theme}`}></div>
-        {this.layersPanelOpen && <ogm-layers theme={this.theme} layers={this.layerControls}></ogm-layers>}
+        <div class={`container ${waScope(this.theme)}`}>
+          <div id="map"></div>
+          {this.layersPanelOpen && <ogm-layers theme={this.theme} layers={this.layerControls}></ogm-layers>}
+        </div>
       </Host>
     );
   }

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -37,6 +37,11 @@ export class OgmPreview {
     return <ogm-map theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-map>;
   }
 
+  // No scope on an element of our own, unlike the components below: nothing we draw reads a color -
+  // each of them draws its own contents and establishes its own scope for them. The link and the
+  // Host's classes still matter, though. The classes are what the parent's stylesheet matches when
+  // we're nested, and the link is what matches them on the children rendered here - which is how
+  // <ogm-alerts>'s :host gets the surface color it fills a failed preview with.
   render() {
     return (
       <Host class={waScope(this.theme)}>

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -82,6 +82,10 @@ export class OgmPreviews {
   // group left standing across a change of previews keeps pointing at whichever tab the user had
   // picked - the third one of a record that now offers two. Keying the group by the whole set
   // replaces it outright when the previews change, which is the only way to clear that.
+  //
+  // The tab group carries the Web Awesome scope as well as the Host, since the stylesheet linked here
+  // establishes the palette with plain class selectors and those never match their own shadow host.
+  // Everything the group draws - the tabs, their panels - reads its colors from it.
   render() {
     const tabs = this.tabs;
     if (!tabs.length) return;
@@ -89,7 +93,7 @@ export class OgmPreviews {
     return (
       <Host class={waScope(this.theme)}>
         <link rel="stylesheet" href={webAwesomeStylesheet()} />
-        <wa-tab-group key={tabs.map(previewer => previewer.previewId).join()}>
+        <wa-tab-group class={waScope(this.theme)} key={tabs.map(previewer => previewer.previewId).join()}>
           {tabs.map(previewer => (
             <wa-tab key={`tab-${previewer.previewId}`} panel={previewer.previewId}>
               {previewer.label()}

--- a/src/lib/init.test.tsx
+++ b/src/lib/init.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from '@stencil/vitest';
+
+import { waScope, webAwesomeReady } from './init';
+
+// A stylesheet link and the element a component would have applied waScope() to, as they sit in a
+// shadow root. Nothing here fetches anything: what a link does with its href is the browser's
+// business, and what this cares about is only when it says it's finished.
+const scoped = (color?: string) => {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  const scope = document.createElement('div');
+  scope.className = waScope('light');
+  // Declared on the element itself rather than inherited from above it, which is happy-dom's limit;
+  // see MapLibreTheme's own tests. A color set here stands in for one the stylesheet brought.
+  if (color) scope.style.setProperty('--wa-color-blue-50', color);
+  document.body.append(link, scope);
+  return { link, scope };
+};
+
+// Long enough for every microtask a promise chain queues to have run, so a promise that hasn't
+// settled by now is one that is genuinely still waiting
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const watch = (promise: Promise<void>) => {
+  const state = { ready: false };
+  promise.then(() => (state.ready = true));
+  return state;
+};
+
+describe('webAwesomeReady', () => {
+  it('is ready straight away when the palette can already be read', async () => {
+    const { link, scope } = scoped('#0071ec');
+
+    const state = watch(webAwesomeReady(link, scope));
+    await flush();
+
+    expect(state.ready).toBe(true);
+  });
+
+  // The colors are a stylesheet away, and the wait is not optional: MapLibre rejects a layer whose
+  // paint properties are the empty string rather than falling back to anything
+  it('waits for the stylesheet when the palette has no colors behind it yet', async () => {
+    const { link, scope } = scoped();
+
+    const state = watch(webAwesomeReady(link, scope));
+    await flush();
+    expect(state.ready).toBe(false);
+
+    link.dispatchEvent(new Event('load'));
+    await flush();
+    expect(state.ready).toBe(true);
+  });
+
+  // A theme that can't be fetched leaves a preview drawn in whatever its fallbacks come out as,
+  // which is a good deal better than one that is never drawn at all
+  it('gives up waiting on a stylesheet that fails to load', async () => {
+    const { link, scope } = scoped();
+
+    const state = watch(webAwesomeReady(link, scope));
+    link.dispatchEvent(new Event('error'));
+    await flush();
+
+    expect(state.ready).toBe(true);
+  });
+});

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -31,11 +31,50 @@ const WA_PALETTE = 'wa-palette-default wa-brand-blue wa-neutral-gray wa-success-
  * <ogm-viewer> above it: custom properties inherit through shadow boundaries, so the outermost one
  * in use is the one that has to establish them, and which component that is depends on the embed.
  *
+ * They belong on an element *inside* the shadow root - a container the component already wraps its
+ * content in - and not on the <Host> alone. Web Awesome declares its palette with plain class
+ * selectors, and a plain class selector in a shadow root's own stylesheet never matches the host of
+ * that root, so a scope class sitting there alone establishes nothing for the tree below it: every
+ * color reads as the empty string. Worth applying to the Host as well, though, because that class is
+ * matched by the *parent's* stylesheet one shadow root out - which is what gives a nested
+ * component's own :host rules their colors.
+ *
  * Applying them more than once down a single tree is harmless - the values are identical, and the
  * browser fetches the stylesheet once - which is why nobody tries to detect whether an ancestor got
  * there first. At first paint there is no reliable answer to that question anyway.
  */
 export const waScope = (theme?: 'light' | 'dark'): string => `${WA_PALETTE} wa-${theme ?? 'light'}`;
+
+// One of the palette's own colors, read to tell whether the palette has arrived. Any of them would
+// do; this is the blue a preview's data falls back to being drawn in.
+const WA_PALETTE_COLOR = '--wa-color-blue-50';
+
+/**
+ * Resolves once the scope established by waScope() has colors behind it, for a component that reads
+ * one in JavaScript rather than leaving it to CSS. A map is the case in point: it has to hand
+ * MapLibre a color, and MapLibre rejects a layer whose paint properties are the empty string
+ * outright rather than falling back to anything.
+ *
+ * There is a real wait here. The theme is two files deep - themes/default.css opens with @import
+ * rules, and the palette is in one of the imported files - so a link's `sheet` being set says only
+ * that the outer file parsed, which happens before either import resolves. The link's `load` event
+ * is the signal that waits for them.
+ *
+ * Ask for this in componentDidLoad, in the same task that rendered the link, and hold the promise
+ * until the colors are actually wanted. Asked for any later - from a handler the map or the page
+ * fired - a `load` event that has already been and gone is one that nobody can hear.
+ */
+export const webAwesomeReady = (link: Element, scope: Element): Promise<void> =>
+  new Promise(resolve => {
+    // Already readable: an ancestor scope established the palette before we rendered at all, or a
+    // stylesheet the browser had in hand loaded before we got here
+    if (window.getComputedStyle(scope).getPropertyValue(WA_PALETTE_COLOR)) return resolve();
+
+    // 'error' as much as 'load': a theme that can't be fetched leaves a preview drawn in whatever
+    // its fallbacks come out as, which is a good deal better than one that is never drawn at all.
+    link.addEventListener('load', () => resolve(), { once: true });
+    link.addEventListener('error', () => resolve(), { once: true });
+  });
 
 // Which theme to draw in when nobody said. Only consulted by a component used on its own;
 // <ogm-viewer> passes its own resolved theme down to everything it renders.


### PR DESCRIPTION
A component used on its own drew in empty colors. `<ogm-map>` and the rest put `waScope()`'s classes on their `<Host>` alongside the stylesheet link, but Web Awesome declares its palette with plain class selectors, and a plain class selector in a shadow root's own stylesheet never matches the host of that root. On the Host alone they establish nothing: every `--wa-color-*` reads as the empty string, `MapLibreTheme` hands MapLibre `""` for every paint property, and MapLibre rejects the layer outright rather than falling back to anything.

Measured on a bare `<ogm-map>` before the fix — the source is added, and not one of its seven style layers:

```js
themeStyle: { dataColor: "", strokeColor: "", textColor: "", ... }
sources:    ["carto", "bare-geojson"]
styleLayerIds: []
```

## Why it hasn't bitten before

Nesting hides it. A child's Host classes *are* matched by the parent's stylesheet one shadow root out, so an `<ogm-map>` inside `<ogm-preview>` — or anything under `<ogm-viewer>`, which has put the scope on a `.container` of its own for as long as it has had one — inherits the palette and draws fine. Only the outermost component of an embed is exposed, and which one that is depends on the embed. The readme documents standalone `<ogm-preview>`, so this is a documented path.

## What changed

**The scope moves onto an element inside each shadow root.** `<ogm-map>` wraps its content in a `.container` to have one: the layer panel needs the palette as much as the map does, and it is a sibling of `#map` rather than a child, so the scope has to sit above both. `<ogm-image>` (`#openseadragon`), `<ogm-alerts>` (`.alerts`) and `<ogm-previews>` (`wa-tab-group`) each already had an element to carry it. `<ogm-preview>` needs none — nothing it draws reads a color, and the children it renders now scope themselves — and `<ogm-attributes>` is covered by the map's, since its popup is built inside `#map`. Every Host keeps its copy: that is what colors a nested component's own `:host` rules.

**The colors also have to have arrived.** `themes/default.css` opens with two `@import` rules and the palette lives in one of the imported files, so a link's `sheet` being set says only that the outer file parsed. `webAwesomeReady()` waits for the link's `load`, which waits for the imports, and `<ogm-map>` holds that promise from `componentDidLoad` until `loadPreview` reads a color. Drawing on the MapLibre `load` event was never the same guarantee: it waits for a round trip to a tile server, which is usually but not always the longer wait, and the redraw after a theme change starts from `style.load`, which is earlier. It resolves on `error` too — a theme that can't be fetched should leave a preview drawn in its fallbacks rather than one that is never drawn at all.

## Notes for review

- **Why a `.container` in `<ogm-map>` rather than the scope on `#map`.** `<ogm-layers>` uses 22 Web Awesome tokens, links no stylesheet of its own, and is a sibling of `#map`. A scope on `#map` alone would have left the layer panel unthemed in a standalone map. This follows `<ogm-viewer>`'s existing `.container` precedent, and `.container` has no positioning of its own, so the panel resolves its offsets against the same box as before.
- **`<ogm-image>`'s `Theme` moved to `#openseadragon` too.** No behavioural effect today — it reads only `--ogm-padding`, which comes from outside either way — but a `Theme` built from the host is the exact shape of this bug, and it is the trap the next token read would fall into. This is what the two image test edits are for; happy to revert it if you'd rather keep the diff to `<ogm-map>`.
- **The four moved padding assertions.** happy-dom resolves a custom property declared on the element itself but doesn't inherit one down the tree, so a property the theme should pick up now has to be set where the theme reads. It is the same concession `MapLibreTheme`'s own tests already document.
- **Found, not fixed:** handing a `previewer` to a live bare `<ogm-map>` before its style has loaded throws `Style is not done loading` as an unhandled rejection — `applyViewConstraints()` calls `setProjection` outside `loadPreview`'s try, and Stencil doesn't await watchers. Pre-existing, still reproduces, only reachable standalone. Being handled separately.

## Verification

`npm test` 718 passed (4 new), `npm run lint` clean.

Checked against the dev server with a bare `<ogm-preview>` carrying a hand-built `GeoJsonPreviewer`, and with a bare `<ogm-map>`:

- bare `<ogm-map>`: all seven style layers present with real colors, and the layer panel renders fully themed — surface `rgb(16, 18, 25)`, text `rgb(241, 242, 243)`, where it previously had neither
- bare `<ogm-preview>`: console clean, layer drawn in theme colors
- `<ogm-viewer>` regressions: record load, light/dark toggle (redraw produced seven layers in light-mode colors), `<ogm-image>` control stack, `<ogm-alerts>` callout
- the `--ogm-*` override API still reaches the new read site two shadow roots down: `--ogm-data-color: #8f1414` on the page arrives as `dataColor: "#8f1414"`, `strokeColor: "#4a0a0a"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
