### PR TITLE
Draw a preview even when the palette can't be read, and say so when it isn't

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ You usually only need the four `--ogm-*-color` properties, plus `--ogm-text-colo
 
 `--ogm-stroke-*` and `--ogm-text-halo-color` are there if you want particular ones instead. Like the other colors, one you name is used in both modes.
 
+Name these in a form MapLibre can parse: a named color, a hex, `rgb()`, or `hsl()`. It refuses a layer whose color it can't read, so a preview styled with anything else - an `oklch()`, a `color-mix()` - reports an error instead of being drawn.
+
 ### Restricted content
 
 For previews of data that need authentication to access, you can set a custom `requestTransform` function to add headers or cookies to the request. It's a DOM property on `<ogm-viewer>` that you can set in JavaScript, like the `recordUrl` property:

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -61,12 +61,27 @@ const drawablePreviewer = () => ({
   url: 'http://example.com/data.json',
   sourceIds: [],
   previewLayers: [],
+  droppedLayerIds: [],
   label: () => 'GeoJSON',
   attach: vi.fn(),
   preview: vi.fn(async () => {}),
   applyLayerState: vi.fn(),
   clearPreview: vi.fn(async () => {}),
   getBounds: vi.fn(async () => bounds),
+});
+
+// What MapLibre says about a paint property it can't read, in the shape it says it: the layer named in
+// the message, and the error raised on the map with no sourceId to tie it to what was being drawn.
+const PAINT_ERROR = "layers.a-preview-polygons.paint.fill-color[2]: Could not parse color from value ''";
+
+// A previewer whose layers the style refused, complaining as MapLibre complains on the way past:
+// inside the addLayer that preview() is doing, before it has resolved to say it drew anything.
+const refusedPreviewer = (el: HTMLElement, message: string) => ({
+  ...drawablePreviewer(),
+  droppedLayerIds: ['a-preview-polygons'],
+  preview: vi.fn(async () => {
+    (el as unknown as { handleMapError: (event: { error: Error }) => void }).handleMapError({ error: new Error(message) });
+  }),
 });
 
 // Stencil doesn't await a watcher, so let what the previewer's own started finish
@@ -237,6 +252,42 @@ describe('ogm-map', () => {
 
     expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
     expect(map.setMaxPitch).toHaveBeenCalledWith(30);
+  });
+
+  // MapLibre drops a layer it rejects without throwing, and fires the error for it on the map with no
+  // sourceId - which handleMapError reads as basemap noise. A preview whose layers all went that way
+  // was a bare basemap with a spinner that stopped and nothing said about any of it.
+  it('reports the layers the style refused, and what it was refused for', async () => {
+    const { el } = await renderMap();
+    const map = loadingMap();
+    const reported = vi.fn();
+    el.addEventListener('previewError', reported);
+    Object.assign(el, { map, layersControl: fakeLayersControl() });
+
+    Object.assign(el, { previewer: refusedPreviewer(el, PAINT_ERROR) });
+    await styleLoads(el, map);
+
+    expect(reported).toHaveBeenCalledTimes(1);
+    expect(reported.mock.calls[0][0].detail.title).toBe("The GeoJSON preview couldn't be read");
+    // The ids and the reason both go to the console: neither is any use to a reader of the alert, and
+    // both are to whoever has to fix it. MapLibre logs none of this itself once we listen for errors.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Layers refused by MapLibre'), ['a-preview-polygons'], PAINT_ERROR);
+    // And carried on from: whatever did land is still worth pointing the map at
+    expect(map.fitBounds).toHaveBeenCalled();
+  });
+
+  // The error we're holding is the last one MapLibre raised about the map rather than about a source,
+  // which is as easily a glyph it couldn't fetch as the layer it refused. Offering that as the reason
+  // would send whoever reads it after the wrong failure.
+  it('offers no reason when the one it has is about something else', async () => {
+    const { el } = await renderMap();
+    const map = loadingMap();
+    Object.assign(el, { map, layersControl: fakeLayersControl() });
+
+    Object.assign(el, { previewer: refusedPreviewer(el, 'Error: NetworkError: Failed to fetch glyph range 0-255') });
+    await styleLoads(el, map);
+
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Layers refused by MapLibre'), ['a-preview-polygons'], 'no reason given');
   });
 
   // The popup is built by hand rather than rendered, so it outlives the component's own markup

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -51,6 +51,10 @@ export class OgmMap {
   // Guards against reporting more than one error per load attempt
   private errorReported: boolean = false;
 
+  // The last thing MapLibre complained about on the map itself rather than about one of our sources,
+  // kept for the length of a load attempt; see reportDroppedLayers for what reads it and why.
+  private lastStyleError: maplibregl.ErrorEvent['error'] | undefined = undefined;
+
   // MapLibre map instance and popup instance for feature info display
   protected map: maplibregl.Map;
   protected mapTheme: MapLibreTheme;
@@ -167,8 +171,10 @@ export class OgmMap {
     // reportError, leaving nothing drawn and nothing said about it.
     if (!this.mapStyleLoaded) return;
 
-    // Fresh load attempt: allow one error to be reported again for this preview
+    // Fresh load attempt: allow one error to be reported again for this preview, and forget what the
+    // last one complained about
     this.errorReported = false;
+    this.lastStyleError = undefined;
 
     // Indicate loading state so we can show the spinner
     this.mapLoading.emit();
@@ -209,6 +215,11 @@ export class OgmMap {
       this.previewer.attach(this.map, this.mapTheme.getStyle());
       await this.previewer.preview();
 
+      // Drawing is not the same as drawn: MapLibre drops a layer it rejects without a word, and
+      // preview() resolves as though it landed. Reported here and then carried on from, because
+      // whatever did land is still worth showing the user and still worth pointing the map at.
+      this.reportDroppedLayers();
+
       // Set up the layer controls
       this.applyLayerState();
       this.setupLayerControls();
@@ -241,9 +252,35 @@ export class OgmMap {
   // Surface MapLibre errors tied to the current preview, skipping the noise from basemap/glyph/
   // sprite loads, and deduped to a single alert per load attempt.
   protected handleMapError(event: maplibregl.ErrorEvent & { sourceId?: string }) {
-    if (this.errorReported || !this.previewer) return;
+    if (!this.previewer) return;
+    // Everything else about the map: a style layer it refused, a glyph or sprite it couldn't fetch.
+    // Held onto rather than reported, since only reportDroppedLayers can tell which of those it was.
+    if (event.sourceId === undefined) this.lastStyleError = event.error;
+    if (this.errorReported) return;
     if (!this.previewer.sourceIds.includes(event.sourceId ?? '')) return;
     this.reportError(event.error);
+  }
+
+  // Say so when the style doesn't hold layers the preview just asked it for. MapLibre does fire an
+  // error for a layer it refuses, but on the map and with no sourceId, so handleMapError above reads
+  // it as basemap noise - and having a listener at all is what stops MapLibre logging it itself, so
+  // nothing reaches the console either. Left at that, a preview drawn in a color MapLibre can't parse
+  // is a bare basemap that nobody is told anything about, in the alerts or in the console.
+  //
+  // So the reason is logged here alongside the ids, when the one we're holding is about a layer we
+  // lost: MapLibre names the layer in the message it refused it with ("layers.<id>.paint.fill-color:
+  // Could not parse color from value ''"). One naming none of them is a different failure - a glyph
+  // that 404d - and saying it was why would send whoever reads it somewhere else entirely.
+  private reportDroppedLayers() {
+    const droppedLayerIds = this.previewer?.droppedLayerIds ?? [];
+    if (droppedLayerIds.length === 0) return;
+
+    const styleError = this.lastStyleError;
+    const reason = styleError && droppedLayerIds.some(layerId => styleError.message.includes(layerId)) ? styleError.message : 'no reason given';
+    console.error(`Layers refused by MapLibre while previewing ${this.previewer.url}:`, droppedLayerIds, reason);
+    this.reportError(
+      new Error("The map refused the layers this preview is drawn with, so it couldn't be shown. A style value it was given - most often a color - is one MapLibre can't use."),
+    );
   }
 
   // Emit a single preview error per load attempt

--- a/src/lib/previewers/geojson.test.ts
+++ b/src/lib/previewers/geojson.test.ts
@@ -373,3 +373,39 @@ describe('OpenIndexMapPreviewer#opacity', () => {
     expect(map.layers.get(indexLayerId('polygon-labels')).paint['text-opacity']).toEqual(1);
   });
 });
+
+// MapLibre validates a style layer as it is added and returns without adding one it rejects - a paint
+// color it can't parse, a property the layer type doesn't define - rather than throwing. So a preview
+// can hand over all seven of its layers, be told nothing, and have none of them drawn. What the style
+// document actually holds is the only witness to that.
+describe('GeoJsonPreviewer#droppedLayerIds', () => {
+  // A map that refuses the layers it is named, the way MapLibre refuses one that doesn't validate:
+  // nothing added, nothing thrown.
+  class RefusingMap extends FakeMap {
+    constructor(readonly refused: string[]) {
+      super();
+    }
+
+    addLayer(layer: any) {
+      if (this.refused.includes(layer.id)) return;
+      super.addLayer(layer);
+    }
+  }
+
+  it('names the layers the style refused, out of everything it was given', async () => {
+    const map = new RefusingMap([layerId('polygons'), layerId('point-labels')]);
+    const previewer = new GeoJsonPreviewer(new GeoJsonResource('princeton-fk4544658v', GEOJSON_URL)).attach(map as unknown as maplibregl.Map, style);
+
+    await previewer.preview();
+
+    // Still recorded as asked for, since clearPreview has to look for every one of them
+    expect(previewer.layerIds).toEqual(SUFFIXES.map(layerId));
+    expect(previewer.droppedLayerIds).toEqual([layerId('polygons'), layerId('point-labels')]);
+  });
+
+  it('is empty when the style holds everything it was given', async () => {
+    const { previewer } = await previewGeoJson();
+
+    expect(previewer.droppedLayerIds).toEqual([]);
+  });
+});

--- a/src/lib/previewers/map.ts
+++ b/src/lib/previewers/map.ts
@@ -119,6 +119,20 @@ export default abstract class MapPreviewer extends Previewer {
     });
   }
 
+  // The style layers this preview asked for that the style document doesn't hold. MapLibre validates
+  // a layer as it is added and returns without adding one it rejects - a paint color it can't parse,
+  // a property the layer type doesn't define - rather than throwing, so preview() above resolves
+  // having recorded every id whether or not anything was drawn. Asking the style what it actually
+  // holds is the only way to tell the difference, and it is worth telling: a preview whose layers
+  // were all dropped looks exactly like a bare basemap.
+  //
+  // Empty for a preview that paints with its own WebGL instead of through the style document, since a
+  // deck.gl overlay goes on as a control and records no layer ids at all.
+  get droppedLayerIds(): string[] {
+    if (!this.attached) return [];
+    return this.layerIds.filter(layerId => !this.map.getLayer(layerId));
+  }
+
   // Remove preview layers and sources
   async clearPreview() {
     if (!this.attached) return;

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -50,6 +50,49 @@ describe('MapLibreTheme', () => {
     });
   });
 
+  // A component used on its own establishes the Web Awesome palette itself, and that can fail: the
+  // theme is linked into a shadow root, so it can 404 or be blocked, and nothing above a bare
+  // <ogm-map> has to have established a scope either. Every token computes to the empty string then -
+  // which is the state this file's own helper leaves them in - and MapLibre rejects a layer whose
+  // paint color is empty rather than drawing it in something. A preview used to be dropped whole.
+  describe('an unreadable palette', () => {
+    // Every color the style names, with nothing declared anywhere: no --ogm-* override to read, and no
+    // --wa-color-* behind it either
+    const colorsOf = (theme: 'light' | 'dark') =>
+      Object.entries(themed(theme).getStyle())
+        .filter(([name]) => name.endsWith('Color'))
+        .map(([name, color]) => [name, String(color)]);
+
+    it('leaves a color behind for every part of a preview', () => {
+      const colors = colorsOf('light');
+
+      // The data, its outline, and the labels, in each of their four states
+      expect(colors).toHaveLength(10);
+      // And every one of them something MapLibre will parse, rather than the empty string
+      expect(colors.filter(([, color]) => !/^#[0-9a-f]{6}$/i.test(color))).toEqual([]);
+    });
+
+    // The mode still decides, so a preview drawn without a palette is still drawn to be seen against
+    // the basemap it lands on
+    it('picks its own color for each mode', () => {
+      const dark = themed('dark').getStyle();
+      const light = themed('light').getStyle();
+
+      expect(dark.dataColor).not.toBe(light.dataColor);
+      // Derived as usual, from a text color that is now readable: dark halo under the near-white text
+      // a dark basemap gets, light halo under the near-black text a light one gets
+      expect(dark.textHaloColor).toBe('#000000');
+      expect(light.textHaloColor).toBe('#ffffff');
+    });
+
+    // The floor is under the token, not over it: a palette that loads is still what a preview is
+    // drawn from, and an app's own override still beats both
+    it('gives way to the palette and to an override', () => {
+      expect(themed('light', { '--wa-color-blue-80': 'rebeccapurple' }).getStyle().dataColor).toBe('rebeccapurple');
+      expect(themed('light', { '--ogm-data-color': '#8f1414' }).getStyle().dataColor).toBe('#8f1414');
+    });
+  });
+
   // The outline isn't a second decision an app has to make. Asserted as a relationship to the color
   // it came from rather than against a hex, so the shift can be retuned without rewriting this.
   describe('derived stroke colors', () => {

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -46,6 +46,31 @@ const defaultGlyphFont = 'Noto Sans Regular';
 // the way it did, and one that names a color gets an outline that follows it into either mode.
 const strokeLightnessShift = 0.26;
 
+// What Web Awesome's default palette holds for each token this theme names. Read only when the
+// palette itself can't be read - a component used on its own whose copy of the theme failed to
+// fetch, or one nothing established a scope for - where every `--wa-color-*` comes out as the empty
+// string. MapLibre rejects a layer whose paint color is empty rather than falling back to anything,
+// so a preview styled from an unreadable palette isn't drawn faintly, it isn't drawn at all.
+//
+// A floor rather than a second theme: these are the colors those tokens hold, so a palette that
+// loads changes nothing, and one that doesn't still gets the map drawn.
+const paletteDefaults = {
+  '--wa-color-blue-50': '#0071ec',
+  '--wa-color-blue-80': '#9fceff',
+  '--wa-color-cyan-60': '#00a3c0',
+  '--wa-color-cyan-80': '#7fd6ec',
+  '--wa-color-green-50': '#00883c',
+  '--wa-color-green-80': '#93da98',
+  '--wa-color-red-50': '#dc3146',
+  '--wa-color-red-60': '#f3676c',
+  '--wa-color-gray-05': '#101219',
+  '--wa-color-gray-95': '#f1f2f3',
+} as const;
+
+// A palette token this theme is allowed to name. One without a color above isn't one, so naming a
+// token nothing can fall back to is a type error here rather than an empty color at runtime.
+type PaletteToken = keyof typeof paletteDefaults;
+
 // Style properties common to all MapLibre-based previewers
 export default class MapLibreTheme extends Theme {
   /**
@@ -102,7 +127,7 @@ export default class MapLibreTheme extends Theme {
   // An embedding app's override if it set one, otherwise our own token for the current mode. One
   // override covers both modes: an app that names a color has said it wants that color, and
   // second-guessing it in dark mode would be picking a color it never asked for.
-  themedColor(override: string, darkColor: string, lightColor: string): string {
+  themedColor(override: string, darkColor: PaletteToken, lightColor: PaletteToken): string {
     return this.readCssProperty(override) || this.dualCssColors(darkColor, lightColor);
   }
 
@@ -122,9 +147,11 @@ export default class MapLibreTheme extends Theme {
     return this.readCssProperty('--ogm-text-halo-color') || contrastColor(textColor) || this.dualCssColors('--wa-color-gray-05', '--wa-color-gray-95');
   }
 
-  // If dark mode, use the first CSS color, otherwise use the second CSS color
-  dualCssColors(darkColor: string, lightColor: string): string {
-    return this.darkMode() ? this.readCssProperty(darkColor) : this.readCssProperty(lightColor);
+  // If dark mode, use the first CSS color, otherwise use the second CSS color - and if the palette
+  // both come from can't be read at all, the color that token holds in it; see paletteDefaults.
+  dualCssColors(darkColor: PaletteToken, lightColor: PaletteToken): string {
+    const token = this.darkMode() ? darkColor : lightColor;
+    return this.readCssProperty(token) || paletteDefaults[token];
   }
 
   // Atmosphere style for globe


### PR DESCRIPTION
A standalone `<ogm-map>` used outside `<ogm-viewer>`/`<ogm-preview>` drew no data: every style layer of its preview was silently dropped by MapLibre, because `MapLibreTheme.getStyle()` handed the previewer `{ dataColor: '', strokeColor: '', … }` and `Style#addLayer` rejects a paint color of `''`.

Most of that cause is already gone from `main`: `ac9c31b` moved the Web Awesome scope classes onto `.container` inside the shadow root (a plain class selector in a shadow root's stylesheet can never match the host of that root), and `f95b383` fixed the neighbouring standalone bug where a previewer handed to a live map before `style.load` threw out of the watcher. What neither covers is the palette failing to arrive **at all** — `webAwesomeReady` resolves on the link's `error` event on purpose, so that a theme which 404s or is blocked leaves a preview "drawn in whatever its fallbacks come out as". There were no fallbacks.

### Put a floor under the palette tokens

`paletteDefaults` in `src/lib/themes/maplibre.ts` holds the color Web Awesome's default palette actually gives each token this theme names, and `dualCssColors` falls through to it. A palette that loads changes nothing; one that doesn't still gets the map drawn. `PaletteToken = keyof typeof paletteDefaults` means naming a token with no color behind it is a type error rather than an empty color at runtime. The strokes and the label halo derive from these colors, so they follow; the numbers and the glyph font already had defaults.

### Say so when the style refuses a layer

Nothing was reported either, and an app that names a color MapLibre can't parse (an `oklch()`, a `color-mix()`) can still land in exactly that state. `Style#addLayer` validates a layer and returns without adding one it rejects rather than throwing, so `preview()` resolved having recorded all seven ids with none of them drawn.

`MapPreviewer.droppedLayerIds` asks the style what it actually holds; `OgmMap.reportDroppedLayers` reports what it doesn't and then carries on, because whatever did land is still worth showing and still worth pointing the map at. Matching MapLibre's validation message text to attribute a `sourceId`-less error would have meant sniffing an internal format, and would only catch rejections that fire an error at all.

MapLibre's error for each rejection arrives on the map with no `sourceId`, which `handleMapError` reads as basemap noise — and registering an error listener at all is what stops MapLibre logging it itself, so the reason reached nobody. The last such error is kept for the length of a load attempt and logged with the ids, but only when it names one of the layers we lost; the same channel carries a glyph that 404'd.

The readme now notes that these colors have to be in a form MapLibre parses, since that is the one user-facing consequence.

### Tests

- `MapLibreTheme > an unreadable palette`: every color a preview is drawn with comes back as parseable hex, the mode still decides, and both the palette and an `--ogm-*` override still win.
- `GeoJsonPreviewer#droppedLayerIds`: names the layers a refusing style dropped, out of all seven it was given.
- `ogm-map`: one alert naming the preview, the ids and the reason in the console, the map still fitted to what landed — and no reason offered when the error it holds is about something else.

727 tests pass; `npm run lint` clean. Each new test was checked against a reverted fix.

### Verified in the browser

On a standalone `<ogm-map>` handed a live `GeoJsonPreviewer`, with the ten `--wa-color-*` tokens the theme reads forced to compute empty:

| | colors handed over | source | layers landed | reported |
| --- | --- | --- | --- | --- |
| empty tokens | `{data: '', stroke: '', text: '', halo: ''}` | 1 | **0 of 7** | nothing |
| the colors `paletteDefaults` supplies | `{data: '#0071ec', stroke: '#69c6ff', text: '#f1f2f3', halo: '#000000'}` | 1 | **7 of 7** | nothing |

In the second state `queryRenderedFeatures` over those seven layers returns 128 features, and `layerIds.filter(id => !map.getLayer(id))` — the signal `droppedLayerIds` reads — names all seven in the first state and none in the second. MapLibre logged nothing in either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)