### PR TITLE
Wait for the style document before drawing a preview

### DIFF
--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -35,6 +35,43 @@ const bounds = [
   [1, 1],
 ];
 
+// Enough of one to draw a whole preview onto: it can be constrained to what the preview needs and
+// fitted to it. Refuses to be written to until its style document has loaded, the way every one of
+// MapLibre's own writers does - see Style#_checkLoaded.
+const loadingMap = () => {
+  const map = {
+    styleLoaded: false,
+    ...fittableMap(),
+    setProjection: vi.fn(() => {
+      if (!map.styleLoaded) throw new Error('Style is not done loading.');
+    }),
+    setMaxPitch: vi.fn(),
+  };
+  return map;
+};
+
+// Built by addControls, so a map that never got a WebGL context has none of it
+const fakeLayersControl = () => ({ setPressed: vi.fn() });
+
+// Enough of a previewer to be drawn: it takes the map and the colors it draws with, draws, and says
+// where it should be looked at. Flat and shallow, like the two previews that paint their own WebGL.
+const drawablePreviewer = () => ({
+  projection: 'mercator',
+  maxPitch: 30,
+  url: 'http://example.com/data.json',
+  sourceIds: [],
+  previewLayers: [],
+  label: () => 'GeoJSON',
+  attach: vi.fn(),
+  preview: vi.fn(async () => {}),
+  applyLayerState: vi.fn(),
+  clearPreview: vi.fn(async () => {}),
+  getBounds: vi.fn(async () => bounds),
+});
+
+// Stencil doesn't await a watcher, so let what the previewer's own started finish
+const settle = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
 const fitTo = (el: HTMLElement, mapBounds: number[][]) => (el as unknown as { fitMapBounds: (bounds: number[][]) => Promise<void> }).fitMapBounds(mapBounds);
 
 // Set a property the theme reads, on the element it reads from - the scope inside the shadow root,
@@ -44,6 +81,15 @@ const fitTo = (el: HTMLElement, mapBounds: number[][]) => (el as unknown as { fi
 const setThemeProperty = (el: HTMLElement, property: string, value: string) => {
   const scope = (el.shadowRoot as ShadowRoot).querySelector('.container') as HTMLElement;
   scope.style.setProperty(property, value);
+};
+
+// What MapLibre's own handlers do between them once it has a style document: the map takes writes, the
+// component knows it does, and whatever preview is attached is drawn into it. There is no map here to
+// fire style.load or load on, so the two of them stand in for the pair.
+const styleLoads = async (el: HTMLElement, map: ReturnType<typeof loadingMap>) => {
+  map.styleLoaded = true;
+  Object.assign(el, { mapStyleLoaded: true });
+  await (el as unknown as { loadPreview: () => Promise<void> }).loadPreview();
 };
 
 const containers: HTMLElement[] = [];
@@ -149,6 +195,48 @@ describe('ogm-map', () => {
     await fitTo(el, bounds);
 
     expect((el as unknown as { map: ReturnType<typeof fittableMap> }).map.fitBounds).toHaveBeenCalledWith(bounds, { padding: 50 });
+  });
+
+  // Only a standalone <ogm-map> gets here: under <ogm-preview> the previewer arrives as an initial prop,
+  // so the watcher never fires in the window before the style has loaded. Writing to a style document
+  // that hasn't loaded throws, and the watcher that lands a preview is async - so what it threw escaped
+  // as an unhandled rejection instead of reaching reportError, and the preview never drew.
+  it('holds a preview handed to it before its style has loaded, then draws it', async () => {
+    const { el } = await renderMap();
+    const map = loadingMap();
+    const previewer = drawablePreviewer();
+    const reported = vi.fn();
+    el.addEventListener('previewError', reported);
+    Object.assign(el, { map, layersControl: fakeLayersControl() });
+
+    Object.assign(el, { previewer });
+    await settle();
+
+    // Nothing written to the style, nothing drawn into it, and nothing thrown on the way past
+    expect(map.setProjection).not.toHaveBeenCalled();
+    expect(previewer.preview).not.toHaveBeenCalled();
+    expect(reported).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await styleLoads(el, map);
+
+    // The whole load ran this time, down to moving the map to what it drew
+    expect(previewer.preview).toHaveBeenCalled();
+    expect(map.fitBounds).toHaveBeenCalled();
+    expect(reported).not.toHaveBeenCalled();
+  });
+
+  // Waiting on the style is all that guard is about: a preview that can't be drawn on a globe still has
+  // to flatten the map it lands on, and tilt it no further than it can be drawn tilted
+  it('draws a preview that needs a flat map on one', async () => {
+    const { el } = await renderMap();
+    const map = loadingMap();
+    Object.assign(el, { map, layersControl: fakeLayersControl(), previewer: drawablePreviewer() });
+
+    await styleLoads(el, map);
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
+    expect(map.setMaxPitch).toHaveBeenCalledWith(30);
   });
 
   // The popup is built by hand rather than rendered, so it outlives the component's own markup

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -155,6 +155,18 @@ export class OgmMap {
   async loadPreview() {
     if (!this.previewer || !this.map) return;
 
+    // Nothing can be written into a style document that hasn't loaded: setProjection below and the
+    // addSource every preview draws itself with both throw before it has. Nothing is lost by holding
+    // off, because whichever style is on its way draws the preview as it lands - the map's own load
+    // event for the first one, and the handler onThemeChange registers for every one after it.
+    //
+    // Reached only by a previewer handed to a live standalone <ogm-map>, which is the one way a preview
+    // can arrive mid-load: under <ogm-preview> it is an initial prop, so the watcher never fires in that
+    // window. And it has to be caught here rather than thrown and reported, because Stencil doesn't
+    // await a watcher - what that throws escapes as an unhandled rejection instead of reaching
+    // reportError, leaving nothing drawn and nothing said about it.
+    if (!this.mapStyleLoaded) return;
+
     // Fresh load attempt: allow one error to be reported again for this preview
     this.errorReported = false;
 


### PR DESCRIPTION
Handing a `previewer` to a live standalone `<ogm-map>` before its MapLibre style had loaded threw an unhandled rejection, and the preview never drew:

```js
const el = document.createElement('ogm-map');
document.body.appendChild(el);
await el.componentOnReady();
el.previewer = new GeoJsonPreviewer(new GeoJsonResource('x', someGeoJsonUrl));
// → Uncaught (in promise) Error: Style is not done loading.
```

## What changed

`loadPreview()` now returns early until `mapStyleLoaded` is set, instead of running into a style document that can't be written to yet.

## Why there and not on the `applyViewConstraints()` call

`setProjection` is only the first of several style writes in that window. Guarding just that call stops the unhandled rejection, but the preview still doesn't draw — the throw simply moves inside the try/catch, where `previewer.preview()` hits the same check:

```
Error: Style is not done loading.
  at Style._checkLoaded
  at Style.addSource
  at Map.addSource
```

That reaches `reportError`, so the result is "Style is not done loading." shown as an alert over a map with nothing on it. Verified in the browser before changing approach.

Nothing is lost by waiting: whichever style is on its way draws the preview as it lands — the map's own `load` event for the first one, and the handler `onThemeChange` registers for every one after it. Only a previewer handed to a live standalone `<ogm-map>` reaches this at all; under `<ogm-preview>` the previewer arrives as an initial prop, so no watcher fires in that window.

## Rebased onto `ac9c31b`, and still needed

`ac9c31b` ("Establish the palette inside the shadow root that reads it") also changed `loadPreview` — it now awaits `themeReady` before reading a color. That await sits inside the try, after `applyViewConstraints()`, so it does not stand between the handover and the throw: with this commit's guard removed on top of `ac9c31b`, the repro still fails identically, with the same unhandled rejection through `onPreviewerChange → loadPreview → applyViewConstraints`. The two fixes are about different prerequisites — colors having arrived, and the style document being writable — and both are needed.

The only conflict was in `ogm-map.test.tsx`, where both commits added a helper at the same spot; both are kept.

## Notes for a reviewer

- **`onThemeChange` interaction.** It sets `mapStyleLoaded = false` before `setStyle`, but the persistent `style.load` handler bound in `componentDidLoad` is registered before the `once('style.load')` that `onThemeChange` adds, so the flag is back up by the time the once-handler calls `loadPreview`. Confirmed on a live standalone map: after a theme swap all 7 layers were re-added, no rejections.
- **First load is unaffected.** MapLibre only fires `load` once `style.loaded()` is true, so `mapStyleLoaded` is already set whenever `loadPreview` runs from that handler.
- **One behavior trade-off.** If a basemap style never loads at all, the preview now waits silently rather than accidentally surfacing "Style is not done loading." That matches the `<ogm-preview>` path, where `handleMapError` already filters basemap failures.

## Tests

Two added alongside the existing ones in `ogm-map.test.tsx`: a preview handed over mid-load is held and then drawn once the style lands, and a preview that needs a flat map still gets one. Both fail without the guard — the first on its assertion, and both reproduce the unhandled rejection.

`npm test` → 720 passed (50 files). `npm run lint` clean.

Verified in the browser on the rebased code, against the original repro: `attach` is not called at handover, then runs once with `isStyleLoaded() === true` and a real `dataColor`; 7/7 layers on the map, fitted to the record's bounds, features rendered, no rejections and no `previewError`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)