### PR TITLE
Set a 20s timeout for data to be drawn before erroring

### DIFF
--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 import maplibregl from 'maplibre-gl';
 
 import { closestAcrossShadows, findElement, getElement } from '../../lib/elements';
-import { referenceError, type PreviewError } from '../../lib/errors';
+import { referenceError, TimeoutError, type PreviewError } from '../../lib/errors';
 import GlobeControl from '../../lib/globe-control';
 import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
 import { dedupeFeatures } from '../../lib/features';
@@ -51,6 +51,18 @@ export class OgmMap {
 
   // Guards against reporting more than one error per load attempt
   private errorReported: boolean = false;
+
+  // The deadline the current load attempt is being held to, and whether it has been met. See
+  // startLoadDeadline.
+  private loadDeadline: ReturnType<typeof setTimeout> | undefined = undefined;
+  private previewDrawn: boolean = false;
+
+  // Resolves once the current attempt has an answer - the preview's first tile arrived, or the
+  // deadline gave up on it - which is what the spinner is held up by. Starts resolved, since there
+  // is nothing to wait for until a load is under way, and every path that ends an attempt resolves
+  // it: nothing here may leave the spinner turning forever. See startLoadDeadline.
+  private previewSettled: Promise<void> = Promise.resolve();
+  private settlePreview: () => void = () => {};
 
   // MapLibre map instance and popup instance for feature info display
   protected map: maplibregl.Map;
@@ -103,6 +115,7 @@ export class OgmMap {
     this.map.on('mousemove', this.handleHover.bind(this));
     this.map.on('click', this.handleClick.bind(this));
     this.map.on('error', this.handleMapError.bind(this));
+    this.map.on('sourcedata', this.handleSourceData.bind(this));
     this.addControls();
 
     // Style as a globe with atmosphere once style is loaded and set the flag
@@ -118,6 +131,7 @@ export class OgmMap {
   // back into the map to clear the highlight and hands the features back to whoever is listening. All
   // of that wants a map that is still there, so it happens before the map goes rather than during it.
   disconnectedCallback() {
+    this.clearLoadDeadline();
     this.destroyPopup();
     if (this.map) this.map.remove();
   }
@@ -170,8 +184,11 @@ export class OgmMap {
     // reportError, leaving nothing drawn and nothing said about it.
     if (!this.mapStyleLoaded) return;
 
-    // Fresh load attempt: allow one error to be reported again for this preview
+    // Fresh load attempt: allow one error to be reported again for this preview, and put the
+    // deadline the last one was held to back on the clock
     this.errorReported = false;
+    this.clearLoadDeadline();
+    this.previewDrawn = false;
 
     // Indicate loading state so we can show the spinner
     this.mapLoading.emit();
@@ -189,14 +206,19 @@ export class OgmMap {
     // that can change without the style document being rebuilt
     this.applyViewConstraints();
 
-    // A preview that paints with its own WebGL - deck.gl's COG overlay - has no MapLibre source to
-    // report on, and only finds out it can't be drawn once its tiles start arriving, after preview()
-    // below has resolved. Give it the same alert a failed load gets. Bound to the previewer it came
-    // from rather than to whichever is current, so a tile of the record we just left can't report
-    // against the one that replaced it.
+    // A preview that paints with its own WebGL - deck.gl's COG overlay, an Allmaps warped scan - has
+    // no MapLibre source to report on, and only finds out how it went once its tiles start arriving,
+    // after preview() below has resolved. So it reports both outcomes itself: a failure gets the same
+    // alert a failed load gets, and a tile drawn is what satisfies the deadline started further down,
+    // in place of the map's own tile events. Both bound to the previewer they came from rather than to
+    // whichever is current, so a tile of the record we just left can't answer for the one that
+    // replaced it.
     const previewer = this.previewer;
     previewer.onError = error => {
       if (this.previewer === previewer) this.reportError(error);
+    };
+    previewer.onDrawn = () => {
+      if (this.previewer === previewer) this.markPreviewDrawn();
     };
 
     try {
@@ -212,6 +234,14 @@ export class OgmMap {
       this.previewer.attach(this.map, this.mapTheme.getStyle());
       await this.previewer.preview();
 
+      // The map has been told what to draw, so this is where the wait for it to actually appear
+      // begins. Started before the bounds are fitted rather than after, because the tiles the
+      // default view asks for are already on their way by now. Held onto rather than read again
+      // below, so that a load starting under this one - a theme change mid-flight - can't leave this
+      // attempt waiting on that one's answer instead of its own.
+      this.startLoadDeadline();
+      const settled = this.previewSettled;
+
       // Set up the layer controls
       this.applyLayerState();
       this.setupLayerControls();
@@ -219,6 +249,11 @@ export class OgmMap {
       // Fit to the preview's bounds; the spinner stays up until the map finishes moving
       const bounds = await this.previewer.getBounds();
       if (bounds) await this.fitMapBounds(bounds);
+
+      // The camera has arrived, but the data it was pointed at may not have. Keep the spinner up
+      // until the preview's first tile lands or its deadline expires, so that a preview which never
+      // draws spins and then says so, rather than presenting itself as loaded and staying blank.
+      await settled;
     } catch (error) {
       console.error(`Error previewing ${this.previewer.url}:`, error);
       this.reportError(error);
@@ -249,10 +284,69 @@ export class OgmMap {
     this.reportError(event.error);
   }
 
+  // One tile of the current preview arriving is the only proof that the preview is really there, so
+  // it's what the deadline below waits for. MapLibre fires this with a tile on it from one place
+  // only - a tile that finished loading and wasn't aborted - so its presence is the whole test; the
+  // same event without one is describing the source rather than any of its contents.
+  protected handleSourceData(event: maplibregl.MapSourceDataEvent) {
+    if (!event.tile || !this.previewer?.sourceIds.includes(event.sourceId)) return;
+    this.markPreviewDrawn();
+  }
+
+  // Something of the current preview is on the map. Reached from the map's own tile events above for
+  // everything MapLibre draws, and from the onDrawn hook for the two previews that draw themselves.
+  private markPreviewDrawn() {
+    this.previewDrawn = true;
+    this.clearLoadDeadline();
+  }
+
+  // Hold this load attempt to a deadline, and call it a failure if nothing is drawn by then.
+  protected startLoadDeadline() {
+    this.clearLoadDeadline();
+    if (!this.previewer) return;
+    if (!this.previewer.sourceIds.length && !this.previewer.reportsDrawing) return;
+
+    // Already answered, before we even got here: MapLibre starts fetching the moment a source goes
+    // on, so a tile can land - or fail loudly enough to be reported - while preview() is still
+    // adding the rest of them. Arming anyway would hold the spinner for the full deadline over a
+    // preview that has either already drawn or already said what went wrong.
+    if (this.previewDrawn || this.errorReported) return;
+
+    this.previewSettled = new Promise<void>(resolve => (this.settlePreview = resolve));
+
+    // Held against the previewer this attempt was for, not whichever is current when it expires, so
+    // a preview the user has already moved on from can't accuse the one that replaced it
+    const previewer = this.previewer;
+    this.loadDeadline = setTimeout(() => {
+      this.loadDeadline = undefined;
+      if (!this.previewDrawn && this.previewer === previewer) {
+        this.reportError(new TimeoutError(`a tile of ${previewer.url}`, previewer.loadTimeout));
+      }
+      // Reached whether or not an alert went up: reportError only speaks once per attempt, and a
+      // preview that has since been replaced gets no alert at all, but this attempt is over either
+      // way and whatever is waiting on it has to be let go.
+      this.clearLoadDeadline();
+    }, previewer.loadTimeout);
+  }
+
+  // Ends the current attempt's wait, from any of the four things that can end it: its first tile
+  // arriving, its deadline expiring, an error being reported, or the attempt being abandoned for a
+  // new load or a teardown.
+  private clearLoadDeadline() {
+    if (this.loadDeadline !== undefined) {
+      clearTimeout(this.loadDeadline);
+      this.loadDeadline = undefined;
+    }
+    this.settlePreview();
+  }
+
   // Emit a single preview error per load attempt
   private reportError(error: unknown) {
     if (this.errorReported || !this.previewer) return;
     this.errorReported = true;
+    // Whatever the deadline was still waiting for, it has nothing left to add: the alert it would
+    // have raised is the one already going up
+    this.clearLoadDeadline();
     this.previewError.emit(referenceError(error, this.previewer.label(), this.previewer.url));
   }
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
 
-import { HttpError, PreviewError, fetchOrThrow, recordError, referenceError } from './errors';
+import { HttpError, PreviewError, TimeoutError, fetchOrThrow, recordError, referenceError } from './errors';
 
 describe('errors', () => {
   afterEach(() => vi.restoreAllMocks());
@@ -14,6 +14,16 @@ describe('errors', () => {
       expect(error.statusText).toBe('Not Found');
       expect(error.url).toBe('http://example.com/x');
       expect(error.message).toContain('404');
+    });
+  });
+
+  describe('TimeoutError', () => {
+    it('records what was waited for and how long, for the console rather than the alert', () => {
+      const error = new TimeoutError('a tile of http://example.com/wms', 20_000);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('TimeoutError');
+      expect(error.message).toContain('http://example.com/wms');
+      expect(error.message).toContain('20000');
     });
   });
 
@@ -108,6 +118,21 @@ describe('errors', () => {
       expect(error.title).toBe("The Web Map Service (WMS) preview couldn't be reached");
       expect(error.message).toMatch(/CORS/);
       expect(error.message).not.toContain('HTTP 0');
+    });
+
+    it('classifies a TimeoutError as a timeout, not as a read error', () => {
+      const error = referenceError(new TimeoutError('a tile of http://example.com/wms', 20_000), 'Web Map Service (WMS)', 'http://example.com/wms');
+      expect(error.title).toBe('The Web Map Service (WMS) preview timed out');
+      expect(error.url).toBe('http://example.com/wms');
+    });
+
+    // A deadline expiring says nothing about how the server answered, so the alert must not read as
+    // though one had. The internal message names a tile and a duration; neither belongs on screen.
+    it('describes what a timeout means rather than repeating the internal message', () => {
+      const error = referenceError(new TimeoutError('a tile of http://example.com/wms', 20_000), 'WMS');
+      expect(error.message).not.toContain('20000');
+      expect(error.message).not.toMatch(/tile/i);
+      expect(error.message).toMatch(/in time/);
     });
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -71,6 +71,28 @@ class ReferenceReadError extends PreviewError {
   }
 }
 
+// Nothing the reference could be drawn from arrived before we stopped waiting. Says what we
+// observed rather than naming a cause, because the two failures that land here look identical from
+// the outside: a host that never answers at all, and a server that answers every tile with a 404 -
+// which MapLibre swallows on purpose, since a missing tile of an XYZ pyramid means "use the parent".
+class ReferenceTimeoutError extends PreviewError {
+  constructor(refType: string, url?: string) {
+    super('Data failed to load in time. The server may be unreachable or overloaded, or it may not hold the requested data.');
+    this.title = `The ${refType} preview timed out`;
+    this.url = url;
+  }
+}
+
+// Used to report that we stopped waiting for something, rather than that it failed. A carrier like
+// HttpError below: it says which kind of PreviewError to build without the code that raises it
+// having to know about them.
+export class TimeoutError extends Error {
+  constructor(what: string, ms: number) {
+    super(`Gave up waiting for ${what} after ${ms}ms`);
+    this.name = 'TimeoutError';
+  }
+}
+
 // Used to re-raise HTTP responses from fetch() with a non-OK status as PreviewErrors
 export class HttpError extends Error {
   readonly status: number;
@@ -139,6 +161,10 @@ export function recordError(error: unknown, url: string): PreviewError {
 export function referenceError(error: unknown, refType: string, url?: string): PreviewError {
   const status = statusOf(error);
   const message = messageOf(error);
+
+  // Nothing failed; we stopped waiting. Checked first, since this is the one case where we have no
+  // response to describe - not a status, and not a network failure the browser reported.
+  if (error instanceof TimeoutError) return new ReferenceTimeoutError(refType, url);
 
   // The request failed to reach the server at all, or was blocked by CORS.
   if (isNetworkError(error)) return new ReferenceNetworkError(refType, url);

--- a/src/lib/previewers/cog-deck.test.ts
+++ b/src/lib/previewers/cog-deck.test.ts
@@ -299,6 +299,32 @@ describe('DeckCogPreviewer', () => {
       expect(reported).toEqual([]);
     });
 
+    // Nothing this preview draws passes through a MapLibre source, so a tile drawn is news only
+    // deck.gl has. See MapPreviewer.onDrawn.
+    it('says so when deck.gl draws a tile, which nothing on the map would report', async () => {
+      const { previewer } = previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      await previewer.preview();
+
+      drawTile(previewer);
+
+      expect(previewer.reportsDrawing).toBe(true);
+      expect(drawn).toBe(1);
+    });
+
+    it('says nothing about a tile that failed', async () => {
+      const { previewer } = previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      previewer.onError = () => {};
+      await previewer.preview();
+
+      failTile(previewer);
+
+      expect(drawn).toBe(0);
+    });
+
     // A fresh load attempt starts over: the tiles of the last one are gone from the overlay
     it('fails again after the preview is drawn a second time', async () => {
       const { map, previewer } = previewFor();

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -27,6 +27,9 @@ export default class DeckCogPreviewer extends MapPreviewer {
   // console fills up, so this preview asks for the flat map it can actually be culled in.
   readonly projection = 'mercator' as const;
 
+  // deck.gl tells us when a tile is drawn, which nothing on the map would; see reportTileDrawn
+  readonly reportsDrawing = true;
+
   // The overlay deck.gl draws into, shared with any other deck previewer on the same map
   protected deckOverlay: DeckOverlay | undefined;
 
@@ -136,11 +139,19 @@ export default class DeckCogPreviewer extends MapPreviewer {
           [east, north],
         ]);
       },
-      onTileLoad: () => (this.anyTileDrawn = true),
+      onTileLoad: () => this.reportTileDrawn(),
       onTileError: (error: unknown) => this.reportTileError(error),
       parameters: { depthCompare: 'always', cullMode: 'back' },
       pool: this.decoderPool,
     });
+  }
+
+  // One tile drawn answers two questions at once: it tells a later failure that this COG is on the
+  // map after all, so the failure is a hole rather than an absence (see reportTileError), and it
+  // tells whoever is waiting on this preview that it need not keep waiting.
+  protected reportTileDrawn() {
+    this.anyTileDrawn = true;
+    this.onDrawn?.();
   }
 
   // A COG can only fail once its tiles start arriving, which is after preview() has resolved - so a

--- a/src/lib/previewers/georeference.test.ts
+++ b/src/lib/previewers/georeference.test.ts
@@ -7,11 +7,27 @@ import type { MapLibreStyle } from '../themes/maplibre';
 
 // Just enough of a MapLibre map to record what the previewer puts on it. Unlike the other previewer
 // fakes this one has to accept a layer with no source, since that is what a custom layer is - and it
-// refuses a paint property outright, which is what MapLibre does for one.
+// refuses a paint property outright, which is what MapLibre does for one. It also carries MapLibre's
+// event API, because that is where @allmaps/maplibre refires the events its renderer emits: the map,
+// not the layer, is how a layer that paints itself can be heard from.
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
   layoutProperties: [string, string, unknown][] = [];
+  listeners = new Map<string, Set<(event: any) => void>>();
+
+  on(type: string, listener: (event: any) => void) {
+    (this.listeners.get(type) ?? this.listeners.set(type, new Set()).get(type)!).add(listener);
+    return this;
+  }
+  off(type: string, listener: (event: any) => void) {
+    this.listeners.get(type)?.delete(listener);
+    return this;
+  }
+  fire(type: string, event: unknown = {}) {
+    this.listeners.get(type)?.forEach(listener => listener(event));
+    return this;
+  }
 
   getSource(id: string) {
     return this.sources.get(id);
@@ -237,5 +253,66 @@ describe('GeoreferencePreviewer', () => {
 
     expect(map.layers.size).toEqual(0);
     expect(previewer.previewLayers).toEqual([]);
+  });
+
+  // Nothing this preview draws passes through a MapLibre source, so whoever is waiting to hear that
+  // it is really on the map can only hear it from here. See MapPreviewer.onDrawn.
+  describe('reporting its own drawing', () => {
+    const FIRST_TILE = 'firstmaptileloaded';
+
+    it('answers for its own drawing rather than being watched through the map', async () => {
+      const { previewer } = await previewFor();
+      expect(previewer.reportsDrawing).toBe(true);
+    });
+
+    it("says so when Allmaps reports the scan's first tile", async () => {
+      const { map, previewer } = await previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      await previewer.preview();
+
+      map.fire(FIRST_TILE, { layerId: 'bb013fz9675-georeference' });
+
+      expect(drawn).toBe(1);
+    });
+
+    // Every warped layer on one map reports down the same channel, so the news has to be checked
+    // against the layer it is about
+    it('ignores a tile drawn by another warped layer on the same map', async () => {
+      const { map, previewer } = await previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      await previewer.preview();
+
+      map.fire(FIRST_TILE, { layerId: 'some-other-scan-georeference' });
+
+      expect(drawn).toBe(0);
+    });
+
+    // A theme change draws the same preview again into a rebuilt style document with no clearPreview
+    // between, so the listener has to be replaced rather than added to
+    it('reports once per tile after being drawn a second time', async () => {
+      const { map, previewer } = await previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      await previewer.preview();
+      await previewer.preview();
+
+      map.fire(FIRST_TILE, { layerId: 'bb013fz9675-georeference' });
+
+      expect(drawn).toBe(1);
+    });
+
+    it('stops listening once the preview is cleared', async () => {
+      const { map, previewer } = await previewFor();
+      let drawn = 0;
+      previewer.onDrawn = () => (drawn += 1);
+      await previewer.preview();
+      await previewer.clearPreview();
+
+      map.fire(FIRST_TILE, { layerId: 'bb013fz9675-georeference' });
+
+      expect(drawn).toBe(0);
+    });
   });
 });

--- a/src/lib/previewers/georeference.ts
+++ b/src/lib/previewers/georeference.ts
@@ -5,6 +5,15 @@ import MapPreviewer from './map';
 import type IIIFManifestResource from '../resources/iiif-manifest';
 import type { PreviewStyleLayer } from '../layers';
 
+// Allmaps' own event for the first tile of one warped map arriving. @allmaps/maplibre refires every
+// event its renderer emits on the MapLibre map, tagged with the layer it came from, so this is how a
+// layer that paints itself can be heard from at all. Spelled out rather than imported from
+// @allmaps/render's WarpedMapEventType, which @allmaps/maplibre does not re-export.
+const FIRST_TILE_EVENT = 'firstmaptileloaded';
+
+// What @allmaps/maplibre puts on the events it refires: which of its layers the news is about.
+type WarpedMapLayerEvent = { layerId?: string };
+
 // Draws a georeferenced scan as a map layer, warping the IIIF image onto the control points a IIIF
 // Georeference Annotation gives it. The second preview a georeferenced manifest offers: the same
 // resource is also an image to page through, and each of those is its own tab.
@@ -28,6 +37,10 @@ export default class GeoreferencePreviewer extends MapPreviewer {
   // Tilting is the same mistake by another route, that viewport having no pitch either: out by a
   // quarter at 30 degrees and more than double at 60. Nothing to fall back on, so it is held flat.
   readonly maxPitch = 0;
+
+  // Allmaps tells us when the scan's first tile lands, which no MapLibre source would; see
+  // handleFirstTile
+  readonly reportsDrawing = true;
 
   // The layer currently on the map. Kept because opacity and bounds are calls on this object, and
   // MapLibre's getLayer() hands back a wrapper of its own rather than what we added.
@@ -81,9 +94,31 @@ export default class GeoreferencePreviewer extends MapPreviewer {
 
     errors.forEach(error => console.warn(`Could not read a georeferenced map in ${this.url}:`, error));
     if (errors.length === results.length) throw errors[0] ?? new Error('The georeference annotation described no maps that could be drawn.');
+
+    this.watchFirstTile();
   }
 
+  // Listen for the scan's first tile. Registered here rather than in attach() so that it is paired
+  // with clearPreview() below, and taken off first so a theme change - which draws the same preview
+  // again into a rebuilt style document, with no clearPreview between - leaves one listener, not two.
+  //
+  // On the map rather than on the layer, because the layer hands its renderer's events to the map;
+  // and filtered by layer, because every warped layer on this map reports through the same channel.
+  protected watchFirstTile() {
+    const events = this.map as maplibregl.Evented;
+    events.off(FIRST_TILE_EVENT, this.handleFirstTile);
+    events.on(FIRST_TILE_EVENT, this.handleFirstTile);
+  }
+
+  // A bound instance property rather than a method, so that off() above and in clearPreview() has
+  // the same function to remove that on() was given
+  private handleFirstTile = (event: WarpedMapLayerEvent) => {
+    if (event.layerId !== this.getLayerId()) return;
+    this.onDrawn?.();
+  };
+
   async clearPreview() {
+    if (this.attached) (this.map as maplibregl.Evented).off(FIRST_TILE_EVENT, this.handleFirstTile);
     await super.clearPreview();
     this.layer = undefined;
   }

--- a/src/lib/previewers/map.ts
+++ b/src/lib/previewers/map.ts
@@ -23,6 +23,13 @@ export default abstract class MapPreviewer extends Previewer {
   // for anything but 'globe', so a preview can't be put back into a projection it isn't drawn in.
   readonly projection: MapProjection = 'globe';
 
+  // How long this preview has to put something on the map before whoever draws it calls the load a
+  // failure. Only a floor on patience, not a cap: the deadline is cleared by the first tile that
+  // arrives, so this is how long a preview has to show one sign of life, not how long it has to
+  // finish. A preview that is slow by nature can raise it. See <ogm-map>'s startLoadDeadline for why
+  // waiting on the browser instead isn't enough.
+  readonly loadTimeout: number = 20_000;
+
   // How far this preview can be tilted, for the one that can't be tilted as far as MapLibre allows.
   // Allmaps' viewport takes a bearing but no pitch, so a tilted map draws the warped scan at the wrong
   // scale - out by a quarter at 30 degrees. deck.gl is handed the whole view state and needs nothing
@@ -49,6 +56,18 @@ export default abstract class MapPreviewer extends Previewer {
   // DeckCogPreviewer, which has tiles arriving one at a time and most of a viewport's worth of
   // failures to say nothing about.
   onError?: (error: unknown) => void;
+
+  // Where a preview that draws itself says it has drawn something, and the counterpart to onError
+  // above: the same two previews that have no MapLibre source to fail on have none to succeed on
+  // either, so the news that they are really on the map has to come from them. Everything MapLibre
+  // draws is watched through the map's own tile events instead. Set by whoever draws this preview.
+  onDrawn?: () => void;
+
+  // Whether this preview answers for its own drawing through onDrawn. Read rather than assumed,
+  // because the alternative is worse in both directions: a preview held to a deadline it has no way
+  // to satisfy would be called broken while it draws, and one exempted by mistake goes back to
+  // failing silently. See <ogm-map>'s startLoadDeadline.
+  readonly reportsDrawing: boolean = false;
 
   // Stored state for added MapLibre sources and layers to allow for cleanup
   sourceIds: string[] = [];


### PR DESCRIPTION
Also updates the spinner to run until timeout.
