### PR TITLE
Rework overviews and locator maps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
+A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent fades in around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
 
 ```js
 overview.addEventListener('highlightChange', event => markRow(event.detail?.place));

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-To bring one result forward, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). Its marker changes color and rises above the others, and its own extent is drawn around it. The camera doesn't move — something on the page has said which result matters, not where to look — and anything that names neither a row nor an id simply clears the highlight.
+To bring one result forward, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). Its marker rises above the others and its own extent is drawn around it, both in the colors a selected feature gets rather than a hovered one — hovering a row is usually what points at it, but what it says is that this is the result being read. The camera doesn't move — something on the page has said which result matters, not where to look — and anything that names neither a row nor an id simply clears the highlight.
 
 ```js
 overview.highlighted = record.id; // or 3, or undefined to clear it

--- a/readme.md
+++ b/readme.md
@@ -66,25 +66,27 @@ ogm-viewer {
 
 Here are the supported properties and what they apply to:
 
-| Property                       | Applies to                                             |
-| ------------------------------ | ------------------------------------------------------ |
-| `--ogm-data-color`             | Polygon fill, line geometry, and circle fill           |
-| `--ogm-highlight-color`        | The same, for a hovered feature                        |
-| `--ogm-selected-color`         | The same, for the feature whose attributes are shown   |
-| `--ogm-invalid-color`          | The same, for a feature marked unavailable             |
-| `--ogm-stroke-color`           | Polygon outlines and circle borders                    |
-| `--ogm-stroke-highlight-color` | Outline of a hovered feature                           |
-| `--ogm-stroke-selected-color`  | Outline of the selected feature                        |
-| `--ogm-stroke-invalid-color`   | Outline of a feature marked unavailable                |
-| `--ogm-text-color`             | Feature label text color                               |
-| `--ogm-text-halo-color`        | Feature label text outline color                       |
-| `--ogm-text-size`              | Feature label font size, in pixels                     |
-| `--ogm-font-family`            | Feature label font name (e.g. `"Noto Sans Regular"`)   |
-| `--ogm-data-opacity`           | Initial opacity of drawn data                          |
-| `--ogm-highlight-opacity`      | Opacity of a highlighted feature                       |
-| `--ogm-bounds-opacity`         | Initial opacity of a bounding box or index map         |
-| `--ogm-padding`                | Gap kept between the data and the view edge (pixels)   |
-| `--ogm-overview-padding`       | Gap for "overview" maps (static, search results, etc.) |
+| Property                       | Applies to                                           |
+| ------------------------------ | ---------------------------------------------------- |
+| `--ogm-data-color`             | Polygon fill, line geometry, and circle fill         |
+| `--ogm-highlight-color`        | The same, for a hovered feature                      |
+| `--ogm-selected-color`         | The same, for the feature whose attributes are shown |
+| `--ogm-invalid-color`          | The same, for a feature marked unavailable           |
+| `--ogm-marker-color`           | Disc a numbered result's marker is drawn on          |
+| `--ogm-marker-highlight-color` | The same, for the highlighted result                 |
+| `--ogm-stroke-color`           | Polygon outlines and circle borders                  |
+| `--ogm-stroke-highlight-color` | Outline of a hovered feature                         |
+| `--ogm-stroke-selected-color`  | Outline of the selected feature                      |
+| `--ogm-stroke-invalid-color`   | Outline of a feature marked unavailable              |
+| `--ogm-text-color`             | Feature label text color                             |
+| `--ogm-text-halo-color`        | Feature label text outline color                     |
+| `--ogm-text-size`              | Feature label font size, in pixels                   |
+| `--ogm-font-family`            | Feature label font name (e.g. `"Noto Sans Regular"`) |
+| `--ogm-data-opacity`           | Initial opacity of drawn data                        |
+| `--ogm-highlight-opacity`      | Opacity of a highlighted feature                     |
+| `--ogm-bounds-opacity`         | Initial opacity of a bounding box or index map       |
+| `--ogm-padding`                | Gap kept between the data and the view edge (pixels) |
+| `--ogm-overview-padding`       | Gap for locator and overview maps (pixels)           |
 
 By default, the viewer uses styles from [Web Awesome](https://webawesome.com/) that match the current mode (dark or light).
 
@@ -92,8 +94,9 @@ You usually only need the four `--ogm-*-color` properties, plus `--ogm-text-colo
 
 - Each outline comes from the color it outlines, moved away from the basemap: darker in light mode, lighter in dark mode. A color you name is used in both modes, but its outline follows the mode, so one declaration reads on either basemap.
 - The label halo comes from `--ogm-text-color`, as black or white — whichever contrasts more, the same choice CSS `contrast-color()` makes. It doesn't consult the mode, because the text color already did.
+- The disc a numbered result sits on comes from the same color, sunk to a fixed depth rather than moved by a step, so the numeral on it is legible on either basemap. The numeral's own color follows from the disc, the same way a halo follows from its text.
 
-`--ogm-stroke-*` and `--ogm-text-halo-color` are there if you want particular ones instead. Like the other colors, one you name is used in both modes.
+`--ogm-marker-*`, `--ogm-stroke-*` and `--ogm-text-halo-color` are there if you want particular ones instead. Like the other colors, one you name is used in both modes.
 
 ### Restricted content
 
@@ -168,6 +171,30 @@ document.querySelector('ogm-previews').previewers = [new GeoJsonPreviewer(geoJso
 ```
 
 `record` and `previewers` are DOM properties too. Neither component has an intrinsic size, so the embedding page should set it via CSS.
+
+#### Locator maps
+
+To show where a single record is — the map GeoBlacklight draws beside a record's metadata — use `<ogm-locator>`. Hand it a `record` and it draws that record's geometry, or the box around it if that's all the record has, and points the camera at what it drew.
+
+```js
+await customElements.whenDefined('ogm-locator');
+
+document.querySelector('ogm-locator').record = record;
+```
+
+`record` is a DOM property, not an attribute. If you've built a `LocationPreviewer` yourself, set `previewer` instead and the record isn't read at all.
+
+The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted, because a locator is read at a glance and a tilted one can't be compared with the next. It reports nothing back: a locator answers one question and has no state an embedding page needs to hear about. The basemap's attribution starts collapsed to the "i" in the corner, since a map this size has little room for it — CARTO and OpenStreetMap both require the credit, so it's there to open rather than gone.
+
+A record with neither `locn_geometry` nor `dcat_bbox` has nowhere to be drawn, so the map opens on the world with nothing on it. Call `record.getGeometry()` first if you'd rather not render the map at all in that case.
+
+Like the other components, `<ogm-locator>` has no intrinsic size, so the embedding page should give it one:
+
+```css
+ogm-locator {
+  height: 250px;
+}
+```
 
 #### Overviews and geosearch
 

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent fades in around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
+A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
 
 ```js
 overview.addEventListener('highlightChange', event => markRow(event.detail?.place));

--- a/readme.md
+++ b/readme.md
@@ -213,11 +213,15 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-To bring one result forward, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). Its marker rises above the others and its own extent is drawn around it, both in the colors a selected feature gets rather than a hovered one — hovering a row is usually what points at it, but what it says is that this is the result being read. The camera doesn't move — something on the page has said which result matters, not where to look — and anything that names neither a row nor an id simply clears the highlight.
+A reader's pointer over a number highlights that result: the marker rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. Nothing else happens — the camera stays where it is, and the viewer reports nothing, since a pointer resting on a number is a question about that number rather than a click.
+
+To highlight one from outside, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). It is drawn exactly as a hovered number is: pointing at a row beside the map and pointing at its number on the map are two ways of saying the same thing, so they get the same drawing. The camera doesn't move here either, and anything that names neither a row nor an id simply clears the highlight.
 
 ```js
 overview.highlighted = record.id; // or 3, or undefined to clear it
 ```
+
+Both can be true at once, of two different results — a page naming one while the reader's pointer is over another — and both are then drawn, since neither statement is a correction of the other.
 
 Set `bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it, and it goes on holding: when the results change, the map returns to it rather than re-framing itself around the new set. It takes the same forms `boundsChange` reports, an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
 

--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ ogm-locator {
 
 #### Overviews and geosearch
 
-For showing just the location (geometry or bounding box) of one or several records, you can use the `<ogm-overview>` component. It takes a list of `record`s and renders a simplified map.
+For showing where several records are — the map beside a page of search results — use `<ogm-overview>`. Hand it a list of `records` and it draws a numbered marker for each one, in the order you gave them.
 
 ```js
 await customElements.whenDefined('ogm-overview');
@@ -206,21 +206,46 @@ await customElements.whenDefined('ogm-overview');
 document.querySelector('ogm-overview').records = [record1, record2];
 ```
 
-With just one record, the globe projection is used. When more than one is provided, the flat map projection is used instead so that everything can be kept in view.
+Nothing of a record is drawn but its number, at the middle of its extent. A record with no geometry still takes up its number, so the numbers keep matching the rows in the list beside the map. Hand it `previewers` instead — a list of `LocationPreviewer`s — and those are numbered instead of the records.
 
-If you set the `geosearch` property on `<ogm-overview>`, the map can be used to search for geographic bounds. The value can be `'auto'` to start in automatic mode, where the map emits `boundsChange` events whenever it moves, or `'manual'` to start in manual mode, where the user must manually trigger the search. Leaving it undefined disables the control.
+The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-```html
-<ogm-overview geosearch="auto"></ogm-overview>
+To bring one result forward, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). Its marker changes color and rises above the others, and its own extent is drawn around it. The camera doesn't move — something on the page has said which result matters, not where to look — and anything that names neither a row nor an id simply clears the highlight.
+
+```js
+overview.highlighted = record.id; // or 3, or undefined to clear it
 ```
 
-To respond to changes in the geographic bounds, listen for the `boundsChange` event on the `<ogm-overview>` element:
+Set `bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it, and it goes on holding: when the results change, the map returns to it rather than re-framing itself around the new set. It takes the same forms `boundsChange` reports, an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
+
+```html
+<ogm-overview bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
+```
+
+Set `geosearch` and a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through the `boundsChange` event; nothing in the viewer answers it, because what a new area means is the embedding page's to say. A line of help text says how to search, and you can replace its wording with `searchHelpText`.
+
+```html
+<ogm-overview geosearch></ogm-overview>
+```
 
 ```javascript
 document.querySelector('ogm-overview').addEventListener('boundsChange', event => {
-  console.log('New bounds:', event.detail); // bounds will have format [minLng, minLat, maxLng, maxLat]
+  // west, south, east, north - with east numerically west of west for a box crossing the antimeridian
+  console.log('New bounds:', event.detail);
 });
 ```
+
+Shift-drag is a mouse gesture, and there's no keyboard equivalent on the map, so keep the page's own search form as the accessible way to search.
+
+##### Upgrading from 0.11
+
+`<ogm-overview>` changed shape in this release, and `<ogm-locator>` above is where a single record now belongs.
+
+- Records are drawn as numbered markers rather than as bounding boxes.
+- `geosearch` is a boolean, and searching is shift+drag only. There is no longer an automatic mode that searches whenever the map moves, and no button. A stale `geosearch="auto"` attribute still switches it on.
+- `searchHereText` and `searchOnMoveText` are gone; `searchHelpText` replaces both.
+- `bounds` now means the area the search is filtered to: it is drawn as a box, and framed with the same gap as everything else rather than exactly.
+- The map always opens as a globe, whatever it was given, and carries a control to flatten it.
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ Here are the supported properties and what they apply to:
 | `--ogm-text-halo-color`        | Feature label text outline color                     |
 | `--ogm-text-size`              | Feature label font size, in pixels                   |
 | `--ogm-font-family`            | Feature label font name (e.g. `"Noto Sans Regular"`) |
+| `--ogm-marker-font`            | CSS font stack for a numbered marker's numeral       |
 | `--ogm-data-opacity`           | Initial opacity of drawn data                        |
 | `--ogm-highlight-opacity`      | Opacity of a highlighted feature                     |
 | `--ogm-bounds-opacity`         | Initial opacity of a bounding box or index map       |
@@ -95,6 +96,8 @@ You usually only need the four `--ogm-*-color` properties, plus `--ogm-text-colo
 - Each outline comes from the color it outlines, moved away from the basemap: darker in light mode, lighter in dark mode. A color you name is used in both modes, but its outline follows the mode, so one declaration reads on either basemap.
 - The label halo comes from `--ogm-text-color`, as black or white — whichever contrasts more, the same choice CSS `contrast-color()` makes. It doesn't consult the mode, because the text color already did.
 - The disc a numbered result sits on comes from the same color, sunk to a fixed depth rather than moved by a step, so the numeral on it is legible on either basemap. The numeral's own color follows from the disc, the same way a halo follows from its text.
+
+A numbered marker is drawn as one image — a disc with its numeral on it — rather than as a circle with text over it. That's what keeps every marker the same size at every zoom, keeps a numeral from ever landing on the marker next to it, and lets the numerals be bold: `--ogm-font-family` names a glyph set the basemap has to serve, while `--ogm-marker-font` is an ordinary CSS stack this library draws with itself.
 
 `--ogm-marker-*`, `--ogm-stroke-*` and `--ogm-text-halo-color` are there if you want particular ones instead. Like the other colors, one you name is used in both modes.
 

--- a/readme.md
+++ b/readme.md
@@ -177,7 +177,7 @@ document.querySelector('ogm-previews').previewers = [new GeoJsonPreviewer(geoJso
 
 #### Locator maps
 
-To show where a single record is — the map GeoBlacklight draws beside a record's metadata — use `<ogm-locator>`. Hand it an `OgmRecord` as `record` and it draws that record's geometry, or the box around it if that's all the record has, and points the camera at what it drew.
+To show where a single record is on earth, you can use the `<ogm-locator>` component. Hand it an `OgmRecord` as `record` and it will draw either the record's full geometry (`locn_geometry`) or its bounding box (`dcat_bbox`) if there's no geometry available.
 
 ```js
 await customElements.whenDefined('ogm-locator');
@@ -187,9 +187,7 @@ document.querySelector('ogm-locator').record = record;
 
 `record` is a DOM property, not an attribute. If you've built a `LocationPreviewer` yourself, set `previewer` instead and the record isn't read at all.
 
-The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted, because a locator is read at a glance and a tilted one can't be compared with the next. It reports nothing back: a locator answers one question and has no state an embedding page needs to hear about. The basemap's attribution starts collapsed to the "i" in the corner, since a map this size has little room for it — CARTO and OpenStreetMap both require the credit, so it's there to open rather than gone.
-
-A record with neither `locn_geometry` nor `dcat_bbox` has nowhere to be drawn, so the map opens on the world with nothing on it. Call `record.getGeometry()` first if you'd rather not render the map at all in that case.
+A record with neither `locn_geometry` nor `dcat_bbox` has nowhere to be drawn, so the map opens on the world with nothing on it.
 
 Like the other components, `<ogm-locator>` has no intrinsic size, so the embedding page should give it one:
 
@@ -201,7 +199,7 @@ ogm-locator {
 
 #### Overviews and geosearch
 
-For showing where several records are — the map beside a page of search results — use `<ogm-overview>`. Hand it a list of `OgmRecord`s as `records` and it draws a numbered marker for each one, in the order you gave them.
+For showing where several records are and searching/filtering them, you can use the `<ogm-overview>` component. Hand it a list of `OgmRecord`s as `records` and it draws a numbered marker for each one, in the order you gave them.
 
 ```js
 await customElements.whenDefined('ogm-overview');
@@ -209,33 +207,23 @@ await customElements.whenDefined('ogm-overview');
 document.querySelector('ogm-overview').records = [record1, record2];
 ```
 
-Nothing of a record is drawn but its number, at the middle of its extent. A record with no geometry still takes up its number, so the numbers keep matching the rows in the list beside the map. Hand it `previewers` instead — what `locationsFor` returns, or a list of `LocationPreviewer`s you built, gaps included — and those are numbered instead of the records.
+Nothing of a record is drawn but its number, at the middle of its extent. A record with no geometry still takes up its number, so the numbers keep matching the rows in the list beside the map. Hand it a list of `LocationPreviewer`s you built and those are numbered instead of the records (GeoBlacklight does this).
 
-The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
-
-A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
+A user's pointer over a number highlights that record and draws its geometry or bounding box temporarily. The `highlightChange` event says which record it is, so you can use this information to update other parts of the page.
 
 ```js
 overview.addEventListener('highlightChange', event => markRow(event.detail?.place));
 ```
 
-The detail carries the result's place in the list counted from one and the id of the record it came from — or, for the `previewers` path, the id of the resource a previewer draws — and is `null` once the pointer has left every number. Only the reader's pointer is reported: setting `highlighted` doesn't come back out, so the obvious handler for this event is free to set it.
+The event detail carries the result's place in the list (counted from one) and the id of the record it came from and is `null` once the pointer has left every number.
 
-To highlight one from outside, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). It is drawn exactly as a hovered number is: pointing at a row beside the map and pointing at its number on the map are two ways of saying the same thing, so they get the same drawing. The camera doesn't move here either, and anything that names neither a row nor an id simply clears the highlight.
+To highlight a record explicitly, set `highlighted` to either its number in the list (counted from one), or the id of the record it came from. Anything else will clear the current highlight. Setting `highlighted` to explicitly highlight a record doesn't fire `highlightChange`, so you won't get an infinite loop.
 
 ```js
 overview.highlighted = record.id; // or 3, or undefined to clear it
 ```
 
-Both can be true at once, of two different results — a page naming one while the reader's pointer is over another — and both are then drawn, since neither statement is a correction of the other.
-
-Set `bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it, and it goes on holding: when the results change, the map returns to it rather than re-framing itself around the new set. It takes the same forms `boundsChange` reports, an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
-
-```html
-<ogm-overview bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
-```
-
-Set `geosearch` and a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through the `boundsChange` event; nothing in the viewer answers it, because what a new area means is the embedding page's to say. A line of help text says how to search, and you can replace its wording with `searchHelpText`.
+Enable `geosearch` and a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through the `boundsChange` event. The help text in the viewer about how to search can be controlled with `searchHelpText`.
 
 ```html
 <ogm-overview geosearch></ogm-overview>
@@ -248,17 +236,11 @@ document.querySelector('ogm-overview').addEventListener('boundsChange', event =>
 });
 ```
 
-Shift-drag is a mouse gesture, and there's no keyboard equivalent on the map, so keep the page's own search form as the accessible way to search.
+Set `bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it. It will accept an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
 
-##### Upgrading from 0.11
-
-`<ogm-overview>` changed shape in this release, and `<ogm-locator>` above is where a single record now belongs.
-
-- Records are drawn as numbered markers rather than as bounding boxes.
-- `geosearch` is a boolean, and searching is shift+drag only. There is no longer an automatic mode that searches whenever the map moves, and no button. A stale `geosearch="auto"` attribute still switches it on.
-- `searchHereText` and `searchOnMoveText` are gone; `searchHelpText` replaces both.
-- `bounds` is new: it names the area the search is filtered to, drawn as a box and framed with the same gap as everything else.
-- The map always opens as a globe, whatever it was given, and carries a control to flatten it.
+```html
+<ogm-overview bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
+```
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,13 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-A reader's pointer over a number highlights that result: the marker rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. Nothing else happens — the camera stays where it is, and the viewer reports nothing, since a pointer resting on a number is a question about that number rather than a click.
+A reader's pointer over a number highlights that result: the marker rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
+
+```js
+overview.addEventListener('highlightChange', event => markRow(event.detail?.place));
+```
+
+The detail carries the result's place in the list counted from one and the id of the record it came from — or, for the `previewers` path, the id of the resource a previewer draws — and is `null` once the pointer has left every number. Only the reader's pointer is reported: setting `highlighted` doesn't come back out, so the obvious handler for this event is free to set it.
 
 To highlight one from outside, set `highlighted` to either its place in the list counted from one, or the id of the record it came from (or, for the `previewers` path, the id of the resource a previewer draws). It is drawn exactly as a hovered number is: pointing at a row beside the map and pointing at its number on the map are two ways of saying the same thing, so they get the same drawing. The camera doesn't move here either, and anything that names neither a row nor an id simply clears the highlight.
 

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ document.querySelector('ogm-previews').previewers = [new GeoJsonPreviewer(geoJso
 
 #### Locator maps
 
-To show where a single record is — the map GeoBlacklight draws beside a record's metadata — use `<ogm-locator>`. Hand it a `record` and it draws that record's geometry, or the box around it if that's all the record has, and points the camera at what it drew.
+To show where a single record is — the map GeoBlacklight draws beside a record's metadata — use `<ogm-locator>`. Hand it an `OgmRecord` as `record` and it draws that record's geometry, or the box around it if that's all the record has, and points the camera at what it drew.
 
 ```js
 await customElements.whenDefined('ogm-locator');
@@ -198,7 +198,7 @@ ogm-locator {
 
 #### Overviews and geosearch
 
-For showing where several records are — the map beside a page of search results — use `<ogm-overview>`. Hand it a list of `records` and it draws a numbered marker for each one, in the order you gave them.
+For showing where several records are — the map beside a page of search results — use `<ogm-overview>`. Hand it a list of `OgmRecord`s as `records` and it draws a numbered marker for each one, in the order you gave them.
 
 ```js
 await customElements.whenDefined('ogm-overview');
@@ -206,7 +206,7 @@ await customElements.whenDefined('ogm-overview');
 document.querySelector('ogm-overview').records = [record1, record2];
 ```
 
-Nothing of a record is drawn but its number, at the middle of its extent. A record with no geometry still takes up its number, so the numbers keep matching the rows in the list beside the map. Hand it `previewers` instead — a list of `LocationPreviewer`s — and those are numbered instead of the records.
+Nothing of a record is drawn but its number, at the middle of its extent. A record with no geometry still takes up its number, so the numbers keep matching the rows in the list beside the map. Hand it `previewers` instead — what `locationsFor` returns, or a list of `LocationPreviewer`s you built, gaps included — and those are numbered instead of the records.
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
@@ -244,7 +244,7 @@ Shift-drag is a mouse gesture, and there's no keyboard equivalent on the map, so
 - Records are drawn as numbered markers rather than as bounding boxes.
 - `geosearch` is a boolean, and searching is shift+drag only. There is no longer an automatic mode that searches whenever the map moves, and no button. A stale `geosearch="auto"` attribute still switches it on.
 - `searchHereText` and `searchOnMoveText` are gone; `searchHelpText` replaces both.
-- `bounds` now means the area the search is filtered to: it is drawn as a box, and framed with the same gap as everything else rather than exactly.
+- `bounds` is new: it names the area the search is filtered to, drawn as a box and framed with the same gap as everything else.
 - The map always opens as a globe, whatever it was given, and carries a control to flatten it.
 
 ## Development

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ Nothing of a record is drawn but its number, at the middle of its extent. A reco
 
 The map opens as a globe, with a button beside the zoom buttons to flatten it. It can be panned and zoomed but not turned or tilted.
 
-A reader's pointer over a number highlights that result: the marker rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
+A reader's pointer over a number highlights that result: the marker grows a little and rises above the others in the colors a highlighted feature gets, and the result's own extent is drawn around it in the same colors. The camera stays where it is — a pointer resting on a number is a question about that number, not a click — and the `highlightChange` event says which result it is, so the list beside the map can light up the matching row:
 
 ```js
 overview.addEventListener('highlightChange', event => markRow(event.detail?.place));

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -315,6 +315,7 @@ declare global {
     };
     interface HTMLOgmOverviewElementEventMap {
         "boundsChange": [number, number, number, number];
+        "highlightChange": { place: number; id: string } | null;
     }
     /**
      * Where several records are: one numbered marker apiece, and optionally a way to search the map for
@@ -501,6 +502,10 @@ declare namespace LocalJSX {
          */
         "highlighted"?: number | string;
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;
+        /**
+          * Which result the reader's pointer is over: its place in the list counted from one, and the id of the record - or of the resource a previewer draws - it came from. Null once the pointer has left every number.  Both terms, because a page holds its results in one or the other, and either is enough to light up the row the reader is pointing at - which is the whole of what this is for:    overview.addEventListener('highlightChange', event => mark(event.detail?.id));  The reader's own pointer only. Setting `highlighted` doesn't come back out: a page that has said which result matters already knows, and reporting it would be a loop waiting to be wired.
+         */
+        "onHighlightChange"?: (event: OgmOverviewCustomEvent<{ place: number; id: string } | null>) => void;
         "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -114,7 +114,7 @@ export namespace Components {
          */
         "geosearch": boolean;
         /**
-          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.
+          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.  A reader's pointer over a number does the same thing without being asked, so both can be true at once - of two different results, if a page names one while the pointer is over another. Each is a way of saying the same thing about a row, so each gets the same drawing; see draw.
          */
         "highlighted"?: number | string;
         "previewers"?: (LocationPreviewer | undefined)[];
@@ -497,7 +497,7 @@ declare namespace LocalJSX {
          */
         "geosearch"?: boolean;
         /**
-          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.
+          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.  A reader's pointer over a number does the same thing without being asked, so both can be true at once - of two different results, if a page names one while the pointer is over another. Each is a way of saying the same thing about a row, so each gets the same drawing; see draw.
          */
         "highlighted"?: number | string;
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -51,6 +51,21 @@ export namespace Components {
         "layers": LayerControl[];
         "theme": 'light' | 'dark';
     }
+    /**
+     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
+     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
+     * One record, or one location built by hand, and nothing else. Several of them at once is a different
+     * question with different answers - which of them is which, and what a reader is meant to compare -
+     * and <ogm-overview> is where those are answered.
+     */
+    interface OgmLocator {
+        "previewer"?: LocationPreviewer;
+        "record"?: OgmRecord;
+        /**
+          * @default themePreference()
+         */
+        "theme": 'light' | 'dark';
+    }
     interface OgmMap {
         "easeMapTo": (options: maplibregl.EaseToOptions) => Promise<maplibregl.Map>;
         /**
@@ -232,6 +247,19 @@ declare global {
         prototype: HTMLOgmLayersElement;
         new (): HTMLOgmLayersElement;
     };
+    /**
+     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
+     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
+     * One record, or one location built by hand, and nothing else. Several of them at once is a different
+     * question with different answers - which of them is which, and what a reader is meant to compare -
+     * and <ogm-overview> is where those are answered.
+     */
+    interface HTMLOgmLocatorElement extends Components.OgmLocator, HTMLStencilElement {
+    }
+    var HTMLOgmLocatorElement: {
+        prototype: HTMLOgmLocatorElement;
+        new (): HTMLOgmLocatorElement;
+    };
     interface HTMLOgmMapElementEventMap {
         "mapIdle": void;
         "mapLoading": void;
@@ -336,6 +364,7 @@ declare global {
         "ogm-attributes": HTMLOgmAttributesElement;
         "ogm-image": HTMLOgmImageElement;
         "ogm-layers": HTMLOgmLayersElement;
+        "ogm-locator": HTMLOgmLocatorElement;
         "ogm-map": HTMLOgmMapElement;
         "ogm-menubar": HTMLOgmMenubarElement;
         "ogm-metadata": HTMLOgmMetadataElement;
@@ -385,6 +414,21 @@ declare namespace LocalJSX {
         "onAllLayersVisibilityChange"?: (event: OgmLayersCustomEvent<boolean>) => void;
         "onLayerOpacityChange"?: (event: OgmLayersCustomEvent<{ id: string; opacity: number }>) => void;
         "onLayerVisibilityChange"?: (event: OgmLayersCustomEvent<{ id: string; visible: boolean }>) => void;
+        "theme"?: 'light' | 'dark';
+    }
+    /**
+     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
+     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
+     * One record, or one location built by hand, and nothing else. Several of them at once is a different
+     * question with different answers - which of them is which, and what a reader is meant to compare -
+     * and <ogm-overview> is where those are answered.
+     */
+    interface OgmLocator {
+        "previewer"?: LocationPreviewer;
+        "record"?: OgmRecord;
+        /**
+          * @default themePreference()
+         */
         "theme"?: 'light' | 'dark';
     }
     interface OgmMap {
@@ -496,6 +540,9 @@ declare namespace LocalJSX {
     interface OgmLayersAttributes {
         "theme": 'light' | 'dark';
     }
+    interface OgmLocatorAttributes {
+        "theme": 'light' | 'dark';
+    }
     interface OgmMapAttributes {
         "theme": 'light' | 'dark';
         "padding": number;
@@ -538,6 +585,7 @@ declare namespace LocalJSX {
         "ogm-attributes": Omit<OgmAttributes, keyof OgmAttributesAttributes> & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes]?: OgmAttributes[K] } & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes as `attr:${K}`]?: OgmAttributesAttributes[K] } & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes as `prop:${K}`]?: OgmAttributes[K] };
         "ogm-image": Omit<OgmImage, keyof OgmImageAttributes> & { [K in keyof OgmImage & keyof OgmImageAttributes]?: OgmImage[K] } & { [K in keyof OgmImage & keyof OgmImageAttributes as `attr:${K}`]?: OgmImageAttributes[K] } & { [K in keyof OgmImage & keyof OgmImageAttributes as `prop:${K}`]?: OgmImage[K] };
         "ogm-layers": Omit<OgmLayers, keyof OgmLayersAttributes> & { [K in keyof OgmLayers & keyof OgmLayersAttributes]?: OgmLayers[K] } & { [K in keyof OgmLayers & keyof OgmLayersAttributes as `attr:${K}`]?: OgmLayersAttributes[K] } & { [K in keyof OgmLayers & keyof OgmLayersAttributes as `prop:${K}`]?: OgmLayers[K] };
+        "ogm-locator": Omit<OgmLocator, keyof OgmLocatorAttributes> & { [K in keyof OgmLocator & keyof OgmLocatorAttributes]?: OgmLocator[K] } & { [K in keyof OgmLocator & keyof OgmLocatorAttributes as `attr:${K}`]?: OgmLocatorAttributes[K] } & { [K in keyof OgmLocator & keyof OgmLocatorAttributes as `prop:${K}`]?: OgmLocator[K] };
         "ogm-map": Omit<OgmMap, keyof OgmMapAttributes> & { [K in keyof OgmMap & keyof OgmMapAttributes]?: OgmMap[K] } & { [K in keyof OgmMap & keyof OgmMapAttributes as `attr:${K}`]?: OgmMapAttributes[K] } & { [K in keyof OgmMap & keyof OgmMapAttributes as `prop:${K}`]?: OgmMap[K] };
         "ogm-menubar": Omit<OgmMenubar, keyof OgmMenubarAttributes> & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes]?: OgmMenubar[K] } & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes as `attr:${K}`]?: OgmMenubarAttributes[K] } & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes as `prop:${K}`]?: OgmMenubar[K] };
         "ogm-metadata": Omit<OgmMetadata, keyof OgmMetadataAttributes> & { [K in keyof OgmMetadata & keyof OgmMetadataAttributes]?: OgmMetadata[K] } & { [K in keyof OgmMetadata & keyof OgmMetadataAttributes as `attr:${K}`]?: OgmMetadataAttributes[K] } & { [K in keyof OgmMetadata & keyof OgmMetadataAttributes as `prop:${K}`]?: OgmMetadata[K] };
@@ -556,6 +604,14 @@ declare module "@stencil/core" {
             "ogm-attributes": LocalJSX.IntrinsicElements["ogm-attributes"] & JSXBase.HTMLAttributes<HTMLOgmAttributesElement>;
             "ogm-image": LocalJSX.IntrinsicElements["ogm-image"] & JSXBase.HTMLAttributes<HTMLOgmImageElement>;
             "ogm-layers": LocalJSX.IntrinsicElements["ogm-layers"] & JSXBase.HTMLAttributes<HTMLOgmLayersElement>;
+            /**
+             * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
+             * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
+             * One record, or one location built by hand, and nothing else. Several of them at once is a different
+             * question with different answers - which of them is which, and what a reader is meant to compare -
+             * and <ogm-overview> is where those are answered.
+             */
+            "ogm-locator": LocalJSX.IntrinsicElements["ogm-locator"] & JSXBase.HTMLAttributes<HTMLOgmLocatorElement>;
             "ogm-map": LocalJSX.IntrinsicElements["ogm-map"] & JSXBase.HTMLAttributes<HTMLOgmMapElement>;
             "ogm-menubar": LocalJSX.IntrinsicElements["ogm-menubar"] & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;
             "ogm-metadata": LocalJSX.IntrinsicElements["ogm-metadata"] & JSXBase.HTMLAttributes<HTMLOgmMetadataElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -51,13 +51,6 @@ export namespace Components {
         "layers": LayerControl[];
         "theme": 'light' | 'dark';
     }
-    /**
-     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
-     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
-     * One record, or one location built by hand, and nothing else. Several of them at once is a different
-     * question with different answers - which of them is which, and what a reader is meant to compare -
-     * and <ogm-overview> is where those are answered.
-     */
     interface OgmLocator {
         "previewer"?: LocationPreviewer;
         "record"?: OgmRecord;
@@ -258,13 +251,6 @@ declare global {
         prototype: HTMLOgmLayersElement;
         new (): HTMLOgmLayersElement;
     };
-    /**
-     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
-     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
-     * One record, or one location built by hand, and nothing else. Several of them at once is a different
-     * question with different answers - which of them is which, and what a reader is meant to compare -
-     * and <ogm-overview> is where those are answered.
-     */
     interface HTMLOgmLocatorElement extends Components.OgmLocator, HTMLStencilElement {
     }
     var HTMLOgmLocatorElement: {
@@ -432,13 +418,6 @@ declare namespace LocalJSX {
         "onLayerVisibilityChange"?: (event: OgmLayersCustomEvent<{ id: string; visible: boolean }>) => void;
         "theme"?: 'light' | 'dark';
     }
-    /**
-     * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
-     * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
-     * One record, or one location built by hand, and nothing else. Several of them at once is a different
-     * question with different answers - which of them is which, and what a reader is meant to compare -
-     * and <ogm-overview> is where those are answered.
-     */
     interface OgmLocator {
         "previewer"?: LocationPreviewer;
         "record"?: OgmRecord;
@@ -635,13 +614,6 @@ declare module "@stencil/core" {
             "ogm-attributes": LocalJSX.IntrinsicElements["ogm-attributes"] & JSXBase.HTMLAttributes<HTMLOgmAttributesElement>;
             "ogm-image": LocalJSX.IntrinsicElements["ogm-image"] & JSXBase.HTMLAttributes<HTMLOgmImageElement>;
             "ogm-layers": LocalJSX.IntrinsicElements["ogm-layers"] & JSXBase.HTMLAttributes<HTMLOgmLayersElement>;
-            /**
-             * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
-             * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
-             * One record, or one location built by hand, and nothing else. Several of them at once is a different
-             * question with different answers - which of them is which, and what a reader is meant to compare -
-             * and <ogm-overview> is where those are answered.
-             */
             "ogm-locator": LocalJSX.IntrinsicElements["ogm-locator"] & JSXBase.HTMLAttributes<HTMLOgmLocatorElement>;
             "ogm-map": LocalJSX.IntrinsicElements["ogm-map"] & JSXBase.HTMLAttributes<HTMLOgmMapElement>;
             "ogm-menubar": LocalJSX.IntrinsicElements["ogm-menubar"] & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -85,6 +85,10 @@ export namespace Components {
      * their geometry or basic bounding boxes.
      */
     interface OgmOverview {
+        /**
+          * Where to point the camera, rather than at whatever is drawn.  Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say where its map opens without any JavaScript at all.  Framed exactly, without the gap or the zoom limit an overview of records gets: the area named is the area on screen, so handing back what `boundsChange` reported leaves the map where the reader already had it. And it goes on holding - whenever what is drawn changes, the map returns here rather than re-framing itself around the new set. Leave it unset for a map that should look at whatever it has been given, which is what an overview usually wants.
+         */
+        "bounds"?: maplibregl.LngLatBoundsLike | string;
         "geosearch"?: 'auto' | 'manual';
         "previewers"?: LocationPreviewer[];
         "records"?: OgmRecord[];
@@ -423,6 +427,10 @@ declare namespace LocalJSX {
      * their geometry or basic bounding boxes.
      */
     interface OgmOverview {
+        /**
+          * Where to point the camera, rather than at whatever is drawn.  Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say where its map opens without any JavaScript at all.  Framed exactly, without the gap or the zoom limit an overview of records gets: the area named is the area on screen, so handing back what `boundsChange` reported leaves the map where the reader already had it. And it goes on holding - whenever what is drawn changes, the map returns here rather than re-framing itself around the new set. Leave it unset for a map that should look at whatever it has been given, which is what an overview usually wants.
+         */
+        "bounds"?: maplibregl.LngLatBoundsLike | string;
         "geosearch"?: 'auto' | 'manual';
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;
         "previewers"?: LocationPreviewer[];
@@ -511,6 +519,7 @@ declare namespace LocalJSX {
         "geosearch": 'auto' | 'manual';
         "searchHereText": string;
         "searchOnMoveText": string;
+        "bounds": maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreviewAttributes {
         "theme": 'light' | 'dark';

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -96,22 +96,33 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     /**
-     * Display the location of one or several records (or previewers) by drawing
-     * their geometry or basic bounding boxes.
+     * Where several records are: one numbered marker apiece, and optionally a way to search the map for
+     * more of them.
+     * Nothing of a record is drawn but its number. A page of boxes says less than a page of numbers a
+     * reader can find again in the list beside the map, and the only two boxes worth drawing are the ones
+     * that answer a question: which area is being searched, and where the one result something outside has
+     * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        /**
+          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Leave it unset for a map that should look at whatever it has been given.
+         */
         "bounds"?: maplibregl.LngLatBoundsLike | string;
-        "geosearch"?: 'auto' | 'manual';
+        /**
+          * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
+          * @default false
+         */
+        "geosearch": boolean;
+        /**
+          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.
+         */
+        "highlighted"?: number | string;
         "previewers"?: LocationPreviewer[];
         "records"?: OgmRecord[];
         /**
-          * @default 'Search here'
+          * @default 'Shift + drag to search an area'
          */
-        "searchHereText": string;
-        /**
-          * @default 'Search when I move the map'
-         */
-        "searchOnMoveText": string;
+        "searchHelpText": string;
         /**
           * @default themePreference()
          */
@@ -306,8 +317,12 @@ declare global {
         "boundsChange": [number, number, number, number];
     }
     /**
-     * Display the location of one or several records (or previewers) by drawing
-     * their geometry or basic bounding boxes.
+     * Where several records are: one numbered marker apiece, and optionally a way to search the map for
+     * more of them.
+     * Nothing of a record is drawn but its number. A page of boxes says less than a page of numbers a
+     * reader can find again in the list beside the map, and the only two boxes worth drawing are the ones
+     * that answer a question: which area is being searched, and where the one result something outside has
+     * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface HTMLOgmOverviewElement extends Components.OgmOverview, HTMLStencilElement {
         addEventListener<K extends keyof HTMLOgmOverviewElementEventMap>(type: K, listener: (this: HTMLOgmOverviewElement, ev: OgmOverviewCustomEvent<HTMLOgmOverviewElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -464,23 +479,34 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     /**
-     * Display the location of one or several records (or previewers) by drawing
-     * their geometry or basic bounding boxes.
+     * Where several records are: one numbered marker apiece, and optionally a way to search the map for
+     * more of them.
+     * Nothing of a record is drawn but its number. A page of boxes says less than a page of numbers a
+     * reader can find again in the list beside the map, and the only two boxes worth drawing are the ones
+     * that answer a question: which area is being searched, and where the one result something outside has
+     * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        /**
+          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Leave it unset for a map that should look at whatever it has been given.
+         */
         "bounds"?: maplibregl.LngLatBoundsLike | string;
-        "geosearch"?: 'auto' | 'manual';
+        /**
+          * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
+          * @default false
+         */
+        "geosearch"?: boolean;
+        /**
+          * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.
+         */
+        "highlighted"?: number | string;
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;
         "previewers"?: LocationPreviewer[];
         "records"?: OgmRecord[];
         /**
-          * @default 'Search here'
+          * @default 'Shift + drag to search an area'
          */
-        "searchHereText"?: string;
-        /**
-          * @default 'Search when I move the map'
-         */
-        "searchOnMoveText"?: string;
+        "searchHelpText"?: string;
         /**
           * @default themePreference()
          */
@@ -557,9 +583,9 @@ declare namespace LocalJSX {
     }
     interface OgmOverviewAttributes {
         "theme": 'light' | 'dark';
-        "geosearch": 'auto' | 'manual';
-        "searchHereText": string;
-        "searchOnMoveText": string;
+        "highlighted": string;
+        "geosearch": boolean;
+        "searchHelpText": string;
         "bounds": maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreviewAttributes {
@@ -616,8 +642,12 @@ declare module "@stencil/core" {
             "ogm-menubar": LocalJSX.IntrinsicElements["ogm-menubar"] & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;
             "ogm-metadata": LocalJSX.IntrinsicElements["ogm-metadata"] & JSXBase.HTMLAttributes<HTMLOgmMetadataElement>;
             /**
-             * Display the location of one or several records (or previewers) by drawing
-             * their geometry or basic bounding boxes.
+             * Where several records are: one numbered marker apiece, and optionally a way to search the map for
+             * more of them.
+             * Nothing of a record is drawn but its number. A page of boxes says less than a page of numbers a
+             * reader can find again in the list beside the map, and the only two boxes worth drawing are the ones
+             * that answer a question: which area is being searched, and where the one result something outside has
+             * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
              */
             "ogm-overview": LocalJSX.IntrinsicElements["ogm-overview"] & JSXBase.HTMLAttributes<HTMLOgmOverviewElement>;
             "ogm-preview": LocalJSX.IntrinsicElements["ogm-preview"] & JSXBase.HTMLAttributes<HTMLOgmPreviewElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -117,7 +117,7 @@ export namespace Components {
           * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.
          */
         "highlighted"?: number | string;
-        "previewers"?: LocationPreviewer[];
+        "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**
           * @default 'Shift + drag to search an area'
@@ -501,7 +501,7 @@ declare namespace LocalJSX {
          */
         "highlighted"?: number | string;
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;
-        "previewers"?: LocationPreviewer[];
+        "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**
           * @default 'Shift + drag to search an area'

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -85,9 +85,6 @@ export namespace Components {
      * their geometry or basic bounding boxes.
      */
     interface OgmOverview {
-        /**
-          * Where to point the camera, rather than at whatever is drawn.  Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say where its map opens without any JavaScript at all.  Framed exactly, without the gap or the zoom limit an overview of records gets: the area named is the area on screen, so handing back what `boundsChange` reported leaves the map where the reader already had it. And it goes on holding - whenever what is drawn changes, the map returns here rather than re-framing itself around the new set. Leave it unset for a map that should look at whatever it has been given, which is what an overview usually wants.
-         */
         "bounds"?: maplibregl.LngLatBoundsLike | string;
         "geosearch"?: 'auto' | 'manual';
         "previewers"?: LocationPreviewer[];
@@ -427,9 +424,6 @@ declare namespace LocalJSX {
      * their geometry or basic bounding boxes.
      */
     interface OgmOverview {
-        /**
-          * Where to point the camera, rather than at whatever is drawn.  Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say where its map opens without any JavaScript at all.  Framed exactly, without the gap or the zoom limit an overview of records gets: the area named is the area on screen, so handing back what `boundsChange` reported leaves the map where the reader already had it. And it goes on holding - whenever what is drawn changes, the map returns here rather than re-framing itself around the new set. Leave it unset for a map that should look at whatever it has been given, which is what an overview usually wants.
-         */
         "bounds"?: maplibregl.LngLatBoundsLike | string;
         "geosearch"?: 'auto' | 'manual';
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;

--- a/src/components/ogm-locator/ogm-locator.css
+++ b/src/components/ogm-locator/ogm-locator.css
@@ -1,0 +1,71 @@
+@import '~maplibre-gl/dist/maplibre-gl.css';
+
+:host {
+  display: block;
+  height: 100%;
+  position: relative;
+}
+
+#map {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+/* Color of the map background ("space" around the globe) */
+.maplibregl-canvas {
+  background-color: var(--wa-color-surface-default);
+}
+
+/* Attribution, which both basemaps require. MapLibre draws it as a white pill with near-black text,
+   which lights up the corner of a dark map; on the same surface tokens as everything else it follows
+   whichever mode the map is drawn in. That it opens as the "i" rather than as the panel behind it is
+   AttributionControl's business and not this file's: there is no state here CSS could tell apart from
+   a panel the reader opened on purpose. */
+.maplibregl-ctrl.maplibregl-ctrl-attrib {
+  color: var(--wa-color-text-normal);
+  background-color: var(--wa-color-surface-default);
+}
+
+/* Subdued the way MapLibre subdues them; on hover its own `color: inherit` picks up the color above
+   and adds the underline. */
+.maplibregl-ctrl-attrib a {
+  color: var(--wa-color-text-quiet);
+}
+
+/* Dark mode map adjustments */
+.wa-dark {
+  /* The zoom and globe buttons, which MapLibre draws as a white pill with near-black glyphs. Turned
+     over wholesale, the same way <ogm-map> does it: those glyphs are background images and can't read
+     a token, so there is nothing here to theme one at a time. The two rules after this are what the
+     inversion costs. The attribution is deliberately left out of it - that one is text on a panel,
+     and inverting it would take the link color and the focus ring's blue with it. */
+  .maplibregl-ctrl.maplibregl-ctrl-group {
+    filter: invert(1);
+  }
+
+  /* Fix for colors appearing orange due to inversion */
+  .maplibregl-ctrl-group button:focus:focus-visible {
+    box-shadow: 0 0 2px 2px #ff6900;
+  }
+
+  /* The globe button while the map is a globe: MapLibre says so by coloring the glyph, and a colored
+     glyph under the inversion above comes out as its opposite. Turned back here so it doesn't. */
+  .maplibregl-ctrl button.maplibregl-ctrl-globe-enabled .maplibregl-ctrl-icon {
+    filter: invert(1);
+  }
+
+  /* The compact attribution button's "i": MapLibre's own glyph with its ink at #fff rather than the
+     default black. A background image can't read a token, so it's replaced rather than themed.
+     MapLibre's translucent white fill for the button goes as well, or it would wash out the pill. */
+  .maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-button {
+    background-color: transparent;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+  }
+
+  /* Attribution showing. MapLibre tints the button black at 5% for this, which is invisible against
+     a dark pill; this is the same tint turned around. */
+  .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-button {
+    background-color: rgb(255 255 255 / 10%);
+  }
+}

--- a/src/components/ogm-locator/ogm-locator.test.tsx
+++ b/src/components/ogm-locator/ogm-locator.test.tsx
@@ -130,7 +130,7 @@ type Locator = HTMLElement & {
   projection: 'globe' | 'mercator';
   addControls: () => void;
   handleStyleLoad: () => Promise<void>;
-  handleProjectionTransition: (event: { newProjection: string }) => Promise<void>;
+  handleProjectionTransition: () => Promise<void>;
   draw: () => Promise<void>;
   frame: () => Promise<void>;
   onRecordChange: () => Promise<void>;
@@ -281,7 +281,10 @@ describe('ogm-locator', () => {
     el.record = record('the-world', { dcat_bbox: THE_WORLD });
     await el.draw();
 
-    await el.handleProjectionTransition({ newProjection: 'mercator' });
+    // The map is already flat by the time it says so: MapLibre changes the projection and announces
+    // the change afterwards, and what the camera does is read off the map rather than off the news
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
 
     expect(frameOf(map)).toEqual([-180, -85, 180, 85]);
   });
@@ -293,7 +296,8 @@ describe('ogm-locator', () => {
     el.record = record('the-world', { dcat_bbox: THE_WORLD });
     await el.draw();
 
-    await el.handleProjectionTransition({ newProjection: 'vertical-perspective' });
+    map.projection = { type: 'vertical-perspective' };
+    await el.handleProjectionTransition();
 
     expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
   });
@@ -306,14 +310,42 @@ describe('ogm-locator', () => {
     el.record = record('one', { dcat_bbox: CALIFORNIA });
     el.mapStyleLoaded = false;
 
-    await el.handleProjectionTransition({ newProjection: 'mercator' });
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
 
-    expect(el.projection).toEqual('globe');
     expect(map.fitBounds).not.toHaveBeenCalled();
 
     await el.handleStyleLoad();
 
     expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+  });
+
+  // The sequence a page that sets the theme as its maps are being built produces, which is what
+  // GeoBlacklight's own theme initializer does: the swap is asked for while the first style document
+  // is still on its way, so that document still lands and raises the flag, and the reset the second
+  // one arrives with falls after it. Taken for the reader reaching for the globe button, that left
+  // the map flat and kept it flat, because the choice was then remembered and put back.
+  it('keeps the globe through a swap asked for before its first style had loaded', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    el.mapStyleLoaded = false;
+
+    el.theme = 'dark';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    // The first document landing, which puts the globe into it and raises the flag
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenLastCalledWith({ type: 'globe' });
+
+    // And then the document the swap asked for, arriving in the projection it names
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenLastCalledWith({ type: 'globe' });
   });
 
   // A style document carries its own projection and neither basemap names one, so every swap arrives

--- a/src/components/ogm-locator/ogm-locator.test.tsx
+++ b/src/components/ogm-locator/ogm-locator.test.tsx
@@ -1,0 +1,479 @@
+import { describe, it, expect, h, vi, beforeEach, afterEach } from '@stencil/vitest';
+
+// Rendered with Stencil's low-level render rather than @stencil/vitest's `render` wrapper, for the
+// same reason ogm-overview's tests are: the wrapper re-throws whatever a lifecycle method leaves
+// behind. componentDidLoad never gets as far as a map here - happy-dom lays nothing out, so the
+// container never has the box whenSized waits for. What's under test is what happens once a map
+// exists, so one is handed to the component afterwards.
+import { render as stencilRender } from '@stencil/core';
+
+import { boundsToBbox } from '../../lib/geometry';
+import LocationPreviewer from '../../lib/previewers/location';
+import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
+import LocationResource from '../../lib/resources/location';
+import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
+
+// Enough of a MapLibre map to draw one location on, to be pointed at it, and to hang the three
+// controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
+// label themselves with, the zoom limits to grey their buttons at, the projection to show, the
+// container to measure - because addControl below really runs onAdd.
+class FakeMap {
+  sources = new Map<string, any>();
+  layers = new Map<string, any>();
+  fitBounds = vi.fn();
+  setSky = vi.fn();
+  setStyle = vi.fn();
+  remove = vi.fn();
+  style = { stylesheet: undefined as unknown, tileManagers: {} as Record<string, unknown> };
+  keyboard = { disableRotation: vi.fn() };
+  touchZoomRotate = { disableRotation: vi.fn() };
+  controls: { control: any; position?: string; element: HTMLElement }[] = [];
+  listeners: Record<string, ((event: unknown) => void)[]> = {};
+  onceListeners: Record<string, ((event: unknown) => void)[]> = {};
+
+  // Written and read back, rather than recorded: which projection the map is in is what decides
+  // whether the camera clamps, and the globe button's own state is read straight off it
+  projection: { type: string } | undefined = undefined;
+  setProjection = vi.fn((spec: { type: string }) => (this.projection = spec));
+  getProjection() {
+    return this.projection;
+  }
+
+  // Resolving the corner the way Map.addControl does, so where a control lands can be asserted:
+  // whatever it was given, else whatever the control asks for, else top right.
+  addControl(control: any, position?: string) {
+    this.controls.push({ control, position: position ?? control.getDefaultPosition?.() ?? 'top-right', element: control.onAdd(this) });
+  }
+  on(event: string, listener: (event: unknown) => void) {
+    (this.listeners[event] ??= []).push(listener);
+  }
+  off(event: string, listener: (event: unknown) => void) {
+    this.listeners[event] = (this.listeners[event] ?? []).filter(bound => bound !== listener);
+  }
+  fire(event: string, data: unknown = {}) {
+    [...(this.listeners[event] ?? [])].forEach(listener => listener(data));
+    [...(this.onceListeners[event] ?? []).splice(0)].forEach(listener => listener(data));
+  }
+
+  // 'moveend' is answered on the spot, because that is the one fitBounds waits on and there is no
+  // camera here to finish moving. Everything else is held until a test fires it - which is what lets
+  // the globe button's wait for a style document be asserted rather than assumed.
+  once(event: string, listener: (event: unknown) => void) {
+    if (event === 'moveend') return listener({});
+    (this.onceListeners[event] ??= []).push(listener);
+  }
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+  addSource(id: string, spec: any) {
+    this.sources.set(id, spec);
+  }
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+  addLayer(layer: any) {
+    this.layers.set(layer.id, layer);
+  }
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+  cameraForBounds() {
+    return { center: [0, 0], zoom: 4 };
+  }
+  // How much of a gap the camera can spare comes off the canvas; see fittablePadding
+  getCanvas() {
+    return { clientWidth: 800, clientHeight: 600 };
+  }
+  getCanvasContainer() {
+    return document.createElement('div');
+  }
+  _getUIString(key: string) {
+    return key;
+  }
+  getZoom() {
+    return 4;
+  }
+  getMinZoom() {
+    return 0;
+  }
+  getMaxZoom() {
+    return 22;
+  }
+}
+
+const record = (id: string, fields: Partial<GeoBlacklightSchemaAardvark> = {}) =>
+  new OgmRecord({
+    id,
+    dct_title_s: id,
+    gbl_resourceClass_sm: ['Datasets'],
+    dct_accessRights_s: 'Public',
+    gbl_mdVersion_s: 'Aardvark',
+    ...fields,
+  } as GeoBlacklightSchemaAardvark);
+
+const CALIFORNIA = 'ENVELOPE(-124.41,-114.13,42.01,32.53)';
+const THE_WORLD = 'ENVELOPE(-180.0,180.0,85.0,-85.0)';
+// An archipelago and a coastline, so the shape and the box around it are two different claims
+const ISLANDS = 'MULTIPOLYGON(((-124 42,-114 42,-114 32,-124 32,-124 42)),((-160 22,-155 22,-155 19,-160 19,-160 22)))';
+
+type Locator = HTMLElement & {
+  record?: OgmRecord;
+  previewer?: LocationPreviewer;
+  theme: 'light' | 'dark';
+  map: FakeMap;
+  mapTheme: MapLibreTheme;
+  mapStyleLoaded: boolean;
+  projection: 'globe' | 'mercator';
+  addControls: () => void;
+  handleStyleLoad: () => Promise<void>;
+  handleProjectionTransition: (event: { newProjection: string }) => Promise<void>;
+  draw: () => Promise<void>;
+  frame: () => Promise<void>;
+  onRecordChange: () => Promise<void>;
+  onThemeChange: () => Promise<void>;
+  componentDidLoad: () => Promise<void>;
+};
+
+const containers: HTMLElement[] = [];
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  containers.splice(0).forEach(container => container.remove());
+  consoleError.mockRestore();
+});
+
+// Mount the component, then hand it the map its own componentDidLoad couldn't build
+const renderLocator = async () => {
+  const container = document.createElement('div');
+  containers.push(container);
+  document.body.appendChild(container);
+  await stencilRender(<ogm-locator></ogm-locator>, container);
+
+  const el = container.firstElementChild as Locator & { componentOnReady?: () => Promise<unknown> };
+  await el.componentOnReady?.();
+  // Anything componentDidLoad reported on the way up is the WebGL gap, not what's under test
+  consoleError.mockClear();
+
+  const map = new FakeMap();
+  Object.assign(el, { map, mapTheme: new MapLibreTheme(el, 'light'), mapStyleLoaded: true });
+  return { el, map };
+};
+
+const drawn = (map: FakeMap) => [...map.layers.keys()];
+const framed = (map: FakeMap) => map.fitBounds.mock.calls.at(-1) as [maplibregl.LngLatBoundsLike, maplibregl.FitBoundsOptions];
+
+// Where the camera was pointed, as west, south, east, north. Two shapes arrive: a camera held to what
+// a globe can face is a LngLatBounds, and one that needed no holding is the pair of corners the
+// resource carries. Each is read as it is rather than put through LngLatBounds.convert, because the
+// bounds a component built came out of the built bundle and so is not an instance of the class this
+// file's own import names - convert would take it for an array and hand back something broken.
+const frameOf = (map: FakeMap): [number, number, number, number] => {
+  const [bounds] = framed(map);
+  if (!Array.isArray(bounds)) return boundsToBbox(bounds as maplibregl.LngLatBounds);
+
+  const [[west, south], [east, north]] = bounds as [[number, number], [number, number]];
+  return [west, south, east, north];
+};
+
+// The basemap's own credit arriving, which is what MapLibre would answer by opening the panel
+const credit = (map: FakeMap) => {
+  map.style.stylesheet = {};
+  map.style.tileManagers = { basemap: { used: true, getSource: () => ({ attribution: '© CARTO' }) } };
+  map.fire('sourcedata', { dataType: 'source', sourceDataType: 'metadata' });
+};
+
+describe('ogm-locator', () => {
+  it('draws where the record says it is', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    await el.draw();
+
+    expect(drawn(map)).toEqual(['one-location-fill', 'one-location-outline']);
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  // Which is what "the geometry or the bounding box, as appropriate" means: squaring an archipelago
+  // off to its envelope claims a stretch of ocean the record says nothing about.
+  it('draws the shape a record carries rather than the box around it', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { locn_geometry: ISLANDS, dcat_bbox: CALIFORNIA });
+    await el.draw();
+
+    expect(map.sources.get('one-location').data.geometry.type).toEqual('MultiPolygon');
+  });
+
+  it('draws the location it was handed instead of the record’s own', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    el.previewer = new LocationPreviewer(new LocationResource('handed-over', { type: 'Point', coordinates: [0, 0] }));
+    await el.draw();
+
+    expect(drawn(map)).toEqual(['handed-over-location-fill', 'handed-over-location-outline']);
+    expect(map.sources.has('one-location')).toBe(false);
+  });
+
+  it('takes the last location off the map before drawing the next', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    await el.draw();
+
+    el.record = record('two', { dcat_bbox: THE_WORLD });
+    await el.onRecordChange();
+
+    expect(drawn(map)).toEqual(['two-location-fill', 'two-location-outline']);
+    expect(map.sources.has('one-location')).toBe(false);
+  });
+
+  // A record can be ordinary metadata with nothing to place it by. That is not a failure, so it gets
+  // a map of everywhere rather than an empty pane or a complaint.
+  it('shows the world for a record that does not say where it is', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('nowhere');
+    await el.draw();
+
+    expect(drawn(map)).toEqual([]);
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
+  });
+
+  it('shows the world when it has nothing at all to place', async () => {
+    const { el, map } = await renderLocator();
+    await el.draw();
+
+    expect(drawn(map)).toEqual([]);
+    expect(map.fitBounds).toHaveBeenCalled();
+  });
+
+  it('opens on a globe', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    el.mapStyleLoaded = false;
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+    // The order matters: whether the camera clamps is read off the projection it is pointed in
+    expect(map.setProjection.mock.invocationCallOrder[0]).toBeLessThan(map.fitBounds.mock.invocationCallOrder[0]);
+    expect(map.setSky).toHaveBeenCalled();
+  });
+
+  // A globe camera has no answer for anything wider than the half of the world facing it, and would
+  // leave the camera where it was rather than say so
+  it('holds a location wider than a hemisphere to the half of the world around it', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('the-world', { dcat_bbox: THE_WORLD });
+    await el.draw();
+
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
+    expect(drawn(map)).toEqual(['the-world-location-fill', 'the-world-location-outline']);
+  });
+
+  // Which is what the globe button is for on a locator: the whole of a record too wide to fit on a
+  // sphere is only visible on a flat map, so switching to one re-frames rather than staying halved.
+  it('frames the whole of a wide location once the reader flattens the map', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('the-world', { dcat_bbox: THE_WORLD });
+    await el.draw();
+
+    await el.handleProjectionTransition({ newProjection: 'mercator' });
+
+    expect(frameOf(map)).toEqual([-180, -85, 180, 85]);
+  });
+
+  // MapLibre has two names for a sphere: 'globe' draws as one until it is zoomed in far enough that a
+  // sphere and a flat map are the same picture, and 'vertical-perspective' stays one throughout.
+  it('reads a vertical perspective as the globe it is', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('the-world', { dcat_bbox: THE_WORLD });
+    await el.draw();
+
+    await el.handleProjectionTransition({ newProjection: 'vertical-perspective' });
+
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
+  });
+
+  // A style loading is itself a projection change: it ends by setting whatever it names, and neither
+  // basemap names anything, so every style document arrives flat. Read as the reader's own choice,
+  // that flattened a globe on every theme swap.
+  it('keeps the globe a style document resets on its way in', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    el.mapStyleLoaded = false;
+
+    await el.handleProjectionTransition({ newProjection: 'mercator' });
+
+    expect(el.projection).toEqual('globe');
+    expect(map.fitBounds).not.toHaveBeenCalled();
+
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+  });
+
+  // A style document carries its own projection and neither basemap names one, so every swap arrives
+  // flat - and would take a globe the reader had chosen with it
+  it('opens in the projection the reader last chose, after a change of theme', async () => {
+    const { el, map } = await renderLocator();
+    el.projection = 'mercator';
+    el.mapStyleLoaded = false;
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
+  });
+
+  it('holds what it frames away from the edge of the map', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    await el.draw();
+
+    const [, options] = framed(map);
+    expect(options.padding).toEqual(el.mapTheme.getOverviewPadding());
+    expect(options.padding).toBeGreaterThan(el.mapTheme.getPadding());
+  });
+
+  // A point is a box with no width, so unasked MapLibre settles for the map's own maxZoom of 22 -
+  // which is a street, on a map whose job is to say roughly where in the world something is
+  it('opens no closer than city scale, whatever it was asked to frame', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('a-point', { locn_geometry: 'POINT(-122.17 37.43)' });
+    await el.draw();
+
+    expect(framed(map)[1].maxZoom).toEqual(12);
+  });
+
+  it('draws the same location into the style document a theme swap empties', async () => {
+    const { el, map } = await renderLocator();
+    el.record = record('one', { dcat_bbox: CALIFORNIA });
+    await el.draw();
+
+    el.theme = 'dark';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    expect(map.setStyle).toHaveBeenCalledWith(darkBasemapStyle);
+
+    // What setStyle would have emptied, emptied - and then drawn again by the load that follows it
+    map.layers.clear();
+    map.sources.clear();
+    await el.handleStyleLoad();
+
+    expect(drawn(map)).toEqual(['one-location-fill', 'one-location-outline']);
+  });
+
+  it('takes its map down with it', async () => {
+    const { el, map } = await renderLocator();
+    (el as unknown as { disconnectedCallback: () => void }).disconnectedCallback();
+
+    expect(map.remove).toHaveBeenCalled();
+  });
+
+  it('carries the Web Awesome scope, being usable on its own', async () => {
+    const { el } = await renderLocator();
+
+    expect(el.className).toContain('wa-palette-default');
+    expect((el.shadowRoot as ShadowRoot).querySelector('link[rel="stylesheet"]')).toBeTruthy();
+  });
+});
+
+describe('ogm-locator controls', () => {
+  // The no-pitch test as much as the zoom one: with no compass there is no control that can turn or
+  // tilt the map, which is what the compass button and its pitch visualiser are for
+  it('offers zoom buttons and no compass', async () => {
+    const { el, map } = await renderLocator();
+    el.addControls();
+
+    const { element } = map.controls[0];
+    expect(Array.from(element.querySelectorAll('button'), button => button.className)).toEqual(['maplibregl-ctrl-zoom-in', 'maplibregl-ctrl-zoom-out']);
+    expect(element.querySelector('.maplibregl-ctrl-compass')).toBeNull();
+  });
+
+  it('offers a globe button, so a locator can be flattened', async () => {
+    const { el, map } = await renderLocator();
+    el.addControls();
+    map.fire('style.load');
+
+    const globe = map.controls.find(added => added.element.querySelector('[class^="maplibregl-ctrl-globe"]'));
+    expect(globe).toBeTruthy();
+    expect(globe!.position).toEqual('top-right');
+  });
+
+  it('keeps the credit in the corner as an "i" rather than an open panel', async () => {
+    const { el, map } = await renderLocator();
+    el.addControls();
+    credit(map);
+
+    const attribution = map.controls.find(added => added.element.classList.contains('maplibregl-ctrl-attrib'))!;
+    expect(attribution.position).toEqual('bottom-right');
+    expect(attribution.element.classList.contains('maplibregl-compact')).toBe(true);
+    expect(attribution.element.classList.contains('maplibregl-compact-show')).toBe(false);
+    expect(attribution.element.textContent).toContain('CARTO');
+  });
+});
+
+// componentDidLoad waits on the palette's stylesheet, which lands in a later task than the one that
+// rendered - so there is a window in which the locator can be taken off the page while it is still
+// waiting. Nothing may start observing the container after that: whenSized gives up only once the
+// container has a box, and a detached one never gets one, so the observer would outlive the component.
+describe('ogm-locator taken off the page while it waits', () => {
+  // Mounted without being handed a map, so componentDidLoad is left where it really parks
+  const mount = async () => {
+    const container = document.createElement('div');
+    containers.push(container);
+    document.body.appendChild(container);
+    await stencilRender(<ogm-locator></ogm-locator>, container);
+    const el = container.firstElementChild as Locator & { componentOnReady?: () => Promise<unknown> };
+    await el.componentOnReady?.();
+    consoleError.mockClear();
+    return { container, el, link: (el.shadowRoot as ShadowRoot).querySelector('link') as HTMLLinkElement };
+  };
+
+  // Counts what gets observed, since that is the thing that outlives the component
+  const countObservers = () => {
+    const real = globalThis.ResizeObserver;
+    const built: unknown[] = [];
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        built.push(callback);
+        return new real(callback);
+      }
+    } as unknown as typeof ResizeObserver;
+    return { built, restore: () => (globalThis.ResizeObserver = real) };
+  };
+
+  // Driven by hand rather than by whatever the environment does with the stylesheet, so which of the
+  // two arrives first is not left to chance
+  const paletteArrives = async (link: HTMLLinkElement, el: Locator) => {
+    void el.componentDidLoad();
+    link.dispatchEvent(new Event('load'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+  };
+
+  it('waits for a box of its own once its palette has arrived', async () => {
+    const { el, link } = await mount();
+
+    const observers = countObservers();
+    await paletteArrives(link, el);
+    observers.restore();
+
+    expect(observers.built.length).toBeGreaterThan(0);
+  });
+
+  it('observes nothing once it has been taken off the page', async () => {
+    const { container, el, link } = await mount();
+    container.remove();
+
+    const observers = countObservers();
+    await paletteArrives(link, el);
+    observers.restore();
+
+    expect(observers.built).toEqual([]);
+    expect(el.map).toBeUndefined();
+  });
+});

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -5,7 +5,7 @@ import AttributionControl from '../../lib/attribution-control';
 import { getElement } from '../../lib/elements';
 import { WORLD } from '../../lib/geometry';
 import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
-import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, setBasemap, whenSized } from '../../lib/maps';
+import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, readProjection, setBasemap, whenSized } from '../../lib/maps';
 import type { MapProjection } from '../../lib/previewers/map';
 import LocationPreviewer, { locationFor } from '../../lib/previewers/location';
 import type OgmRecord from '../../lib/record';
@@ -29,7 +29,9 @@ export class OgmLocator {
   // Used to prevent trying to style layers before the map is ready
   private mapStyleLoaded: boolean = false;
 
-  // We track this so it survives theme/basemap swaps; MapLibre doesn't track it
+  // Which projection to open a new style document in. Held only for that: a swap arrives flat,
+  // because a style carries its own projection and neither basemap names one, so the map forgets what
+  // the reader was looking at. Everything else asks the map - see readProjection.
   private projection: MapProjection = 'globe';
 
   // What is currently drawn, if there is anything to draw
@@ -97,16 +99,19 @@ export class OgmLocator {
     await this.draw();
   }
 
-  // Called when you click the globe. We remember the projection you chose, and
-  // also reframe everything to match the new projection.
-  private handleProjectionTransition = async (event: maplibregl.MapProjectionEvent) => {
+  /**
+   * The projection changing under the camera, which is worth a fresh one: what a globe can be pointed
+   * at is not what a flat map can - see frameLocation - so flattening one is how a reader sees the
+   * whole of something too wide to fit on a sphere.
+   *
+   * Nothing is remembered here, because this event can't say who caused it. A reader pressing the
+   * globe button and a style document naming its own projection on the way in arrive as the same
+   * thing, and no flag holds them apart: a swap asked for while the map is still loading the document
+   * before it lands that reset squarely inside any window this could call the reader's. What to put
+   * back after a swap is read off the map instead, at the point the swap starts - see onThemeChange.
+   */
+  private handleProjectionTransition = async () => {
     if (!this.mapStyleLoaded) return;
-
-    // Anything that isn't flat is a globe as far as the camera is concerned. MapLibre has two names
-    // for one: 'globe' is the projection that draws as a sphere until it is zoomed in past the point
-    // where a sphere and a flat map are the same picture, and 'vertical-perspective' is the one that
-    // stays a sphere throughout.
-    this.projection = event.newProjection === 'mercator' ? 'mercator' : 'globe';
     await this.frame();
   };
 
@@ -123,6 +128,11 @@ export class OgmLocator {
   protected async onThemeChange() {
     if (!this.map) return;
     this.mapTheme.theme = this.theme;
+
+    // Read now, while the map still knows: the document replacing this one names its own projection
+    // and neither basemap names anything, so the map comes back flat unless it is put back.
+    this.projection = readProjection(this.map) ?? this.projection;
+
     this.mapStyleLoaded = false;
     await setBasemap(this.map, this.mapTheme);
     // style.load has already fired by the time this resolves, and it draws - so there is nothing
@@ -149,7 +159,14 @@ export class OgmLocator {
     if (!this.map || !this.mapStyleLoaded) return;
 
     const extent = await this.drawn?.getBounds();
-    await frameLocation(this.map, this.mapTheme, extent ?? WORLD, this.projection === 'globe', { maxZoom: LOCATION_MAX_ZOOM });
+    await frameLocation(this.map, this.mapTheme, extent ?? WORLD, this.globe(), { maxZoom: LOCATION_MAX_ZOOM });
+  }
+
+  // Whether the camera is pointing at a sphere, which is what decides whether what it is pointed at
+  // has to be held to the half of the world facing it. Asked of the map, because the map is the one
+  // that knows: a reader can change this without anything here being told which way it went.
+  private globe(): boolean {
+    return (readProjection(this.map) ?? this.projection) === 'globe';
   }
 
   // Take the last location back off the map

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -1,0 +1,207 @@
+import { Component, Element, h, Host, Prop, Watch } from '@stencil/core';
+import type maplibregl from 'maplibre-gl';
+
+import AttributionControl from '../../lib/attribution-control';
+import { getElement } from '../../lib/elements';
+import { WORLD } from '../../lib/geometry';
+import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
+import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, setBasemap, whenSized } from '../../lib/maps';
+import type { MapProjection } from '../../lib/previewers/map';
+import LocationPreviewer, { locationFor } from '../../lib/previewers/location';
+import type OgmRecord from '../../lib/record';
+import MapLibreTheme from '../../lib/themes/maplibre';
+
+/**
+ * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
+ * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
+ *
+ * One record, or one location built by hand, and nothing else. Several of them at once is a different
+ * question with different answers - which of them is which, and what a reader is meant to compare -
+ * and <ogm-overview> is where those are answered.
+ */
+@Component({
+  tag: 'ogm-locator',
+  styleUrl: 'ogm-locator.css',
+  shadow: true,
+})
+export class OgmLocator {
+  @Element() el: HTMLElement;
+  @Prop() theme: 'light' | 'dark' = themePreference();
+
+  // The record to place. A DOM property rather than an attribute: an OgmRecord doesn't survive being
+  // written as one.
+  @Prop() record?: OgmRecord;
+
+  // A location built by hand, for an application that has one already. Takes the place of `record`,
+  // which is then not read at all - the same arrangement <ogm-previews> has with its own two.
+  @Prop() previewer?: LocationPreviewer;
+
+  private map: maplibregl.Map;
+  private mapTheme: MapLibreTheme;
+
+  // Used to prevent drawing into a style document that isn't there yet
+  private mapStyleLoaded: boolean = false;
+
+  // Which projection the map is in, as the reader last left it. Held rather than read off the map,
+  // because the map forgets: a style document carries its own projection and neither basemap names
+  // one, so every theme swap arrives flat and would take a globe the reader had chosen with it.
+  // A globe to start with, because one place on a sphere reads better than one place on a rectangle,
+  // and the button to flatten it is right there.
+  private projection: MapProjection = 'globe';
+
+  // What is currently drawn, if there is anything to draw
+  private drawn?: LocationPreviewer;
+
+  async componentDidLoad() {
+    const container = getElement(this.el, '#map');
+
+    // Held until that palette has actually arrived. Once, here, rather than before each draw: the
+    // map is built after it, so nothing that gets drawn on the map can be early.
+    await webAwesomeReady(getElement(this.el, 'link'), container);
+
+    // Taken back off the page while we waited for it. Checked here as well as below, because the wait
+    // below starts observing the container and only gives up once it has a box: a container that has
+    // been detached will never get one, so a locator that came and went before its palette arrived
+    // would leave an observer running behind it for good.
+    if (!this.el.isConnected) return;
+
+    // And until there is a box to build the map into; see whenSized. A locator is as likely as a
+    // preview to be mounted inside something hidden, and draw() answers for having no map yet.
+    await whenSized(container);
+
+    // Taken back off the page while we waited, so there is nothing left to build a map in
+    if (!this.el.isConnected) return;
+
+    this.mapTheme = new MapLibreTheme(container, this.theme);
+    this.map = createMap(container, this.mapTheme, {
+      ...LOCATION_MAP,
+      // Ours instead, added below: MapLibre's opens the credit panel as soon as CARTO's arrives, and
+      // a map this size has no corner to spare for it. See AttributionControl.
+      attributionControl: false,
+      // MapLibre offers shift+drag as a zoom by default. On a map whose whole contract is that it
+      // frames what it drew, that is a camera the reader can move somewhere arbitrary with nothing
+      // to bring it back. <ogm-overview> keeps the gesture and spends it on a search instead.
+      boxZoom: false,
+    });
+    disableRotation(this.map);
+
+    // Before the style loads, because none of them writes anything into it
+    this.addControls();
+
+    // A reader reaching for the globe button, which is worth a fresh camera: what a globe can be
+    // pointed at is not what a flat map can - see frameLocation - so flattening one is how a reader
+    // sees the whole of a record too wide to fit on a sphere.
+    this.map.on('projectiontransition', this.handleProjectionTransition);
+
+    // Everything below lives in the style document, so all of it is done again for each new one: once
+    // at first load, and again after every theme swap.
+    this.map.on('style.load', () => this.handleStyleLoad());
+  }
+
+  // Clean up the map to prevent warnings/errors when removed from the DOM
+  disconnectedCallback() {
+    if (this.map) this.map.remove();
+  }
+
+  private addControls() {
+    addLocationControls(this.map);
+
+    // Bottom right, which is where MapLibre's own would have gone
+    this.map.addControl(new AttributionControl({ compact: true }));
+  }
+
+  // A new style document, which arrives empty: at first load, and again after every theme swap.
+  //
+  // The projection is set here rather than by the camera. A style carries its own and neither basemap
+  // names one, so each document opens flat until this says otherwise; setting it per camera instead
+  // would stamp over the reader's press every time a new record was drawn. It can't happen any
+  // earlier either - setProjection throws before a style has loaded - and it happens before the flag
+  // goes up, so that neither MapLibre's reset nor this correction of it is mistaken for the reader
+  // reaching for the button. The draw below is what frames.
+  private async handleStyleLoad() {
+    this.map.setSky(this.mapTheme.getSkyStyle());
+    this.map.setProjection({ type: this.projection });
+    this.mapStyleLoaded = true;
+    await this.draw();
+  }
+
+  // The reader reaching for the globe button.
+  //
+  // Held to a style document that is already up, because a style loading is itself two of these: it
+  // ends by setting whatever projection it names, which is mercator for both basemaps, and then
+  // handleStyleLoad above puts the reader's choice back. Neither is a choice, and taking the first
+  // for one would flatten a globe on every theme swap - which is what it did.
+  private handleProjectionTransition = async (event: maplibregl.MapProjectionEvent) => {
+    if (!this.mapStyleLoaded) return;
+
+    // Anything that isn't flat is a globe as far as the camera is concerned. MapLibre has two names
+    // for one: 'globe' is the projection that draws as a sphere until it is zoomed in past the point
+    // where a sphere and a flat map are the same picture, and 'vertical-perspective' is the one that
+    // stays a sphere throughout.
+    this.projection = event.newProjection === 'mercator' ? 'mercator' : 'globe';
+    await this.frame();
+  };
+
+  @Watch('record')
+  @Watch('previewer')
+  protected async onRecordChange() {
+    await this.clear();
+    await this.draw();
+  }
+
+  // When the theme changes, swap the basemap to match, then draw the same location into the style
+  // document the swap just emptied.
+  @Watch('theme')
+  protected async onThemeChange() {
+    if (!this.map) return;
+    this.mapTheme.theme = this.theme;
+    this.mapStyleLoaded = false;
+    await setBasemap(this.map, this.mapTheme);
+    // style.load has already fired by the time this resolves, and it draws - so there is nothing
+    // to do here but let it. Kept as an await so a caller can wait for the swap to finish.
+  }
+
+  // Put the record's location on the map, and point the map at it
+  private async draw() {
+    if (!this.map || !this.mapStyleLoaded) return;
+
+    // Only known now: the colors come out of the theme, and the theme can change under a location
+    // that is already on screen.
+    const style = this.mapTheme.getStyle();
+    this.drawn = this.previewer ?? (this.record && locationFor(this.record));
+
+    // Nothing here reaches the network - a LocationResource is built from a shape rather than a URL
+    await this.drawn?.attach(this.map, style).preview();
+
+    await this.frame();
+  }
+
+  // Point the camera at what was drawn, or at the world when there was nothing to draw. A record with
+  // no geometry is ordinary metadata rather than a broken record, so what it gets is a map of
+  // everywhere rather than an empty pane or a complaint.
+  private async frame() {
+    if (!this.map || !this.mapStyleLoaded) return;
+
+    const extent = await this.drawn?.getBounds();
+    await frameLocation(this.map, this.mapTheme, extent ?? WORLD, this.projection === 'globe', { maxZoom: LOCATION_MAX_ZOOM });
+  }
+
+  // Take the last location back off the map
+  private async clear() {
+    await this.drawn?.clearPreview();
+    this.drawn = undefined;
+  }
+
+  // Web Awesome is linked even though nothing here renders a wa-* element: MapLibreTheme reads
+  // --wa-color-* tokens for the shape it draws and the stylesheet reads them for MapLibre's own
+  // chrome, and this component is only ever used on its own, so it is always the one establishing
+  // them.
+  render() {
+    return (
+      <Host class={waScope(this.theme)}>
+        <link rel="stylesheet" href={webAwesomeStylesheet()} />
+        <div id="map" class={waScope(this.theme)}></div>
+      </Host>
+    );
+  }
+}

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -11,14 +11,7 @@ import LocationPreviewer, { locationFor } from '../../lib/previewers/location';
 import type OgmRecord from '../../lib/record';
 import MapLibreTheme from '../../lib/themes/maplibre';
 
-/**
- * Where one record is, on a map of its own: the geometry the record carries, or the box around it if
- * that is all the record has. The map GeoBlacklight draws with Leaflet beside a record's metadata.
- *
- * One record, or one location built by hand, and nothing else. Several of them at once is a different
- * question with different answers - which of them is which, and what a reader is meant to compare -
- * and <ogm-overview> is where those are answered.
- */
+// A component for locating a single record on a map using its geometry
 @Component({
   tag: 'ogm-locator',
   styleUrl: 'ogm-locator.css',
@@ -27,26 +20,16 @@ import MapLibreTheme from '../../lib/themes/maplibre';
 export class OgmLocator {
   @Element() el: HTMLElement;
   @Prop() theme: 'light' | 'dark' = themePreference();
-
-  // The record to place. A DOM property rather than an attribute: an OgmRecord doesn't survive being
-  // written as one.
   @Prop() record?: OgmRecord;
-
-  // A location built by hand, for an application that has one already. Takes the place of `record`,
-  // which is then not read at all - the same arrangement <ogm-previews> has with its own two.
-  @Prop() previewer?: LocationPreviewer;
+  @Prop() previewer?: LocationPreviewer; // Overrides record if passed
 
   private map: maplibregl.Map;
   private mapTheme: MapLibreTheme;
 
-  // Used to prevent drawing into a style document that isn't there yet
+  // Used to prevent trying to style layers before the map is ready
   private mapStyleLoaded: boolean = false;
 
-  // Which projection the map is in, as the reader last left it. Held rather than read off the map,
-  // because the map forgets: a style document carries its own projection and neither basemap names
-  // one, so every theme swap arrives flat and would take a globe the reader had chosen with it.
-  // A globe to start with, because one place on a sphere reads better than one place on a rectangle,
-  // and the button to flatten it is right there.
+  // We track this so it survives theme/basemap swaps; MapLibre doesn't track it
   private projection: MapProjection = 'globe';
 
   // What is currently drawn, if there is anything to draw
@@ -55,8 +38,7 @@ export class OgmLocator {
   async componentDidLoad() {
     const container = getElement(this.el, '#map');
 
-    // Held until that palette has actually arrived. Once, here, rather than before each draw: the
-    // map is built after it, so nothing that gets drawn on the map can be early.
+    // Wait until we can read the palette CSS colors to draw
     await webAwesomeReady(getElement(this.el, 'link'), container);
 
     // Taken back off the page while we waited for it. Checked here as well as below, because the wait
@@ -65,8 +47,8 @@ export class OgmLocator {
     // would leave an observer running behind it for good.
     if (!this.el.isConnected) return;
 
-    // And until there is a box to build the map into; see whenSized. A locator is as likely as a
-    // preview to be mounted inside something hidden, and draw() answers for having no map yet.
+    // Wait until we're inside an element that actually has a box to draw the map
+    // into, otherwise MapLibre will throw errors
     await whenSized(container);
 
     // Taken back off the page while we waited, so there is nothing left to build a map in
@@ -75,13 +57,8 @@ export class OgmLocator {
     this.mapTheme = new MapLibreTheme(container, this.theme);
     this.map = createMap(container, this.mapTheme, {
       ...LOCATION_MAP,
-      // Ours instead, added below: MapLibre's opens the credit panel as soon as CARTO's arrives, and
-      // a map this size has no corner to spare for it. See AttributionControl.
+      // We handle this on our own so we can start it collapsed
       attributionControl: false,
-      // MapLibre offers shift+drag as a zoom by default. On a map whose whole contract is that it
-      // frames what it drew, that is a camera the reader can move somewhere arbitrary with nothing
-      // to bring it back. <ogm-overview> keeps the gesture and spends it on a search instead.
-      boxZoom: false,
     });
     disableRotation(this.map);
 
@@ -110,14 +87,9 @@ export class OgmLocator {
     this.map.addControl(new AttributionControl({ compact: true }));
   }
 
-  // A new style document, which arrives empty: at first load, and again after every theme swap.
-  //
-  // The projection is set here rather than by the camera. A style carries its own and neither basemap
-  // names one, so each document opens flat until this says otherwise; setting it per camera instead
-  // would stamp over the reader's press every time a new record was drawn. It can't happen any
-  // earlier either - setProjection throws before a style has loaded - and it happens before the flag
-  // goes up, so that neither MapLibre's reset nor this correction of it is mistaken for the reader
-  // reaching for the button. The draw below is what frames.
+  // Called on first load and every time the theme is changed. We use the
+  // projection we remembered here to keep it the same; everything else gets
+  // redrawn from scratch.
   private async handleStyleLoad() {
     this.map.setSky(this.mapTheme.getSkyStyle());
     this.map.setProjection({ type: this.projection });
@@ -125,12 +97,8 @@ export class OgmLocator {
     await this.draw();
   }
 
-  // The reader reaching for the globe button.
-  //
-  // Held to a style document that is already up, because a style loading is itself two of these: it
-  // ends by setting whatever projection it names, which is mercator for both basemaps, and then
-  // handleStyleLoad above puts the reader's choice back. Neither is a choice, and taking the first
-  // for one would flatten a globe on every theme swap - which is what it did.
+  // Called when you click the globe. We remember the projection you chose, and
+  // also reframe everything to match the new projection.
   private handleProjectionTransition = async (event: maplibregl.MapProjectionEvent) => {
     if (!this.mapStyleLoaded) return;
 
@@ -176,9 +144,7 @@ export class OgmLocator {
     await this.frame();
   }
 
-  // Point the camera at what was drawn, or at the world when there was nothing to draw. A record with
-  // no geometry is ordinary metadata rather than a broken record, so what it gets is a map of
-  // everywhere rather than an empty pane or a complaint.
+  // Point the camera at what was drawn, or at the world when there was nothing to draw
   private async frame() {
     if (!this.map || !this.mapStyleLoaded) return;
 

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -21,10 +21,12 @@ const feature = {
 // Enough of a MapLibre map for a selection to be drawn on, and to be taken down afterwards
 const fakeMap = () => ({ setFeatureState: vi.fn(), remove: vi.fn() });
 
-// Enough of one to fit bounds on: it can work out a camera for them, it can be moved, and it reports
-// the move as having finished, which is what fitMapBounds waits for before resolving.
+// Enough of one to fit bounds on: it can work out a camera for them, it can say how big its canvas is
+// - which is what decides how much of a gap it can spare - it can be moved, and it reports the move
+// as having finished, which is what fitMapBounds waits for before resolving.
 const fittableMap = () => ({
   cameraForBounds: vi.fn(() => ({ center: [0, 0], zoom: 4 })),
+  getCanvas: () => ({ clientWidth: 800, clientHeight: 600 }),
   fitBounds: vi.fn(),
   easeTo: vi.fn(),
   once: vi.fn((_event: string, listener: () => void) => listener()),

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -22,6 +22,7 @@ import MapLibreTheme from '../../lib/themes/maplibre';
 // fraction of a pixel. Odd-numbered so the clicked pixel is the exact center of the window.
 const QUERY_WINDOW = 51;
 
+// A component for rendering an interactive data preview on a map
 @Component({
   tag: 'ogm-map',
   styleUrl: 'ogm-map.css',
@@ -83,25 +84,23 @@ export class OgmMap {
     // so an --ogm-* override set on the host or on the embedding page still reaches it by inheritance.
     const scope = getElement(this.el, '.container');
     this.mapTheme = new MapLibreTheme(scope, this.theme);
-    // Asked for here, in the same task that rendered the link, and awaited in loadPreview
     this.themeReady = webAwesomeReady(getElement(this.el, 'link'), scope);
 
     // Keep attributes outside Stencil render pipeline so that MapLibre can
-    // use the HTML directly for the popup content. Before the wait below, since nothing about the
-    // popup needs a map to exist and a selection can arrive before one does.
+    // use the HTML directly for the popup content
     this.attributesEl = document.createElement('ogm-attributes') as HTMLOgmAttributesElement;
     this.attributesEl.features = [];
 
-    // A map is only ever built into a container with a box to build it in; see whenSized. Ours can be
-    // mounted inside one that has none - an inactive tab panel, a pane an embedding page has hidden -
-    // and every method below already answers for a component that has no map yet.
+    // Wait until we're inside an element that actually has a box to draw the map
+    // into, otherwise MapLibre will throw errors
     const container = getElement(this.el, '#map');
     await whenSized(container);
 
-    // Taken back off the page while we waited, so there is nothing left to build a map in
+    // Taken back off the page while we waited
     if (!this.el.isConnected) return;
 
     this.map = createMap(container, this.mapTheme, {
+      minZoom: 1,
       cooperativeGestures: true,
       // Read fresh on every request rather than captured once, so it always reflects whichever
       // previewer is currently attached - including across onPreviewerChange, with no watcher of
@@ -110,7 +109,7 @@ export class OgmMap {
       transformRequest: (url, resourceType) => toMapLibreRequest(this.previewer?.requestTransform?.(url, ourResourceType(resourceType)), url),
     });
 
-    // Bound before the controls go on: a control that can't be built shouldn't cost us the preview
+    // Bound before the controls go on, so the preview still works if that fails
     this.map.on('load', () => this.loadPreview());
     this.map.on('mousemove', this.handleHover.bind(this));
     this.map.on('click', this.handleClick.bind(this));

--- a/src/components/ogm-overview/ogm-overview.css
+++ b/src/components/ogm-overview/ogm-overview.css
@@ -17,12 +17,12 @@
   background-color: var(--wa-color-surface-default);
 }
 
-/* The geosearch control, when an embedder has asked for one. Drawn on the same surface tokens as the
-   attribution below rather than out of MapLibre's button chrome, because it carries a line of text
-   instead of a glyph: it deliberately isn't a .maplibregl-ctrl-group, which is both what supplies that
-   chrome and what <ogm-map> inverts wholesale in dark mode. Text under that inversion would take the
-   checkbox's accent and the focus ring with it - the reason ogm-map.css leaves the attribution out of
-   it too - so the tokens follow the mode by themselves here and there is no dark-mode rule below.
+/* The line of text that says how to search, when an embedder has asked for one. Drawn on the same
+   surface tokens as the attribution below rather than out of MapLibre's button chrome, because it
+   carries words instead of a glyph: it deliberately isn't a .maplibregl-ctrl-group, which is both what
+   supplies that chrome and what the dark-mode rules at the end invert wholesale. Text under that
+   inversion would take the focus ring with it - the reason the attribution is left out of it too - so
+   the tokens follow the mode by themselves here and there is no dark-mode rule for this.
    .maplibregl-ctrl on its own still gives the float and the 10px inset from the corner. */
 .maplibregl-ctrl-geosearch {
   color: var(--wa-color-text-normal);
@@ -33,48 +33,34 @@
   font-family: var(--wa-font-family-body);
   font-size: var(--wa-font-size-s);
   line-height: var(--wa-line-height-condensed);
-}
-
-/* One target for the box and the words together. `display` goes on these rather than on the container:
-   an author display beats the [hidden] the mode swap sets, and there are always two of these with one
-   of them hidden. */
-.maplibregl-ctrl-geosearch .on-move,
-.maplibregl-ctrl-geosearch .search-here {
-  display: flex;
-  align-items: center;
-  gap: var(--wa-space-xs);
   padding: var(--wa-space-2xs) var(--wa-space-s);
-  cursor: pointer;
-  text-align: start;
+  /* A translated string can run a good deal longer than ours, and this sits over the map: left to run
+     it would cross the whole thing. Held in characters rather than as a share of the map, because
+     MapLibre's corners are absolutely positioned boxes that shrink to fit whatever floats inside
+     them - a percentage here resolves against a width that is itself waiting on this one, and comes
+     out at a column of single words. */
+  max-width: 24ch;
 }
 
-.maplibregl-ctrl-geosearch [hidden] {
+/* Out of the way while a box is being drawn - which is why nothing above sets `display`: an author
+   display here would beat the rule the browser has for the attribute. */
+.maplibregl-ctrl-geosearch[hidden] {
   display: none;
 }
 
-/* The button reads as the same line of text the label does, rather than as native button chrome inside
-   a panel that is already one */
-.maplibregl-ctrl-geosearch .search-here {
-  appearance: none;
-  background: none;
-  border: 0;
-  color: inherit;
-  font: inherit;
-}
-
-/* The one place a native control's own accent shows through, so it follows the palette and not the
-   browser's blue. The same treatment ogm-layers gives its checkbox. */
-.maplibregl-ctrl-geosearch input {
-  accent-color: var(--wa-color-brand-fill-loud, currentColor);
-  flex: none;
-  margin: 0;
+/* The rectangle a reader drags to search. MapLibre draws its own in white with a near-black dotted
+   edge, which flares on a dark map and reads as nothing in particular on a light one. On the text
+   token instead it lands as a wash in either mode and needs no rule below. Plainer than the box it
+   will produce, deliberately: this one is under the reader's hand and gone in a second. */
+.maplibregl-boxzoom {
+  background-color: var(--wa-color-text-normal);
+  border: 2px dashed var(--wa-color-surface-default);
+  opacity: 0.4;
 }
 
 /* Attribution, which both basemaps require. MapLibre draws it as a white pill with near-black text,
    which lights up the corner of a dark map; on the same surface tokens as everything else it follows
-   whichever mode the map is drawn in. The same rules <ogm-map> carries, minus the ones for the buttons
-   this map doesn't have: the globe is turned by hand rather than by a control, there are no layers to
-   open, and no projection to switch to. */
+   whichever mode the map is drawn in. */
 .maplibregl-ctrl.maplibregl-ctrl-attrib {
   color: var(--wa-color-text-normal);
   background-color: var(--wa-color-surface-default);
@@ -85,6 +71,25 @@
 }
 
 .wa-dark {
+  /* The zoom and globe buttons, which MapLibre draws as a white pill with near-black glyphs. Turned
+     over wholesale, the same way <ogm-map> and <ogm-locator> do it: those glyphs are background
+     images and can't read a token, so there is nothing here to theme one at a time. The two rules
+     after this are what the inversion costs. */
+  .maplibregl-ctrl.maplibregl-ctrl-group {
+    filter: invert(1);
+  }
+
+  /* Fix for colors appearing orange due to inversion */
+  .maplibregl-ctrl-group button:focus:focus-visible {
+    box-shadow: 0 0 2px 2px #ff6900;
+  }
+
+  /* The globe button while the map is a globe: MapLibre says so by coloring the glyph, and a colored
+     glyph under the inversion above comes out as its opposite. Turned back here so it doesn't. */
+  .maplibregl-ctrl button.maplibregl-ctrl-globe-enabled .maplibregl-ctrl-icon {
+    filter: invert(1);
+  }
+
   /* The compact attribution button's "i": MapLibre's own glyph with its ink at #fff rather than the
      default black. A background image can't read a token, so it's replaced rather than themed.
      MapLibre's translucent white fill for the button goes as well, or it would wash out the pill. */

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -176,7 +176,7 @@ type Overview = HTMLElement & {
   addControls: () => void;
   followPointer: () => void;
   handleStyleLoad: () => Promise<void>;
-  handleProjectionTransition: (event: { newProjection: string }) => Promise<void>;
+  handleProjectionTransition: () => Promise<void>;
   load: () => Promise<void>;
   draw: () => void;
   frame: () => Promise<void>;
@@ -367,12 +367,45 @@ describe('ogm-overview', () => {
   // basemap names anything, so every style document arrives flat. Read as the reader's own choice,
   // that flattened a globe on every theme swap.
   it('keeps the globe a style document resets on its way in', async () => {
-    const { el } = await renderOverview();
+    const { el, map } = await renderOverview();
     el.mapStyleLoaded = false;
 
-    await el.handleProjectionTransition({ newProjection: 'mercator' });
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
 
-    expect(el.projection).toEqual('globe');
+    expect(map.fitBounds).not.toHaveBeenCalled();
+
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+  });
+
+  // The sequence a page that sets the theme as its maps are being built produces, which is what
+  // GeoBlacklight's own theme initializer does: the swap is asked for while the first style document
+  // is still on its way, so that document still lands and raises the flag, and the reset the second
+  // one arrives with falls after it. Taken for the reader reaching for the globe button, that left
+  // the map flat and kept it flat, because the choice was then remembered and put back.
+  it('keeps the globe through a swap asked for before its first style had loaded', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
+    el.mapStyleLoaded = false;
+
+    el.theme = 'dark';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    // The first document landing, which puts the globe into it and raises the flag
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenLastCalledWith({ type: 'globe' });
+
+    // And then the document the swap asked for, arriving in the projection it names
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenLastCalledWith({ type: 'globe' });
   });
 
   it('opens in the projection the reader last chose, after a change of theme', async () => {
@@ -411,7 +444,10 @@ describe('ogm-overview', () => {
     await el.load();
     const framedOnce = map.fitBounds.mock.calls.length;
 
-    await el.handleProjectionTransition({ newProjection: 'mercator' });
+    // The map is already flat by the time it says so: MapLibre changes the projection and announces
+    // the change afterwards, and what the camera does is read off the map rather than off the news
+    map.projection = { type: 'mercator' };
+    await el.handleProjectionTransition();
 
     expect(map.fitBounds.mock.calls.length).toBeGreaterThan(framedOnce);
     expect(frameOf(map)).toEqual([-180, -85, 180, 85]);

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -12,7 +12,7 @@ import { boundsToBbox } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import { HIGHLIGHT_BOUNDS, RESULT_HIGHLIGHT, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
+import { HIGHLIGHT_BOUNDS, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
 import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
@@ -22,6 +22,7 @@ import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
+  images = new Map<string, any>();
   fitBounds = vi.fn();
   setSky = vi.fn();
   setStyle = vi.fn();
@@ -76,6 +77,17 @@ class FakeMap {
   once(event: string, listener: (event: unknown) => void) {
     if (event === 'moveend') return listener({});
     (this.onceListeners[event] ??= []).push(listener);
+  }
+
+  // A marker is a picture now, so the images are as much part of what gets drawn as the layers are
+  addImage(id: string, image: any) {
+    this.images.set(id, image);
+  }
+  removeImage(id: string) {
+    this.images.delete(id);
+  }
+  listImages() {
+    return [...this.images.keys()];
   }
 
   getSource(id: string) {
@@ -192,7 +204,7 @@ const renderOverview = async () => {
   return { el, map };
 };
 
-const NUMBER_LAYERS = [`${RESULT_NUMBERS}-circle`, `${RESULT_NUMBERS}-label`, `${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`];
+const MARKER_LAYERS = [RESULT_MARKERS];
 const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
@@ -220,7 +232,7 @@ describe('ogm-overview', () => {
     await el.load();
 
     expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '2']);
-    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
+    expect(layerIds(map)).toEqual(MARKER_LAYERS);
   });
 
   // A page of boxes says less than a page of numbers a reader can find again in the list beside the
@@ -291,7 +303,7 @@ describe('ogm-overview', () => {
     await el.onRecordsChange();
 
     expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1']);
-    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
+    expect(layerIds(map)).toEqual(MARKER_LAYERS);
   });
 
   it('shows the whole world when it has no records to place', async () => {
@@ -425,7 +437,7 @@ describe('ogm-overview search filter', () => {
     el.bounds = CALIFORNIA;
     await el.load();
 
-    expect(layerIds(map)).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...NUMBER_LAYERS]);
+    expect(layerIds(map)).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...MARKER_LAYERS]);
     expect(map.sources.get(SEARCH_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-124.41, 32.53]);
   });
 
@@ -520,10 +532,9 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toEqual('2');
-    // The highlighted pair goes on last, which is the only thing that lifts a whole marker
-    expect(layerIds(map).slice(-2)).toEqual([`${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`]);
-    expect(map.layers.get(`${RESULT_HIGHLIGHT}-circle`).paint['circle-color']).toEqual(el.mapTheme.getStyle().markerHighlightColor);
-    expect(map.layers.get(`${RESULT_NUMBERS}-circle`).paint['circle-color']).toEqual(el.mapTheme.getStyle().markerColor);
+    // It wears a picture of its own, which is what carries the color, and sorts above every other
+    expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual(['ogm-result-marker-1', 'ogm-result-marker-highlight-2']);
+    expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 
   it('draws the highlighted result’s own extent under its number', async () => {
@@ -532,7 +543,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(map.sources.get(HIGHLIGHT_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
-    expect(layerIds(map)).toEqual([...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...NUMBER_LAYERS]);
+    expect(layerIds(map)).toEqual([...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
     expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeHighlightColor);
   });
 
@@ -855,7 +866,7 @@ describe('ogm-overview theme', () => {
     map.sources.clear();
     await el.handleStyleLoad();
 
-    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
+    expect(layerIds(map)).toEqual(MARKER_LAYERS);
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -12,7 +12,7 @@ import { boundsToBbox } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import { HIGHLIGHT_BOUNDS, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
+import { SELECTED_BOUNDS, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
 import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
@@ -209,7 +209,7 @@ const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
 const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);
-const highlightedLabel = (map: FakeMap) => marked(map).find((properties: { highlighted: boolean }) => properties.highlighted)?.label;
+const highlightedLabel = (map: FakeMap) => marked(map).find((properties: { selected: boolean }) => properties.selected)?.label;
 
 const framed = (map: FakeMap) => map.fitBounds.mock.calls.at(-1) as [maplibregl.LngLatBoundsLike, maplibregl.FitBoundsOptions];
 
@@ -526,15 +526,17 @@ describe('ogm-overview highlight', () => {
     return rendered;
   };
 
-  it('brings a highlighted result to the front, in its own color', async () => {
+  // Drawn as a selected feature rather than a hovered one: a hover is what points at it, but what it
+  // says is that this is the result being read
+  it('brings the result it was pointed at to the front, in the colors of a selection', async () => {
     const { el, map } = await two();
     el.highlighted = 2;
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toEqual('2');
     // It wears a picture of its own, which is what carries the color, and sorts above every other
-    expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual(['ogm-result-marker-1', 'ogm-result-marker-highlight-2']);
-    expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
+    expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual(['ogm-result-marker-1', 'ogm-result-marker-selected-2']);
+    expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'selected'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 
   it('draws the highlighted result’s own extent under its number', async () => {
@@ -542,9 +544,9 @@ describe('ogm-overview highlight', () => {
     el.highlighted = 2;
     el.onHighlightedChange();
 
-    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
-    expect(layerIds(map)).toEqual([...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeHighlightColor);
+    expect(map.sources.get(SELECTED_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(layerIds(map)).toEqual([...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeSelectedColor);
   });
 
   it('highlights a result named by id', async () => {
@@ -600,7 +602,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
   });
 
   // A map with no highlight, rather than one with the wrong highlight. Each of these is a value a page
@@ -614,7 +616,7 @@ describe('ogm-overview highlight', () => {
       el.onHighlightedChange();
 
       expect(highlightedLabel(map)).toBeUndefined();
-      expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+      expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
     }
   });
 
@@ -638,7 +640,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
   });
 
   // Something on the page has said which result matters, not where to look
@@ -650,7 +652,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(map.fitBounds.mock.calls.length).toEqual(framedOnce);
-    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(true);
+    expect(map.sources.has(SELECTED_BOUNDS)).toBe(true);
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -227,9 +227,10 @@ const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 // highlight from flashing. See drawResults.
 const ALL_LAYERS = [...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS];
 
-// Whether one of the two boxes has anything in it. Both stay on the map holding nothing when there is
-// nothing to say, so being there is not the question.
-const drawnBox = (map: FakeMap, id: string) => (map.sources.get(id)?.data.features ?? []).length > 0;
+// Whether one of the two boxes is being shown. Both stay on the map once drawn, and so does whatever
+// they were drawn from: what comes and goes is their opacity, so that a box fades rather than appears.
+// See drawBox.
+const drawnBox = (map: FakeMap, id: string) => (map.layers.get(`${id}-outline`)?.paint['line-opacity'] ?? 0) > 0;
 
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
 const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -70,6 +70,10 @@ class FakeMap {
   cameraForBounds() {
     return { center: [0, 0], zoom: 4 };
   }
+  // How much of a gap the camera can spare comes off the canvas; see fittablePadding
+  getCanvas() {
+    return { clientWidth: 800, clientHeight: 600 };
+  }
   once(_event: string, listener: () => void) {
     listener();
   }

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -8,7 +8,7 @@ import { describe, it, expect, h, vi, beforeEach, afterEach } from '@stencil/vit
 import { render as stencilRender } from '@stencil/core';
 import { LngLatBounds } from 'maplibre-gl';
 
-import { WORLD } from '../../lib/geometry';
+import { boundsToBbox, WORLD } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
@@ -96,7 +96,10 @@ type Overview = HTMLElement & {
   mapTheme: MapLibreTheme;
   mapStyleLoaded: boolean;
   draw: () => Promise<void>;
+  frame: () => Promise<void>;
   onRecordsChange: () => Promise<void>;
+  bounds?: number[] | string;
+  onBoundsChange: () => Promise<void>;
   geosearch?: 'auto' | 'manual';
   searchHereText: string;
   searchOnMoveText: string;
@@ -237,6 +240,101 @@ describe('ogm-overview', () => {
     const [, options] = map.fitBounds.mock.calls[0];
     expect(options.padding).toEqual(el.mapTheme.getStyle().overviewPadding);
     expect(options.padding).toBeGreaterThan(el.mapTheme.getPadding());
+  });
+
+  it('points the camera where it was told, rather than at what it drew', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    await el.draw();
+
+    el.bounds = CALIFORNIA;
+    await el.onBoundsChange();
+
+    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
+
+    // Only the view of it changed; what was on the map is still on it, and still where it was
+    expect(boxLayers(map)).toEqual(['one-location-fill', 'one-location-outline']);
+  });
+
+  // An embedder naming an area has already said what they want on screen, so neither the gap nor the
+  // zoom limit an overview of records gets is applied to it
+  it('frames a stated camera exactly', async () => {
+    const { el, map } = await renderOverview();
+    el.bounds = CALIFORNIA;
+    await el.draw();
+
+    expect(map.fitBounds.mock.calls.at(-1)![1]).toEqual({ padding: 0 });
+  });
+
+  // The round trip: the area a reader asked to search, handed back, is a camera that doesn't move
+  it('holds the map where it was when the area it reported is handed back', async () => {
+    const { el, map } = await renderOverview();
+    const view = map.getBounds();
+
+    el.bounds = boundsToBbox(view);
+    await el.draw();
+
+    const [bounds] = map.fitBounds.mock.calls.at(-1)!;
+    expect(bounds.getEast() - bounds.getWest()).toEqual(view.getEast() - view.getWest());
+    expect([bounds.getSouth(), bounds.getNorth()]).toEqual([view.getSouth(), view.getNorth()]);
+  });
+
+  // A globe can't be pointed at every box one might name, so a stated camera is always a flat one
+  it('draws a single record on a flat map when the camera was stated', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
+    el.bounds = ICELAND;
+    await el.draw();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
+  });
+
+  it('returns to a stated camera when what is drawn changes', async () => {
+    const { el, map } = await renderOverview();
+    el.bounds = CALIFORNIA;
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    await el.draw();
+
+    el.records = [record('two', { dcat_bbox: THE_WORLD })];
+    await el.onRecordsChange();
+
+    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  it('goes back to framing what it drew when the camera is withdrawn', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.bounds = CALIFORNIA;
+    await el.draw();
+
+    el.bounds = undefined;
+    await el.onBoundsChange();
+
+    const [bounds, options] = map.fitBounds.mock.calls.at(-1)!;
+    expect(boundsToBbox(bounds)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+    expect(options.maxZoom).toEqual(12);
+  });
+
+  // Which is how a page rendered by a server says where its map opens, without any JavaScript
+  it('takes a camera from an attribute', async () => {
+    const { el, map } = await renderOverview();
+    el.setAttribute('bounds', CALIFORNIA);
+
+    expect(el.bounds).toEqual(CALIFORNIA);
+    await el.frame();
+    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  it('frames what it drew, and says so, when it cannot read the camera it was given', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.bounds = 'somewhere nice';
+    await el.draw();
+
+    expect(consoleWarn).toHaveBeenCalledWith('Could not read bounds:', 'somewhere nice');
+    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-24.55, 63.39, -13.49, 66.57]);
+    consoleWarn.mockRestore();
   });
 
   it('carries the Web Awesome scope, being usable on its own', async () => {

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -227,10 +227,9 @@ const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 // highlight from flashing. See drawResults.
 const ALL_LAYERS = [...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS];
 
-// Whether one of the two boxes is being shown. Both stay on the map once drawn, and so does whatever
-// they were drawn from: what comes and goes is their opacity, so that a box fades rather than appears.
-// See drawBox.
-const drawnBox = (map: FakeMap, id: string) => (map.layers.get(`${id}-outline`)?.paint['line-opacity'] ?? 0) > 0;
+// Whether one of the two boxes has anything in it. Both stay on the map holding nothing when there is
+// nothing to say, so being there is not the question.
+const drawnBox = (map: FakeMap, id: string) => (map.sources.get(id)?.data.features ?? []).length > 0;
 
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
 const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -723,7 +723,12 @@ describe('ogm-overview pointer', () => {
     rendered.el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
     await rendered.el.load();
     rendered.el.followPointer();
-    return rendered;
+
+    // What a page would be listening for, in the order it arrives
+    const reported: unknown[] = [];
+    rendered.el.addEventListener('highlightChange', event => reported.push((event as CustomEvent).detail));
+
+    return { ...rendered, reported };
   };
 
   // The reader's own way of asking the same question the `highlighted` prop asks
@@ -797,6 +802,76 @@ describe('ogm-overview pointer', () => {
     await el.onRecordsChange();
 
     expect(highlightedLabels(map)).toEqual([]);
+  });
+
+  // What a list beside the map needs to light up the row the reader is pointing at. Both terms, since a
+  // page holds its results in one or the other.
+  it('says which result the pointer is over, by place and by id', async () => {
+    const { map, reported } = await hovering();
+    pointAt(map, '2');
+
+    expect(reported).toEqual([{ place: 2, id: 'two' }]);
+  });
+
+  // The id of the resource a previewer draws, which is what that path has instead of a record
+  it('names the resource a previewer draws when that is what it was given', async () => {
+    const { el, map, reported } = await renderOverview().then(async rendered => {
+      rendered.el.previewers = [new LocationPreviewer(new LocationResource('a-resource', { type: 'Point', coordinates: [0, 0] }))];
+      await rendered.el.load();
+      rendered.el.followPointer();
+      const reported: unknown[] = [];
+      rendered.el.addEventListener('highlightChange', event => reported.push((event as CustomEvent).detail));
+      return { ...rendered, reported };
+    });
+    pointAt(map, '1');
+
+    expect(el.previewers).toHaveLength(1);
+    expect(reported).toEqual([{ place: 1, id: 'a-resource' }]);
+  });
+
+  // Null rather than undefined, because that is what a CustomEvent carries either way
+  it('says so when the pointer leaves', async () => {
+    const { map, reported } = await hovering();
+    pointAt(map, '2');
+    pointAway(map);
+
+    expect(reported).toEqual([{ place: 2, id: 'two' }, null]);
+  });
+
+  it('says nothing twice while the pointer stays on the same number', async () => {
+    const { map, reported } = await hovering();
+    pointAt(map, '1');
+    pointAt(map, '1');
+    pointAt(map, '2');
+
+    expect(reported).toEqual([
+      { place: 1, id: 'one' },
+      { place: 2, id: 'two' },
+    ]);
+  });
+
+  // A page that has said which result matters already knows. Reporting it back is a loop waiting to be
+  // wired, since the obvious handler for this event is the one that sets the prop.
+  it('says nothing when the highlight is set from outside', async () => {
+    const { el, reported } = await hovering();
+    el.highlighted = 2;
+    el.onHighlightedChange();
+
+    el.highlighted = undefined;
+    el.onHighlightedChange();
+
+    expect(reported).toEqual([]);
+  });
+
+  // Or the row stays lit beside a map that no longer has that marker on it
+  it('says the pointer is over nothing when the results change under it', async () => {
+    const { el, map, reported } = await hovering();
+    pointAt(map, '2');
+
+    el.records = [record('three', { dcat_bbox: ICELAND })];
+    await el.onRecordsChange();
+
+    expect(reported).toEqual([{ place: 2, id: 'two' }, null]);
   });
 
   // A style document is emptied and rebuilt by a theme swap, but a layer listener is the map's own

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -12,7 +12,7 @@ import { boundsToBbox } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import { SELECTED_BOUNDS, markerImageId, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
+import { HIGHLIGHT_BOUNDS, markerImageId, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
 import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
@@ -60,11 +60,18 @@ class FakeMap {
     this.controls = this.controls.filter(added => added.control !== control);
     control.onRemove(this);
   }
-  on(event: string, listener: (event: unknown) => void) {
-    (this.listeners[event] ??= []).push(listener);
+  on(event: string, layer: unknown, listener?: (event: unknown) => void) {
+    const [key, bound] = this.delegated(event, layer, listener);
+    (this.listeners[key] ??= []).push(bound);
   }
-  off(event: string, listener: (event: unknown) => void) {
-    this.listeners[event] = (this.listeners[event] ?? []).filter(bound => bound !== listener);
+  off(event: string, layer: unknown, listener?: (event: unknown) => void) {
+    const [key, bound] = this.delegated(event, layer, listener);
+    this.listeners[key] = (this.listeners[key] ?? []).filter(other => other !== bound);
+  }
+  // MapLibre takes a layer id in the middle when a listener is only interested in that layer's
+  // features, so the two shapes are told apart the way it tells them apart
+  private delegated(event: string, layer: unknown, listener?: (event: unknown) => void): [string, (event: unknown) => void] {
+    return listener ? [`${event}:${layer}`, listener] : [event, layer as (event: unknown) => void];
   }
   fire(event: string, data: unknown = {}) {
     [...(this.listeners[event] ?? [])].forEach(listener => listener(data));
@@ -167,6 +174,7 @@ type Overview = HTMLElement & {
   geosearch: boolean;
   searchHelpText: string;
   addControls: () => void;
+  followPointer: () => void;
   handleStyleLoad: () => Promise<void>;
   handleProjectionTransition: (event: { newProjection: string }) => Promise<void>;
   load: () => Promise<void>;
@@ -217,15 +225,25 @@ const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 // Every layer an overview draws, in the order they are drawn in. All of them go on with the first draw
 // and none of them ever comes off: what a redraw changes is the data in them, which is what keeps a
 // highlight from flashing. See drawResults.
-const ALL_LAYERS = [...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS];
+const ALL_LAYERS = [...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS];
 
 // Whether one of the two boxes has anything in it. Both stay on the map holding nothing when there is
 // nothing to say, so being there is not the question.
-const drawnBox = (map: FakeMap, id: string) => !!map.sources.get(id)?.data.geometry;
+const drawnBox = (map: FakeMap, id: string) => (map.sources.get(id)?.data.features ?? []).length > 0;
 
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
 const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);
-const highlightedLabel = (map: FakeMap) => marked(map).find((properties: { selected: boolean }) => properties.selected)?.label;
+// A pointer over some of the numbers, and a pointer leaving them, as MapLibre delegates each to a
+// listener bound to that layer. The features arrive in no promised order, so a test can say so.
+const pointAt = (map: FakeMap, ...labels: string[]) => map.fire(`mousemove:${RESULT_MARKERS}`, { features: labels.map(label => ({ properties: { label } })) });
+const pointAway = (map: FakeMap) => map.fire(`mouseleave:${RESULT_MARKERS}`);
+
+// Every number drawn as highlighted, and - where there should only be one - the one of them
+const highlightedLabels = (map: FakeMap): string[] =>
+  marked(map)
+    .filter((properties: { highlighted: boolean }) => properties.highlighted)
+    .map((properties: { label: string }) => properties.label);
+const highlightedLabel = (map: FakeMap) => highlightedLabels(map)[0];
 
 const framed = (map: FakeMap) => map.fitBounds.mock.calls.at(-1) as [maplibregl.LngLatBoundsLike, maplibregl.FitBoundsOptions];
 
@@ -259,7 +277,7 @@ describe('ogm-overview', () => {
     await el.load();
 
     expect(drawnBox(map, SEARCH_BOUNDS)).toBe(false);
-    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
+    expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(false);
   });
 
   // Which is what `locationsFor` hands back, and what the library documents as the way to build these
@@ -456,7 +474,7 @@ describe('ogm-overview search filter', () => {
     await el.load();
 
     expect(layerIds(map)).toEqual(ALL_LAYERS);
-    expect(map.sources.get(SEARCH_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-124.41, 32.53]);
+    expect(map.sources.get(SEARCH_BOUNDS).data.features[0].geometry.coordinates[0][0]).toEqual([-124.41, 32.53]);
   });
 
   it('takes the box away when the search filter is withdrawn', async () => {
@@ -544,9 +562,9 @@ describe('ogm-overview highlight', () => {
     return rendered;
   };
 
-  // Drawn as a selected feature rather than a hovered one: a hover is what points at it, but what it
-  // says is that this is the result being read
-  it('brings the result it was pointed at to the front, in the colors of a selection', async () => {
+  // The colors of a hovered feature, since being pointed at is what is being said - by a page here,
+  // and by the reader's own pointer in the tests below
+  it('brings the result it was pointed at to the front, in the colors of a highlight', async () => {
     const { el, map } = await two();
     el.highlighted = 2;
     el.onHighlightedChange();
@@ -555,7 +573,7 @@ describe('ogm-overview highlight', () => {
     // It wears a picture of its own, which is what carries the color, and sorts above every other
     const style = el.mapTheme.getStyle();
     expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual([markerImageId('1', style), markerImageId('2', style, true)]);
-    expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'selected'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
+    expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 
   it('draws the highlighted result’s own extent under its number', async () => {
@@ -563,9 +581,9 @@ describe('ogm-overview highlight', () => {
     el.highlighted = 2;
     el.onHighlightedChange();
 
-    expect(map.sources.get(SELECTED_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features[0].geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
     expect(layerIds(map)).toEqual(ALL_LAYERS);
-    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeSelectedColor);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeSelectedColor);
   });
 
   it('highlights a result named by id', async () => {
@@ -621,7 +639,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
+    expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(false);
   });
 
   // A map with no highlight, rather than one with the wrong highlight. Each of these is a value a page
@@ -635,7 +653,7 @@ describe('ogm-overview highlight', () => {
       el.onHighlightedChange();
 
       expect(highlightedLabel(map)).toBeUndefined();
-      expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
+      expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(false);
     }
   });
 
@@ -659,7 +677,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
+    expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(false);
   });
 
   // The redraw a hover drives, over and over as the pointer moves down the list beside the map. Nothing
@@ -693,7 +711,106 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(map.fitBounds.mock.calls.length).toEqual(framedOnce);
-    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(true);
+    expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(true);
+  });
+});
+
+describe('ogm-overview pointer', () => {
+  // The pointer is bound to the layer in componentDidLoad, which never gets as far as a map here; see
+  // renderOverview. Everything else about these is what the reader does.
+  const hovering = async () => {
+    const rendered = await renderOverview();
+    rendered.el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
+    await rendered.el.load();
+    rendered.el.followPointer();
+    return rendered;
+  };
+
+  // The reader's own way of asking the same question the `highlighted` prop asks
+  it('highlights the number the pointer is over, and draws its extent', async () => {
+    const { map } = await hovering();
+    pointAt(map, '2');
+
+    expect(highlightedLabels(map)).toEqual(['2']);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features[0].geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+  });
+
+  it('lets the highlight go when the pointer leaves', async () => {
+    const { map } = await hovering();
+    pointAt(map, '2');
+    pointAway(map);
+
+    expect(highlightedLabels(map)).toEqual([]);
+    expect(drawnBox(map, HIGHLIGHT_BOUNDS)).toBe(false);
+  });
+
+  // Markers overlap, and the one the reader can see is the earliest of them, since that is how they are
+  // sorted. MapLibre hands back everything under the pointer without promising an order.
+  it('highlights the number drawn on top where two of them overlap', async () => {
+    const { map } = await hovering();
+    pointAt(map, '2', '1');
+
+    expect(highlightedLabels(map)).toEqual(['1']);
+  });
+
+  // Two separate statements about two different rows, and neither is a correction of the other
+  it('highlights what the page named and what the pointer is over', async () => {
+    const { el, map } = await hovering();
+    el.highlighted = 1;
+    el.onHighlightedChange();
+    pointAt(map, '2');
+
+    expect(highlightedLabels(map)).toEqual(['1', '2']);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toHaveLength(2);
+  });
+
+  // The pointer reports every pixel it crosses, and a marker is a good many pixels wide
+  it('redraws nothing while the pointer stays on the same number', async () => {
+    const { map } = await hovering();
+    pointAt(map, '2');
+    const setData = vi.spyOn(map.sources.get(RESULT_NUMBERS), 'setData');
+
+    pointAt(map, '2');
+    pointAt(map, '2');
+
+    expect(setData).not.toHaveBeenCalled();
+  });
+
+  // Something on the page has said which result matters, not where to look - and a pointer resting on a
+  // number has said even less than that
+  it('leaves the camera where it is when the pointer moves', async () => {
+    const { map } = await hovering();
+    const framed = map.fitBounds.mock.calls.length;
+
+    pointAt(map, '2');
+
+    expect(map.fitBounds.mock.calls.length).toEqual(framed);
+  });
+
+  // The place the pointer named now names a different result, and MapLibre won't say so again: it
+  // reports a pointer that moves, and this one is holding still.
+  it('forgets what the pointer was over when the results change', async () => {
+    const { el, map } = await hovering();
+    pointAt(map, '2');
+
+    el.records = [record('three', { dcat_bbox: ICELAND })];
+    await el.onRecordsChange();
+
+    expect(highlightedLabels(map)).toEqual([]);
+  });
+
+  // A style document is emptied and rebuilt by a theme swap, but a layer listener is the map's own
+  it('goes on following the pointer after a theme swap', async () => {
+    const { el, map } = await hovering();
+
+    el.theme = 'dark';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+    await el.handleStyleLoad();
+    pointAt(map, '2');
+
+    expect(highlightedLabels(map)).toEqual(['2']);
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -6,28 +6,54 @@ import { describe, it, expect, h, vi, beforeEach, afterEach } from '@stencil/vit
 // never has the box whenSized waits for. What's under test is what happens once a map exists, so one
 // is handed to the component afterwards.
 import { render as stencilRender } from '@stencil/core';
-import { LngLatBounds } from 'maplibre-gl';
+import { LngLat, Point } from 'maplibre-gl';
 
-import { boundsToBbox, WORLD } from '../../lib/geometry';
+import { boundsToBbox } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import MapLibreTheme from '../../lib/themes/maplibre';
+import { HIGHLIGHT_BOUNDS, RESULT_HIGHLIGHT, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
+import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
-// Enough of a MapLibre map to draw boxes on and to be pointed at them
+// Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
+// controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
+// label themselves with, the zoom limits to grey their buttons at, the projection to show, the
+// container to measure - because addControl below really runs onAdd.
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
   fitBounds = vi.fn();
-  setProjection = vi.fn();
+  setSky = vi.fn();
+  setStyle = vi.fn();
   remove = vi.fn();
+  keyboard = { disableRotation: vi.fn() };
+  touchZoomRotate = { disableRotation: vi.fn() };
   controls: { control: any; position?: string; element: HTMLElement }[] = [];
   listeners: Record<string, ((event: unknown) => void)[]> = {};
+  onceListeners: Record<string, ((event: unknown) => void)[]> = {};
 
-  // Real enough to build the control against: addControl is what hands it the map it binds to, so a
-  // stand-in that only recorded the call would leave the half being tested unrun.
+  // Enough of the box-zoom handler to be switched on and off, and to have been caught mid-gesture
+  boxZoom = { enable: vi.fn(), disable: vi.fn(), isEnabled: vi.fn(() => true), isActive: vi.fn(() => false), reset: vi.fn() };
+
+  // Written and read back, rather than recorded: which projection the map is in is what decides
+  // whether the camera clamps, and the globe button's own state is read straight off it
+  projection: { type: string } | undefined = undefined;
+  setProjection = vi.fn((spec: { type: string }) => (this.projection = spec));
+  getProjection() {
+    return this.projection;
+  }
+
+  // Pixels read as degrees, upside down. Which is all this needs: what matters is which corner of a
+  // drag becomes which edge of the area reported, and the inversion is the part that matters, since
+  // screen y grows downward and latitude grows upward.
+  unproject([x, y]: [number, number]) {
+    return new LngLat(x, -y);
+  }
+
+  // Resolving the corner the way Map.addControl does, so where a control lands can be asserted:
+  // whatever it was given, else whatever the control asks for, else top right.
   addControl(control: any, position?: string) {
-    this.controls.push({ control, position, element: control.onAdd(this) });
+    this.controls.push({ control, position: position ?? control.getDefaultPosition?.() ?? 'top-right', element: control.onAdd(this) });
   }
   removeControl(control: any) {
     this.controls = this.controls.filter(added => added.control !== control);
@@ -41,12 +67,15 @@ class FakeMap {
   }
   fire(event: string, data: unknown = {}) {
     [...(this.listeners[event] ?? [])].forEach(listener => listener(data));
+    [...(this.onceListeners[event] ?? []).splice(0)].forEach(listener => listener(data));
   }
 
-  // A view the reader has panned three times east: MapLibre never wraps a camera's bounds, so both
-  // edges are out of range and boundsToBbox has something to bring back
-  getBounds() {
-    return new LngLatBounds([530, -10], [560, 10]);
+  // 'moveend' is answered on the spot, because that is the one fitBounds waits on and there is no
+  // camera here to finish moving. Everything else is held until a test fires it - which is what lets
+  // the globe button's wait for a style document be asserted rather than assumed.
+  once(event: string, listener: (event: unknown) => void) {
+    if (event === 'moveend') return listener({});
+    (this.onceListeners[event] ??= []).push(listener);
   }
 
   getSource(id: string) {
@@ -74,8 +103,20 @@ class FakeMap {
   getCanvas() {
     return { clientWidth: 800, clientHeight: 600 };
   }
-  once(_event: string, listener: () => void) {
-    listener();
+  getCanvasContainer() {
+    return document.createElement('div');
+  }
+  _getUIString(key: string) {
+    return key;
+  }
+  getZoom() {
+    return 4;
+  }
+  getMinZoom() {
+    return 0;
+  }
+  getMaxZoom() {
+    return 22;
   }
 }
 
@@ -96,25 +137,31 @@ const THE_WORLD = 'ENVELOPE(-180.0,180.0,85.0,-85.0)';
 type Overview = HTMLElement & {
   records?: OgmRecord[];
   previewers?: LocationPreviewer[];
+  theme: 'light' | 'dark';
   map: FakeMap;
   mapTheme: MapLibreTheme;
   mapStyleLoaded: boolean;
-  draw: () => Promise<void>;
-  frame: () => Promise<void>;
-  onRecordsChange: () => Promise<void>;
+  projection: 'globe' | 'mercator';
+  extents: unknown[];
+  highlighted?: number | string;
   bounds?: number[] | string;
+  geosearch: boolean;
+  searchHelpText: string;
+  addControls: () => void;
+  handleStyleLoad: () => Promise<void>;
+  handleProjectionTransition: (event: { newProjection: string }) => Promise<void>;
+  load: () => Promise<void>;
+  draw: () => void;
+  frame: () => Promise<void>;
+  search: (start: Point, end: Point) => void;
+  onRecordsChange: () => Promise<void>;
   onBoundsChange: () => Promise<void>;
-  geosearch?: 'auto' | 'manual';
-  searchHereText: string;
-  searchOnMoveText: string;
+  onHighlightedChange: () => void;
   onGeosearchChange: () => void;
-  onGeosearchLabelsChange: () => void;
-  emitBounds: () => void;
+  onSearchHelpTextChange: () => void;
+  onThemeChange: () => Promise<void>;
   componentDidLoad: () => Promise<void>;
 };
-
-// The reader's own hand on the camera; see GeosearchControl.handleCameraEnd
-const DROVE = { originalEvent: new MouseEvent('mouseup') };
 
 const containers: HTMLElement[] = [];
 let consoleError: ReturnType<typeof vi.spyOn>;
@@ -126,7 +173,6 @@ beforeEach(() => {
 afterEach(() => {
   containers.splice(0).forEach(container => container.remove());
   consoleError.mockRestore();
-  vi.useRealTimers();
 });
 
 // Mount the component, then hand it the map its own componentDidLoad couldn't build
@@ -146,199 +192,173 @@ const renderOverview = async () => {
   return { el, map };
 };
 
-const boxLayers = (map: FakeMap) => [...map.layers.keys()];
+const NUMBER_LAYERS = [`${RESULT_NUMBERS}-circle`, `${RESULT_NUMBERS}-label`, `${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`];
+const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
+
+const layerIds = (map: FakeMap) => [...map.layers.keys()];
+const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);
+const highlightedLabel = (map: FakeMap) => marked(map).find((properties: { highlighted: boolean }) => properties.highlighted)?.label;
+
+const framed = (map: FakeMap) => map.fitBounds.mock.calls.at(-1) as [maplibregl.LngLatBoundsLike, maplibregl.FitBoundsOptions];
+
+// Where the camera was pointed, as west, south, east, north. Two shapes arrive: a camera held to what
+// a globe can face is a LngLatBounds, and one that needed no holding is whatever it was given. Each
+// is read as it is rather than put through LngLatBounds.convert, because the bounds a component built
+// came out of the built bundle and so is not an instance of the class this file's own import names.
+const frameOf = (map: FakeMap): [number, number, number, number] => {
+  const [bounds] = framed(map);
+  if (!Array.isArray(bounds)) return boundsToBbox(bounds as maplibregl.LngLatBounds);
+
+  const [[west, south], [east, north]] = bounds as [[number, number], [number, number]];
+  return [west, south, east, north];
+};
 
 describe('ogm-overview', () => {
-  it('draws a box for every record it is given', async () => {
+  it('draws a numbered marker for every record it can place', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
-    await el.draw();
+    await el.load();
 
-    expect(boxLayers(map)).toEqual(['one-location-fill', 'one-location-outline', 'two-location-fill', 'two-location-outline']);
+    expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '2']);
+    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
   });
 
-  it('draws the extents it was handed instead of the records’ own', async () => {
+  // A page of boxes says less than a page of numbers a reader can find again in the list beside the
+  // map. The two boxes that are drawn are the ones that answer a question; see below.
+  it('draws nothing of a result but its number', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
+    await el.load();
+
+    expect([...map.sources.keys()]).toEqual([RESULT_NUMBERS]);
+  });
+
+  it('numbers the extents it was handed instead of the records’ own', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: CALIFORNIA })];
     el.previewers = [new LocationPreviewer(new LocationResource('handed-over', { type: 'Point', coordinates: [0, 0] }))];
-    await el.draw();
+    await el.load();
 
-    expect(boxLayers(map)).toEqual(['handed-over-location-fill', 'handed-over-location-outline']);
+    expect(map.sources.get(RESULT_NUMBERS).data.features).toHaveLength(1);
+    expect(map.sources.get(RESULT_NUMBERS).data.features[0].geometry.coordinates).toEqual([0, 0]);
   });
 
-  it('takes the last set of boxes off the map before drawing the next', async () => {
+  // The number is the row a reader sees beside the map, so closing the gap would point every result
+  // after it at the wrong row
+  it('spends a number on a record it has nowhere to put', async () => {
     const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
-    await el.draw();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('nowhere'), record('three', { dcat_bbox: ICELAND })];
+    await el.load();
 
-    el.records = [record('two', { dcat_bbox: ICELAND })];
+    expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '3']);
+  });
+
+  it('takes the last set of numbers off the map before drawing the next', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
+    await el.load();
+
+    el.records = [record('three', { dcat_bbox: ICELAND })];
     await el.onRecordsChange();
 
-    expect(boxLayers(map)).toEqual(['two-location-fill', 'two-location-outline']);
-    expect(map.sources.has('one-location')).toBe(false);
+    expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1']);
+    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
   });
 
   it('shows the whole world when it has no records to place', async () => {
     const { el, map } = await renderOverview();
     el.records = [];
-    await el.draw();
+    await el.load();
 
-    expect(map.fitBounds.mock.calls[0][0]).toEqual(WORLD);
-    expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
+    // Held to the half of the world a globe camera can face; see frameLocation
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
   });
 
-  it('draws a single record on a globe', async () => {
-    const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
-    await el.draw();
-
-    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
-    expect(map.setProjection.mock.invocationCallOrder[0]).toBeLessThan(map.fitBounds.mock.invocationCallOrder[0]);
-  });
-
-  it('draws several records on a flat map', async () => {
+  it('opens on a globe, whatever it has to show', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
-    await el.draw();
+    el.mapStyleLoaded = false;
+    await el.handleStyleLoad();
+
+    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+    // The order matters: whether the camera clamps is read off the projection it is pointed in
+    expect(map.setProjection.mock.invocationCallOrder[0]).toBeLessThan(map.fitBounds.mock.invocationCallOrder[0]);
+    expect(map.setSky).toHaveBeenCalled();
+  });
+
+  // A style loading is itself a projection change: it ends by setting whatever it names, and neither
+  // basemap names anything, so every style document arrives flat. Read as the reader's own choice,
+  // that flattened a globe on every theme swap.
+  it('keeps the globe a style document resets on its way in', async () => {
+    const { el } = await renderOverview();
+    el.mapStyleLoaded = false;
+
+    await el.handleProjectionTransition({ newProjection: 'mercator' });
+
+    expect(el.projection).toEqual('globe');
+  });
+
+  it('opens in the projection the reader last chose, after a change of theme', async () => {
+    const { el, map } = await renderOverview();
+    el.projection = 'mercator';
+    el.mapStyleLoaded = false;
+    await el.handleStyleLoad();
 
     expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
   });
 
-  it('draws a globe when only one of several records says where it is', async () => {
-    const { el, map } = await renderOverview();
-    el.records = [record('nowhere'), record('two', { dcat_bbox: ICELAND }), record('nowhere-either')];
-    await el.draw();
-
-    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
-  });
-
-  it('keeps the globe for a single record too wide to fit on one', async () => {
+  // A globe camera has no answer for anything wider than the half of the world facing it: it hands
+  // back nothing and leaves the camera where it was, rather than saying so
+  it('holds a globe camera to the half of the world it can point at', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('the-world', { dcat_bbox: THE_WORLD })];
-    await el.draw();
+    await el.load();
 
-    expect(map.setProjection).toHaveBeenCalledWith({ type: 'globe' });
-    expect(boxLayers(map)).toEqual(['the-world-location-fill', 'the-world-location-outline']);
-
-    const [bounds] = map.fitBounds.mock.calls[0];
-    expect(bounds.getEast() - bounds.getWest()).toEqual(180);
-    expect(bounds.getCenter().lng).toEqual(0);
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
   });
 
+  it('points a flat map at the whole of what it drew', async () => {
+    const { el, map } = await renderOverview();
+    el.projection = 'mercator';
+    el.records = [record('the-world', { dcat_bbox: THE_WORLD })];
+    await el.load();
+
+    expect(frameOf(map)).toEqual([-180, -85, 180, 85]);
+  });
+
+  // Which is what the globe button is for: the whole of a set of results too wide to fit on a sphere
+  // is only visible on a flat map
+  it('frames what it drew again when the reader changes projection', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('the-world', { dcat_bbox: THE_WORLD })];
+    await el.load();
+    const framedOnce = map.fitBounds.mock.calls.length;
+
+    await el.handleProjectionTransition({ newProjection: 'mercator' });
+
+    expect(map.fitBounds.mock.calls.length).toBeGreaterThan(framedOnce);
+    expect(frameOf(map)).toEqual([-180, -85, 180, 85]);
+  });
+
+  // There may be nothing named on the basemap to place a page of results any closer by
   it('opens no closer than city scale, whatever it was asked to frame', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('a-point', { locn_geometry: 'POINT(-122.17 37.43)' })];
-    await el.draw();
+    await el.load();
 
-    const [, options] = map.fitBounds.mock.calls[0];
-    expect(options.maxZoom).toEqual(12);
+    expect(framed(map)[1].maxZoom).toEqual(12);
   });
 
-  // The gap the theme keeps around an overview, which is wider than the one a preview gets: a box
+  // The gap the theme keeps around an overview, which is wider than the one a preview gets: a marker
   // drawn against the edge of a map this small reads as running off it.
   it('holds what it frames away from the edge of the map', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: CALIFORNIA })];
-    await el.draw();
+    await el.load();
 
-    const [, options] = map.fitBounds.mock.calls[0];
-    expect(options.padding).toEqual(el.mapTheme.getStyle().overviewPadding);
+    const [, options] = framed(map);
+    expect(options.padding).toEqual(el.mapTheme.getOverviewPadding());
     expect(options.padding).toBeGreaterThan(el.mapTheme.getPadding());
-  });
-
-  it('points the camera where it was told, rather than at what it drew', async () => {
-    const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: ICELAND })];
-    await el.draw();
-
-    el.bounds = CALIFORNIA;
-    await el.onBoundsChange();
-
-    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
-
-    // Only the view of it changed; what was on the map is still on it, and still where it was
-    expect(boxLayers(map)).toEqual(['one-location-fill', 'one-location-outline']);
-  });
-
-  // An embedder naming an area has already said what they want on screen, so neither the gap nor the
-  // zoom limit an overview of records gets is applied to it
-  it('frames a stated camera exactly', async () => {
-    const { el, map } = await renderOverview();
-    el.bounds = CALIFORNIA;
-    await el.draw();
-
-    expect(map.fitBounds.mock.calls.at(-1)![1]).toEqual({ padding: 0 });
-  });
-
-  // The round trip: the area a reader asked to search, handed back, is a camera that doesn't move
-  it('holds the map where it was when the area it reported is handed back', async () => {
-    const { el, map } = await renderOverview();
-    const view = map.getBounds();
-
-    el.bounds = boundsToBbox(view);
-    await el.draw();
-
-    const [bounds] = map.fitBounds.mock.calls.at(-1)!;
-    expect(bounds.getEast() - bounds.getWest()).toEqual(view.getEast() - view.getWest());
-    expect([bounds.getSouth(), bounds.getNorth()]).toEqual([view.getSouth(), view.getNorth()]);
-  });
-
-  // A globe can't be pointed at every box one might name, so a stated camera is always a flat one
-  it('draws a single record on a flat map when the camera was stated', async () => {
-    const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
-    el.bounds = ICELAND;
-    await el.draw();
-
-    expect(map.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
-  });
-
-  it('returns to a stated camera when what is drawn changes', async () => {
-    const { el, map } = await renderOverview();
-    el.bounds = CALIFORNIA;
-    el.records = [record('one', { dcat_bbox: ICELAND })];
-    await el.draw();
-
-    el.records = [record('two', { dcat_bbox: THE_WORLD })];
-    await el.onRecordsChange();
-
-    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
-  });
-
-  it('goes back to framing what it drew when the camera is withdrawn', async () => {
-    const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: ICELAND })];
-    el.bounds = CALIFORNIA;
-    await el.draw();
-
-    el.bounds = undefined;
-    await el.onBoundsChange();
-
-    const [bounds, options] = map.fitBounds.mock.calls.at(-1)!;
-    expect(boundsToBbox(bounds)).toEqual([-24.55, 63.39, -13.49, 66.57]);
-    expect(options.maxZoom).toEqual(12);
-  });
-
-  // Which is how a page rendered by a server says where its map opens, without any JavaScript
-  it('takes a camera from an attribute', async () => {
-    const { el, map } = await renderOverview();
-    el.setAttribute('bounds', CALIFORNIA);
-
-    expect(el.bounds).toEqual(CALIFORNIA);
-    await el.frame();
-    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-124.41, 32.53, -114.13, 42.01]);
-  });
-
-  it('frames what it drew, and says so, when it cannot read the camera it was given', async () => {
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { el, map } = await renderOverview();
-    el.records = [record('one', { dcat_bbox: ICELAND })];
-    el.bounds = 'somewhere nice';
-    await el.draw();
-
-    expect(consoleWarn).toHaveBeenCalledWith('Could not read bounds:', 'somewhere nice');
-    expect(boundsToBbox(map.fitBounds.mock.calls.at(-1)![0])).toEqual([-24.55, 63.39, -13.49, 66.57]);
-    consoleWarn.mockRestore();
   });
 
   it('carries the Web Awesome scope, being usable on its own', async () => {
@@ -347,96 +367,430 @@ describe('ogm-overview', () => {
     expect(el.className).toContain('wa-palette-default');
     expect((el.shadowRoot as ShadowRoot).querySelector('link[rel="stylesheet"]')).toBeTruthy();
   });
+
+  it('takes its map down with it', async () => {
+    const { el, map } = await renderOverview();
+    (el as unknown as { disconnectedCallback: () => void }).disconnectedCallback();
+
+    expect(map.remove).toHaveBeenCalled();
+  });
+});
+
+describe('ogm-overview search filter', () => {
+  it('points the camera where it was told, rather than at what it drew', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    await el.load();
+
+    el.bounds = CALIFORNIA;
+    await el.onBoundsChange();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+    // Only the view of it changed; the results are still on the map, still numbered
+    expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1']);
+  });
+
+  it('draws the area being searched as a box under everything else', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.bounds = CALIFORNIA;
+    await el.load();
+
+    expect(layerIds(map)).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...NUMBER_LAYERS]);
+    expect(map.sources.get(SEARCH_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-124.41, 32.53]);
+  });
+
+  it('takes the box away when the search filter is withdrawn', async () => {
+    const { el, map } = await renderOverview();
+    el.bounds = CALIFORNIA;
+    await el.load();
+
+    el.bounds = undefined;
+    await el.onBoundsChange();
+
+    expect(map.sources.has(SEARCH_BOUNDS)).toBe(false);
+  });
+
+  // The same gap everything else gets, which is what makes the box readable as a box - and a reader
+  // who searched one street shouldn't come back to a view of the city, so no zoom limit
+  it('gives a search filter the same room it gives everything else', async () => {
+    const { el, map } = await renderOverview();
+    el.bounds = CALIFORNIA;
+    await el.load();
+
+    const [, options] = framed(map);
+    expect(options.padding).toEqual(el.mapTheme.getOverviewPadding());
+    expect(options.maxZoom).toBeUndefined();
+  });
+
+  it('returns to the search filter when what is drawn changes', async () => {
+    const { el, map } = await renderOverview();
+    el.bounds = CALIFORNIA;
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    await el.load();
+
+    el.records = [record('two', { dcat_bbox: THE_WORLD })];
+    await el.onRecordsChange();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  it('goes back to framing what it drew when the filter is withdrawn', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.bounds = CALIFORNIA;
+    await el.load();
+
+    el.bounds = undefined;
+    await el.onBoundsChange();
+
+    expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+    expect(framed(map)[1].maxZoom).toEqual(12);
+  });
+
+  // Which is how a page rendered by a server says what its map is filtered to, without any JavaScript
+  it('takes a filter from an attribute', async () => {
+    const { el, map } = await renderOverview();
+    el.setAttribute('bounds', CALIFORNIA);
+
+    expect(el.bounds).toEqual(CALIFORNIA);
+    await el.onBoundsChange();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+    expect(map.sources.has(SEARCH_BOUNDS)).toBe(true);
+  });
+
+  it('frames what it drew, and says so, when it cannot read the filter it was given', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.bounds = 'somewhere nice';
+    // Whatever the watcher said about it on the way in; what is under test is the load below
+    consoleWarn.mockClear();
+    await el.load();
+
+    expect(consoleWarn).toHaveBeenCalledWith('Could not read bounds:', 'somewhere nice');
+    // Once per load, rather than once for the box and again for the camera
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('ogm-overview highlight', () => {
+  const two = async () => {
+    const rendered = await renderOverview();
+    rendered.el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
+    await rendered.el.load();
+    return rendered;
+  };
+
+  it('brings a highlighted result to the front, in its own color', async () => {
+    const { el, map } = await two();
+    el.highlighted = 2;
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('2');
+    // The highlighted pair goes on last, which is the only thing that lifts a whole marker
+    expect(layerIds(map).slice(-2)).toEqual([`${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`]);
+    expect(map.layers.get(`${RESULT_HIGHLIGHT}-circle`).paint['circle-color']).toEqual(el.mapTheme.getStyle().markerHighlightColor);
+    expect(map.layers.get(`${RESULT_NUMBERS}-circle`).paint['circle-color']).toEqual(el.mapTheme.getStyle().markerColor);
+  });
+
+  it('draws the highlighted result’s own extent under its number', async () => {
+    const { el, map } = await two();
+    el.highlighted = 2;
+    el.onHighlightedChange();
+
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(layerIds(map)).toEqual([...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...NUMBER_LAYERS]);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeHighlightColor);
+  });
+
+  it('highlights a result named by id', async () => {
+    const { el, map } = await two();
+    el.highlighted = 'two';
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('2');
+  });
+
+  // An attribute is always a string, and Stencil hands one over as it stands for a prop that takes
+  // either a number or a string
+  it('highlights a place written down, which is what an attribute hands over', async () => {
+    const { el, map } = await two();
+    el.setAttribute('highlighted', '2');
+
+    expect(el.highlighted).toEqual('2');
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('2');
+  });
+
+  // An id we hold is a match; a place is only a count
+  it('prefers a result whose id is a number to the row of that number', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('3', { dcat_bbox: CALIFORNIA }), record('1', { dcat_bbox: ICELAND })];
+    await el.load();
+
+    el.highlighted = '1';
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('2');
+  });
+
+  it('highlights a previewer by the id of the resource it draws', async () => {
+    const { el, map } = await renderOverview();
+    el.previewers = [new LocationPreviewer(new LocationResource('handed-over', { type: 'Point', coordinates: [0, 0] }))];
+    await el.load();
+
+    el.highlighted = 'handed-over';
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('1');
+  });
+
+  // There is no number on the map to bring forward and no extent to draw around, which is the truth
+  it('highlights nothing for a result it has nowhere to put', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('nowhere')];
+    await el.load();
+
+    el.highlighted = 2;
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toBeUndefined();
+    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+  });
+
+  // A map with no highlight, rather than one with the wrong highlight
+  it('highlights nothing it cannot find', async () => {
+    const { el, map } = await two();
+
+    for (const value of ['nope', 99, 0, '', 1.5]) {
+      el.highlighted = value as number | string;
+      el.onHighlightedChange();
+      expect(highlightedLabel(map)).toBeUndefined();
+    }
+  });
+
+  it('clears the highlight when it is withdrawn', async () => {
+    const { el, map } = await two();
+    el.highlighted = 1;
+    el.onHighlightedChange();
+
+    el.highlighted = undefined;
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toBeUndefined();
+    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+  });
+
+  // Something on the page has said which result matters, not where to look
+  it('leaves the camera where it is when the highlight changes', async () => {
+    const { el, map } = await two();
+    const framedOnce = map.fitBounds.mock.calls.length;
+
+    el.highlighted = 2;
+    el.onHighlightedChange();
+
+    expect(map.fitBounds.mock.calls.length).toEqual(framedOnce);
+    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(true);
+  });
+});
+
+describe('ogm-overview controls', () => {
+  // The no-pitch test as much as the zoom one: with no compass there is no control that can turn or
+  // tilt the map, which is what the compass button and its pitch visualiser are for
+  it('offers zoom buttons and no compass', async () => {
+    const { el, map } = await renderOverview();
+    el.addControls();
+
+    const { element } = map.controls[0];
+    expect(Array.from(element.querySelectorAll('button'), button => button.className)).toEqual(['maplibregl-ctrl-zoom-in', 'maplibregl-ctrl-zoom-out']);
+    expect(element.querySelector('.maplibregl-ctrl-compass')).toBeNull();
+  });
+
+  it('offers a projection toggle, so an overview can be flattened', async () => {
+    const { el, map } = await renderOverview();
+    el.addControls();
+    map.fire('style.load');
+
+    expect(map.controls.some(added => added.element.querySelector('[class^="maplibregl-ctrl-globe"]'))).toBe(true);
+  });
 });
 
 describe('ogm-overview geosearch', () => {
-  // An overview of one record's location has nobody to report a search to
   it('offers no search unless it was asked to', async () => {
     const { el, map } = await renderOverview();
     el.onGeosearchChange();
 
     expect(map.controls).toEqual([]);
+    expect(map.boxZoom.disable).toHaveBeenCalled();
   });
 
-  // Top left because the attribution, this map's only other control, is drawn bottom right
-  it('puts the control over the top left of the map', async () => {
+  // Top left because the zoom and globe buttons are top right, and the attribution both basemaps
+  // require is bottom right
+  it('puts the help text over the top left of the map', async () => {
     const { el, map } = await renderOverview();
-    el.geosearch = 'auto';
+    el.geosearch = true;
     el.onGeosearchChange();
 
     expect(map.controls).toHaveLength(1);
     expect(map.controls[0].position).toEqual('top-left');
     expect(map.controls[0].element.className).toContain('maplibregl-ctrl-geosearch');
-  });
-
-  it('starts the control in the mode it was given', async () => {
-    const { el, map } = await renderOverview();
-    el.geosearch = 'manual';
-    el.onGeosearchChange();
-
-    const { element } = map.controls[0];
-    expect((element.querySelector('button') as HTMLButtonElement).hidden).toBe(false);
-    expect((element.querySelector('label') as HTMLLabelElement).hidden).toBe(true);
+    expect(map.controls[0].element.textContent).toEqual(el.searchHelpText);
   });
 
   it('hands the control its wording, and passes on a change to it', async () => {
     const { el, map } = await renderOverview();
-    el.geosearch = 'auto';
-    el.searchHereText = 'Cerca aquí';
-    el.searchOnMoveText = 'Cerca quan moc el mapa';
+    el.geosearch = true;
+    el.searchHelpText = 'Cerca arrossegant amb la tecla de majúscules';
     el.onGeosearchChange();
 
     const { element } = map.controls[0];
-    expect(element.querySelector('label')?.textContent).toEqual('Cerca quan moc el mapa');
+    expect(element.textContent).toEqual('Cerca arrossegant amb la tecla de majúscules');
 
-    el.searchHereText = 'Search here';
-    el.onGeosearchLabelsChange();
-    expect(element.querySelector('button')?.textContent).toEqual('Search here');
+    el.searchHelpText = 'Shift + drag to search an area';
+    el.onSearchHelpTextChange();
+    expect(element.textContent).toEqual('Shift + drag to search an area');
   });
 
-  // The whole path: the reader moves the map, the control waits for them to stop, and what comes out is
-  // the area a query can state - both edges brought back into range, east numerically west of west
-  // because the view straddles the antimeridian. See boundsToBbox.
-  it('reports where the reader asked to search, in west, south, east, north', async () => {
+  it('answers shift+drag only when it was asked to', async () => {
     const { el, map } = await renderOverview();
-    el.geosearch = 'auto';
+    el.geosearch = true;
     el.onGeosearchChange();
 
-    const areas: [number, number, number, number][] = [];
-    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent<[number, number, number, number]>).detail));
+    expect(map.boxZoom.enable).toHaveBeenCalled();
 
-    vi.useFakeTimers();
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(800);
+    el.geosearch = false;
+    el.onGeosearchChange();
 
-    expect(areas).toEqual([[170, -10, -160, 10]]);
+    expect(map.boxZoom.disable).toHaveBeenCalled();
   });
 
-  it('reports nothing for a camera it moved itself', async () => {
+  // A disabled handler stops being offered the mouseup that would have cleared its rectangle and the
+  // crosshair cursor, so a gesture caught halfway has to be called off first
+  it('clears a gesture it was switched off partway through', async () => {
     const { el, map } = await renderOverview();
-    el.geosearch = 'auto';
+    el.geosearch = true;
     el.onGeosearchChange();
 
-    const areas: unknown[] = [];
-    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent).detail));
+    map.boxZoom.isActive.mockReturnValue(true);
+    el.geosearch = false;
+    el.onGeosearchChange();
 
-    vi.useFakeTimers();
-    map.fire('moveend', {});
-    vi.advanceTimersByTime(800);
-
-    expect(areas).toEqual([]);
+    expect(map.boxZoom.reset).toHaveBeenCalled();
+    expect(map.boxZoom.reset.mock.invocationCallOrder[0]).toBeLessThan(map.boxZoom.disable.mock.invocationCallOrder.at(-1)!);
   });
 
   it('takes the control back off, and its bindings with it, when the offer is withdrawn', async () => {
     const { el, map } = await renderOverview();
-    el.geosearch = 'auto';
+    el.geosearch = true;
     el.onGeosearchChange();
 
-    el.geosearch = undefined;
+    el.geosearch = false;
     el.onGeosearchChange();
 
     expect(map.controls).toEqual([]);
-    expect(map.listeners['moveend']).toEqual([]);
+    expect(map.listeners['boxzoomstart']).toEqual([]);
+  });
+
+  it('gets out of the way while a box is being drawn', async () => {
+    const { el, map } = await renderOverview();
+    el.geosearch = true;
+    el.onGeosearchChange();
+    const { element } = map.controls[0];
+
+    map.fire('boxzoomstart');
+    expect(element.hidden).toBe(true);
+
+    map.fire('boxzoomend');
+    expect(element.hidden).toBe(false);
+  });
+
+  // The whole point of the gesture: what comes out is the box the reader drew, as an area a query can
+  // state. The fake reads pixels as degrees upside down, so the top of the box is its north edge.
+  it('reports the area the reader drew, in west, south, east, north', async () => {
+    const { el } = await renderOverview();
+    const areas: [number, number, number, number][] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent<[number, number, number, number]>).detail));
+
+    el.search(new Point(10, 10), new Point(30, 40));
+
+    expect(areas).toEqual([[10, -40, 30, -10]]);
+  });
+
+  it('reports the same area whichever way the reader dragged it', async () => {
+    const { el } = await renderOverview();
+    const areas: [number, number, number, number][] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent<[number, number, number, number]>).detail));
+
+    el.search(new Point(30, 40), new Point(10, 10));
+
+    expect(areas).toEqual([[10, -40, 30, -10]]);
+  });
+
+  // Which edge is west is decided on screen rather than by longitude: taking the smaller of 175 and
+  // -175 for west would describe the other 350 degrees. See boundsToBbox for the form it comes out in.
+  it('reports an area straddling the antimeridian as the strait it covers', async () => {
+    const { el, map } = await renderOverview();
+    map.unproject = ([x, y]: [number, number]) => new LngLat(x > 0 ? -175 : 175, -y);
+    const areas: [number, number, number, number][] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent<[number, number, number, number]>).detail));
+
+    el.search(new Point(-10, 10), new Point(10, 40));
+
+    expect(areas).toEqual([[175, -40, -175, -10]]);
+  });
+
+  // Under MapLibre's own line between a click and a drag, no rectangle was ever drawn - and a search
+  // the reader got no sight of is one they didn't ask for
+  it('reports nothing for a shift-click that never drew a box', async () => {
+    const { el } = await renderOverview();
+    const areas: unknown[] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent).detail));
+
+    el.search(new Point(10, 10), new Point(11, 11));
+
+    expect(areas).toEqual([]);
+  });
+
+  it('says so, and reports nothing, when it cannot read the area drawn', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { el, map } = await renderOverview();
+    // A flat map's unproject can hand back a latitude past a pole, which no bounds can hold
+    map.unproject = ([x]: [number, number]) => ({ lng: x, lat: 120 }) as LngLat;
+    const areas: unknown[] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent).detail));
+
+    el.search(new Point(10, 10), new Point(30, 40));
+
+    expect(areas).toEqual([]);
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('ogm-overview theme', () => {
+  it('draws the same results into the style document a theme swap empties', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: CALIFORNIA })];
+    await el.load();
+
+    el.theme = 'dark';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    expect(map.setStyle).toHaveBeenCalledWith(darkBasemapStyle);
+
+    // What setStyle would have emptied, emptied - and then drawn again by the load that follows it
+    map.layers.clear();
+    map.sources.clear();
+    await el.handleStyleLoad();
+
+    expect(layerIds(map)).toEqual(NUMBER_LAYERS);
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -136,7 +136,7 @@ const THE_WORLD = 'ENVELOPE(-180.0,180.0,85.0,-85.0)';
 
 type Overview = HTMLElement & {
   records?: OgmRecord[];
-  previewers?: LocationPreviewer[];
+  previewers?: (LocationPreviewer | undefined)[];
   theme: 'light' | 'dark';
   map: FakeMap;
   mapTheme: MapLibreTheme;
@@ -231,6 +231,35 @@ describe('ogm-overview', () => {
     await el.load();
 
     expect([...map.sources.keys()]).toEqual([RESULT_NUMBERS]);
+  });
+
+  // Which is what `locationsFor` hands back, and what the library documents as the way to build these
+  // by hand: a record it could not place is a gap rather than a missing entry
+  it('numbers a list of extents with gaps in it', async () => {
+    const { el, map } = await renderOverview();
+    el.previewers = [
+      new LocationPreviewer(new LocationResource('one', { type: 'Point', coordinates: [0, 0] })),
+      undefined,
+      new LocationPreviewer(new LocationResource('three', { type: 'Point', coordinates: [10, 10] })),
+    ];
+    await el.load();
+
+    expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '3']);
+  });
+
+  it('highlights one of those by id, counting the gap', async () => {
+    const { el, map } = await renderOverview();
+    el.previewers = [
+      new LocationPreviewer(new LocationResource('one', { type: 'Point', coordinates: [0, 0] })),
+      undefined,
+      new LocationPreviewer(new LocationResource('three', { type: 'Point', coordinates: [10, 10] })),
+    ];
+    await el.load();
+
+    el.highlighted = 'three';
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toEqual('3');
   });
 
   it('numbers the extents it was handed instead of the records’ own', async () => {
@@ -563,15 +592,30 @@ describe('ogm-overview highlight', () => {
     expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
   });
 
-  // A map with no highlight, rather than one with the wrong highlight
+  // A map with no highlight, rather than one with the wrong highlight. Each of these is a value a page
+  // can plausibly arrive at - a name nothing carries, a row past the end, a row counted from zero, a
+  // number that is no row at all - and none of them may land on a neighbour.
   it('highlights nothing it cannot find', async () => {
     const { el, map } = await two();
 
-    for (const value of ['nope', 99, 0, '', 1.5]) {
+    for (const value of ['nope', 99, 0, -1, '', 1.5]) {
       el.highlighted = value as number | string;
       el.onHighlightedChange();
+
       expect(highlightedLabel(map)).toBeUndefined();
+      expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
     }
+  });
+
+  // The one it could land on by accident: the row before the end, if a place past the end were let
+  // through and read modulo the list, or if a fractional place were rounded
+  it('does not round a place onto the row beside it', async () => {
+    const { el, map } = await two();
+
+    el.highlighted = 1.6;
+    el.onHighlightedChange();
+
+    expect(highlightedLabel(map)).toBeUndefined();
   });
 
   it('clears the highlight when it is withdrawn', async () => {
@@ -662,11 +706,14 @@ describe('ogm-overview geosearch', () => {
     el.onGeosearchChange();
 
     expect(map.boxZoom.enable).toHaveBeenCalled();
+    expect(map.boxZoom.disable).not.toHaveBeenCalled();
 
+    map.boxZoom.enable.mockClear();
     el.geosearch = false;
     el.onGeosearchChange();
 
     expect(map.boxZoom.disable).toHaveBeenCalled();
+    expect(map.boxZoom.enable).not.toHaveBeenCalled();
   });
 
   // A disabled handler stops being offered the mouseup that would have cleared its rectangle and the
@@ -742,6 +789,24 @@ describe('ogm-overview geosearch', () => {
     el.search(new Point(-10, 10), new Point(10, 40));
 
     expect(areas).toEqual([[175, -40, -175, -10]]);
+  });
+
+  // Screen y and latitude only run together while the pole is off screen. Pan one into view on a globe
+  // and a line of pixels crosses it, so the higher pixel can be the lower latitude - and a box dragged
+  // over the pole would otherwise come out with its south edge north of its north edge, which is a
+  // bbox no query can answer.
+  it('reports a box dragged over a pole the right way up', async () => {
+    const { el, map } = await renderOverview();
+    // The far side of the pole, where latitude starts coming back down again
+    map.unproject = ([, y]: [number, number]) => new LngLat(0, y < 20 ? 80 : 88);
+    const areas: [number, number, number, number][] = [];
+    el.addEventListener('boundsChange', event => areas.push((event as CustomEvent<[number, number, number, number]>).detail));
+
+    el.search(new Point(10, 10), new Point(30, 40));
+
+    const [[, south, , north]] = areas;
+    expect(south).toBeLessThan(north);
+    expect([south, north]).toEqual([80, 88]);
   });
 
   // Under MapLibre's own line between a click and a drag, no rectangle was ever drawn - and a search

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -12,7 +12,7 @@ import { boundsToBbox } from '../../lib/geometry';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import { SELECTED_BOUNDS, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
+import { SELECTED_BOUNDS, markerImageId, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
 import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
@@ -86,15 +86,19 @@ class FakeMap {
   removeImage(id: string) {
     this.images.delete(id);
   }
+  hasImage(id: string) {
+    return this.images.has(id);
+  }
   listImages() {
     return [...this.images.keys()];
   }
 
+  // Handed new data rather than taken off and put back, which is what a redraw does now; see drawResults
   getSource(id: string) {
     return this.sources.get(id);
   }
   addSource(id: string, spec: any) {
-    this.sources.set(id, spec);
+    this.sources.set(id, { ...spec, setData: (data: any) => (this.sources.get(id).data = data) });
   }
   removeSource(id: string) {
     this.sources.delete(id);
@@ -107,6 +111,9 @@ class FakeMap {
   }
   removeLayer(id: string) {
     this.layers.delete(id);
+  }
+  setPaintProperty(id: string, property: string, value: unknown) {
+    this.layers.get(id).paint[property] = value;
   }
   cameraForBounds() {
     return { center: [0, 0], zoom: 4 };
@@ -207,6 +214,15 @@ const renderOverview = async () => {
 const MARKER_LAYERS = [RESULT_MARKERS];
 const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 
+// Every layer an overview draws, in the order they are drawn in. All of them go on with the first draw
+// and none of them ever comes off: what a redraw changes is the data in them, which is what keeps a
+// highlight from flashing. See drawResults.
+const ALL_LAYERS = [...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS];
+
+// Whether one of the two boxes has anything in it. Both stay on the map holding nothing when there is
+// nothing to say, so being there is not the question.
+const drawnBox = (map: FakeMap, id: string) => !!map.sources.get(id)?.data.geometry;
+
 const layerIds = (map: FakeMap) => [...map.layers.keys()];
 const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);
 const highlightedLabel = (map: FakeMap) => marked(map).find((properties: { selected: boolean }) => properties.selected)?.label;
@@ -232,7 +248,7 @@ describe('ogm-overview', () => {
     await el.load();
 
     expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '2']);
-    expect(layerIds(map)).toEqual(MARKER_LAYERS);
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
   });
 
   // A page of boxes says less than a page of numbers a reader can find again in the list beside the
@@ -242,7 +258,8 @@ describe('ogm-overview', () => {
     el.records = [record('one', { dcat_bbox: CALIFORNIA })];
     await el.load();
 
-    expect([...map.sources.keys()]).toEqual([RESULT_NUMBERS]);
+    expect(drawnBox(map, SEARCH_BOUNDS)).toBe(false);
+    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
   });
 
   // Which is what `locationsFor` hands back, and what the library documents as the way to build these
@@ -294,7 +311,7 @@ describe('ogm-overview', () => {
     expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1', '3']);
   });
 
-  it('takes the last set of numbers off the map before drawing the next', async () => {
+  it('replaces the last set of numbers rather than adding to it', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: CALIFORNIA }), record('two', { dcat_bbox: ICELAND })];
     await el.load();
@@ -303,7 +320,8 @@ describe('ogm-overview', () => {
     await el.onRecordsChange();
 
     expect(marked(map).map((properties: { label: string }) => properties.label)).toEqual(['1']);
-    expect(layerIds(map)).toEqual(MARKER_LAYERS);
+    // The same layers throughout, in the same order: what a redraw changes is the data in them
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
   });
 
   it('shows the whole world when it has no records to place', async () => {
@@ -437,7 +455,7 @@ describe('ogm-overview search filter', () => {
     el.bounds = CALIFORNIA;
     await el.load();
 
-    expect(layerIds(map)).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...MARKER_LAYERS]);
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
     expect(map.sources.get(SEARCH_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-124.41, 32.53]);
   });
 
@@ -449,7 +467,7 @@ describe('ogm-overview search filter', () => {
     el.bounds = undefined;
     await el.onBoundsChange();
 
-    expect(map.sources.has(SEARCH_BOUNDS)).toBe(false);
+    expect(drawnBox(map, SEARCH_BOUNDS)).toBe(false);
   });
 
   // The same gap everything else gets, which is what makes the box readable as a box - and a reader
@@ -498,7 +516,7 @@ describe('ogm-overview search filter', () => {
     await el.onBoundsChange();
 
     expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
-    expect(map.sources.has(SEARCH_BOUNDS)).toBe(true);
+    expect(drawnBox(map, SEARCH_BOUNDS)).toBe(true);
   });
 
   it('frames what it drew, and says so, when it cannot read the filter it was given', async () => {
@@ -535,7 +553,8 @@ describe('ogm-overview highlight', () => {
 
     expect(highlightedLabel(map)).toEqual('2');
     // It wears a picture of its own, which is what carries the color, and sorts above every other
-    expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual(['ogm-result-marker-1', 'ogm-result-marker-selected-2']);
+    const style = el.mapTheme.getStyle();
+    expect(marked(map).map((properties: { icon: string }) => properties.icon)).toEqual([markerImageId('1', style), markerImageId('2', style, true)]);
     expect(map.layers.get(RESULT_MARKERS).layout['symbol-sort-key']).toEqual(['case', ['get', 'selected'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 
@@ -545,7 +564,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(map.sources.get(SELECTED_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
-    expect(layerIds(map)).toEqual([...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
     expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual(el.mapTheme.getStyle().strokeSelectedColor);
   });
 
@@ -602,7 +621,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
+    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
   });
 
   // A map with no highlight, rather than one with the wrong highlight. Each of these is a value a page
@@ -616,7 +635,7 @@ describe('ogm-overview highlight', () => {
       el.onHighlightedChange();
 
       expect(highlightedLabel(map)).toBeUndefined();
-      expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
+      expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
     }
   });
 
@@ -640,7 +659,29 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(highlightedLabel(map)).toBeUndefined();
-    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
+    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(false);
+  });
+
+  // The redraw a hover drives, over and over as the pointer moves down the list beside the map. Nothing
+  // comes off the map to do it: dropping a source drops its tiles on the spot, and taking a marker's
+  // picture off has MapLibre place every symbol on the map again, so either one costs a frame with no
+  // numbers in it - which is what a reader sees as a flash. See drawResults.
+  it('takes nothing off the map to move the highlight', async () => {
+    const { el, map } = await two();
+    const removeLayer = vi.spyOn(map, 'removeLayer');
+    const removeSource = vi.spyOn(map, 'removeSource');
+    const removeImage = vi.spyOn(map, 'removeImage');
+    const drawn = layerIds(map);
+
+    for (const value of [1, 2, undefined]) {
+      el.highlighted = value;
+      el.onHighlightedChange();
+    }
+
+    expect(layerIds(map)).toEqual(drawn);
+    expect(removeLayer).not.toHaveBeenCalled();
+    expect(removeSource).not.toHaveBeenCalled();
+    expect(removeImage).not.toHaveBeenCalled();
   });
 
   // Something on the page has said which result matters, not where to look
@@ -652,7 +693,7 @@ describe('ogm-overview highlight', () => {
     el.onHighlightedChange();
 
     expect(map.fitBounds.mock.calls.length).toEqual(framedOnce);
-    expect(map.sources.has(SELECTED_BOUNDS)).toBe(true);
+    expect(drawnBox(map, SELECTED_BOUNDS)).toBe(true);
   });
 });
 
@@ -868,7 +909,7 @@ describe('ogm-overview theme', () => {
     map.sources.clear();
     await el.handleStyleLoad();
 
-    expect(layerIds(map)).toEqual(MARKER_LAYERS);
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -276,8 +276,8 @@ export class OgmOverview {
     await this.load();
   }
 
-  // The area being searched has changed. The box that says where it is has to go on again, but
-  // nothing about the results has moved, so nobody is asked for their extent a second time.
+  // The area being searched has changed. The box that says where it is changes with it, but nothing
+  // about the results has moved, so nobody is asked for their extent a second time.
   @Watch('bounds')
   protected async onBoundsChange() {
     this.readSearchFilter();
@@ -285,10 +285,11 @@ export class OgmOverview {
     await this.frame();
   }
 
-  // A highlight arriving from outside. Only the marker and the box around its extent change, and the
-  // camera is left exactly where it is: something on the page has said which result matters, not
-  // where to look, and flying the map at a row the reader happened to hover is not what they asked
-  // for.
+  // A highlight arriving from outside. Only the marker and the box around its extent change - nothing
+  // is taken off the map to do it, or the whole set of markers would blink each time the pointer moved
+  // to the next row; see drawResults. The camera is left exactly where it is: something on the page has
+  // said which result matters, not where to look, and flying the map at a row the reader happened to
+  // hover is not what they asked for.
   @Watch('highlighted')
   protected onHighlightedChange() {
     this.draw();

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -156,6 +156,7 @@ export class OgmOverview {
       // on: their box never has the canvas' own shape, so the camera always covers more than they
       // asked about.
       boxZoom: { boxZoomEnd: (_map, start, end) => this.search(start, end) },
+      minZoom: 1,
     });
     disableRotation(this.map);
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -176,7 +176,7 @@ export class OgmOverview {
     const style = this.mapTheme.getStyle();
     this.drawn = this.previewers ?? locationsFor(this.records ?? []);
 
-  // In the order given, so the boxes are painted in the same order they're numbered. Nothing hereread
+    // In the order given, so the boxes are painted in the same order they're numbered. Nothing here
     // reaches the network - a LocationResource is built from a shape rather than a URL - so
     // drawing them one after another costs nothing.
     for (const previewer of this.drawn) await previewer?.attach(this.map, style).preview();

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -3,21 +3,30 @@ import type maplibregl from 'maplibre-gl';
 
 import { getElement } from '../../lib/elements';
 import GeosearchControl from '../../lib/geosearch-control';
-import { boundsToBbox, clampToHemisphere, readBounds, unionBounds, WORLD } from '../../lib/geometry';
+import { boundsToBbox, readBounds, unionBounds, WORLD } from '../../lib/geometry';
 import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
-import { createMap, fitBounds, setBasemap, whenSized } from '../../lib/maps';
+import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, setBasemap, whenSized } from '../../lib/maps';
 import LocationPreviewer, { locationsFor } from '../../lib/previewers/location';
+import type { MapProjection } from '../../lib/previewers/map';
 import type OgmRecord from '../../lib/record';
+import { drawResults } from '../../lib/results';
 import MapLibreTheme from '../../lib/themes/maplibre';
 
-// We need to ensure that there are identifiable features around to read so
-// that the location of the data is clear; no point zooming in any further than
-// this because the map may be missing names for cities, towns, etc.
-const MAX_ZOOM = 12;
+// How far a shift-drag has to go before it counts as asking about an area, in pixels. MapLibre's own
+// line between a click and a drag, and the point at which it starts drawing the rectangle: under it
+// the reader saw no box at all, and a search they got no sight of is one they didn't ask for. MapLibre
+// reports the gesture anyway - only an exactly stationary mouseup is called off - so the floor is ours
+// to hold.
+const MIN_SEARCH_DRAG = 3;
 
 /**
- * Display the location of one or several records (or previewers) by drawing
- * their geometry or basic bounding boxes.
+ * Where several records are: one numbered marker apiece, and optionally a way to search the map for
+ * more of them.
+ *
+ * Nothing of a record is drawn but its number. A page of boxes says less than a page of numbers a
+ * reader can find again in the list beside the map, and the only two boxes worth drawing are the ones
+ * that answer a question: which area is being searched, and where the one result something outside has
+ * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
  */
 @Component({
   tag: 'ogm-overview',
@@ -29,11 +38,37 @@ export class OgmOverview {
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() records?: OgmRecord[];
   @Prop() previewers?: LocationPreviewer[];
-  @Prop() geosearch?: 'auto' | 'manual';
-  @Prop() searchHereText: string = 'Search here';
-  @Prop() searchOnMoveText: string = 'Search when I move the map';
 
-  // Where to point the camera, provided externally
+  /**
+   * Which result to bring forward, as either its place in the list counted from one or the id of the
+   * record - or of the resource a previewer draws - that it came from. An attribute hands over a
+   * string for either, since an attribute is always one.
+   *
+   * The marker changes color and comes to the front, and the result's own extent is drawn around it.
+   * The camera doesn't move: something on the page has said which result matters, not where to look.
+   */
+  @Prop() highlighted?: number | string;
+
+  /**
+   * Whether a reader can search the map by holding shift and dragging a box over it. The area they
+   * drew is reported through `boundsChange`; nothing here answers it, because what a new area means
+   * is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings
+   * for the control this replaces through Rails I18n.
+   */
+  @Prop() geosearch: boolean = false;
+  @Prop() searchHelpText: string = 'Shift + drag to search an area';
+
+  /**
+   * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the
+   * west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form
+   * `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an
+   * attribute, so a page rendered by a server can say what its map is filtered to without any
+   * JavaScript at all.
+   *
+   * It goes on holding: whenever what is drawn changes, the camera returns here rather than
+   * re-framing itself around the new set of results. Leave it unset for a map that should look at
+   * whatever it has been given.
+   */
   @Prop() bounds?: maplibregl.LngLatBoundsLike | string;
 
   // Where the reader has asked to search, as the west, south, east, north degrees a query states -
@@ -47,8 +82,20 @@ export class OgmOverview {
   // Used to prevent drawing into a style document that isn't there yet
   private mapStyleLoaded: boolean = false;
 
-  // Things currently drawn to the map
-  private drawn: (LocationPreviewer | undefined)[] = [];
+  // Which projection the map is in, as the reader last left it. Held rather than read off the map,
+  // because the map forgets: a style document carries its own projection and neither basemap names
+  // one, so every theme swap arrives flat and would take a globe the reader had chosen with it.
+  private projection: MapProjection = 'globe';
+
+  // Where every result is and what each of them is called, in the order they were given - including
+  // the ones nobody could place, which keep their position in both. See highlightedPosition.
+  private extents: (maplibregl.LngLatBoundsLike | undefined)[] = [];
+  private ids: string[] = [];
+
+  // The area a search is filtered to, as this map can read it. Held rather than read where it is
+  // used: it is wanted twice on every draw, once for the box and once for the camera, and reading it
+  // twice would report an unreadable one twice as well.
+  private searchFilter?: maplibregl.LngLatBounds;
 
   async componentDidLoad() {
     const container = getElement(this.el, '#map');
@@ -74,27 +121,29 @@ export class OgmOverview {
 
     this.mapTheme = new MapLibreTheme(container, this.theme);
     this.map = createMap(container, this.mapTheme, {
-      cooperativeGestures: true,
-      dragRotate: false,
-      touchPitch: false,
-      minZoom: 0,
+      ...LOCATION_MAP,
+      // Always handed over, even with geosearch switched off: MapLibre reads this once as the handler
+      // is built and offers no way to hand it one later, so the offer has to be made now and taken
+      // back by disabling the handler - see applyGeosearch. Making it at all is also what stops a
+      // shift-drag flying the camera to whatever it enclosed. A search shouldn't move the map, and the
+      // area worth reporting is the box the reader drew rather than the wider view a fit to it settles
+      // on: their box never has the canvas' own shape, so the camera always covers more than they
+      // asked about.
+      boxZoom: { boxZoomEnd: (_map, start, end) => this.search(start, end) },
     });
-    this.map.keyboard.disableRotation();
-    this.map.touchZoomRotate.disableRotation();
+    disableRotation(this.map);
 
-    // Before the style loads, because the control draws nothing into it and asks the map for nothing
-    // but its bounds - and those only once the reader has moved it
-    this.addGeosearch();
+    // Before the style loads, because none of these writes anything into it
+    this.addControls();
 
-    // Everything below lives in the style document, so all of it is drawn again for each new one:
-    // once at first load, and again after every theme swap. The projection goes with it - a style
-    // carries its own and neither basemap names one - which is why draw() sets it rather than this
-    // does. Either way it can't be set any earlier: setProjection throws before a style has loaded.
-    this.map.on('style.load', async () => {
-      this.mapStyleLoaded = true;
-      this.map.setSky(this.mapTheme.getSkyStyle());
-      await this.draw();
-    });
+    // A reader reaching for the globe button, which is worth a fresh camera: what a globe can be
+    // pointed at is not what a flat map can - see frameLocation - so flattening one is how a reader
+    // sees the whole of a set of results too wide to fit on a sphere.
+    this.map.on('projectiontransition', this.handleProjectionTransition);
+
+    // Everything below lives in the style document, so all of it is done again for each new one: once
+    // at first load, and again after every theme swap.
+    this.map.on('style.load', () => this.handleStyleLoad());
   }
 
   // Clean up the map to prevent warnings/errors when removed from the DOM
@@ -102,60 +151,139 @@ export class OgmOverview {
     if (this.map) this.map.remove();
   }
 
+  // Zoom buttons and the projection toggle, plus the search hint if one was asked for
+  private addControls() {
+    addLocationControls(this.map);
+    this.applyGeosearch();
+  }
+
+  // A new style document, which arrives empty: at first load, and again after every theme swap.
+  //
+  // The projection is set here rather than by the camera. A style carries its own and neither basemap
+  // names one, so each document opens flat until this says otherwise; setting it per camera instead
+  // would stamp over the reader's press every time the results changed. It can't happen any earlier
+  // either - setProjection throws before a style has loaded - and it happens before the flag goes up,
+  // so that neither MapLibre's reset nor this correction of it is mistaken for the reader reaching for
+  // the button. The load below is what draws and frames.
+  private async handleStyleLoad() {
+    this.map.setSky(this.mapTheme.getSkyStyle());
+    this.map.setProjection({ type: this.projection });
+    this.mapStyleLoaded = true;
+    await this.load();
+  }
+
+  // The reader reaching for the globe button.
+  //
+  // Held to a style document that is already up, because a style loading is itself two of these: it
+  // ends by setting whatever projection it names, which is mercator for both basemaps, and then
+  // handleStyleLoad above puts the reader's choice back. Neither is a choice, and taking the first for
+  // one would flatten a globe on every theme swap.
+  private handleProjectionTransition = async (event: maplibregl.MapProjectionEvent) => {
+    if (!this.mapStyleLoaded) return;
+
+    // Anything that isn't flat is a globe as far as the camera is concerned. MapLibre has two names
+    // for one: 'globe' is the projection that draws as a sphere until it is zoomed in past the point
+    // where a sphere and a flat map are the same picture, and 'vertical-perspective' is the one that
+    // stays a sphere throughout.
+    this.projection = event.newProjection === 'mercator' ? 'mercator' : 'globe';
+    await this.frame();
+  };
+
   // Added and taken off rather than hidden the way <ogm-map>'s controls are: this is the only thing in
   // its corner, so there is no stack for it to come back to the bottom of - and going means its
-  // bindings to the map go with it. A change of starting mode arrives the same way, as a fresh control.
+  // bindings to the map go with it. The gesture is switched on and off rather than rebuilt, because
+  // MapLibre reads the callback behind it once, as the handler is built.
   @Watch('geosearch')
   protected onGeosearchChange() {
+    this.applyGeosearch();
+  }
+
+  // Retexted where it stands, so a change of wording doesn't interrupt a reader partway through a box
+  @Watch('searchHelpText')
+  protected onSearchHelpTextChange() {
+    this.geosearchControl?.setText(this.searchHelpText);
+  }
+
+  private applyGeosearch() {
     if (!this.map) return;
+
+    if (this.geosearch) {
+      this.map.boxZoom.enable();
+    } else {
+      // Reset before disabling, or a gesture caught halfway leaves its rectangle and the crosshair
+      // cursor behind: a disabled handler stops being offered the mouseup that would have cleared
+      // them, and nothing short of the window losing focus does it instead.
+      if (this.map.boxZoom.isActive()) this.map.boxZoom.reset();
+      this.map.boxZoom.disable();
+    }
 
     if (this.geosearchControl) {
       this.map.removeControl(this.geosearchControl);
       this.geosearchControl = undefined;
     }
+    if (!this.geosearch) return;
 
-    this.addGeosearch();
-  }
+    this.geosearchControl = new GeosearchControl(this.searchHelpText);
 
-  // Retexted where it stands, so a change of wording doesn't put the control back into the mode it
-  // started in or interrupt a reader partway through using it
-  @Watch('searchHereText')
-  @Watch('searchOnMoveText')
-  protected onGeosearchLabelsChange() {
-    this.geosearchControl?.setLabels({ searchHere: this.searchHereText, searchOnMove: this.searchOnMoveText });
-  }
-
-  private addGeosearch() {
-    if (!this.map || !this.geosearch) return;
-
-    this.geosearchControl = new GeosearchControl(() => this.emitBounds(), { searchHere: this.searchHereText, searchOnMove: this.searchOnMoveText }, this.geosearch);
-
-    // Top left, which is empty: the attribution this map's only other control draws sits bottom right
+    // Top left, which is empty: the zoom and globe buttons are top right, and the attribution both
+    // basemaps require is bottom right
     this.map.addControl(this.geosearchControl, 'top-left');
   }
 
-  // Read when the control asks rather than when the camera stopped, so what gets searched is where the
-  // map came to rest even if a wait started partway through getting there
-  private emitBounds() {
-    if (!this.map) return;
-    this.boundsChange.emit(boundsToBbox(this.map.getBounds()));
+  /**
+   * What the reader drew, as an area a query can state.
+   *
+   * The two corners arrive as pixels on the canvas, so which is west is decided on screen rather than
+   * by longitude. With rotation disabled the left edge is always the west one, and it has to be read
+   * that way round: a box dragged across the antimeridian unprojects to 175 and -175, and taking the
+   * smaller of those for west would describe the other 350 degrees. Screen y grows downward, so the
+   * top of the box is its north edge.
+   *
+   * On a globe those two corners aren't the corners of a rectangle at all - the top edge of a screen
+   * box isn't a line of latitude - but they are what the reader enclosed, and they are the same two
+   * points MapLibre's own box zoom would have fitted.
+   */
+  private search(start: maplibregl.Point, end: maplibregl.Point) {
+    if (start.dist(end) < MIN_SEARCH_DRAG) return;
+
+    const northWest = this.map.unproject([Math.min(start.x, end.x), Math.min(start.y, end.y)]);
+    const southEast = this.map.unproject([Math.max(start.x, end.x), Math.max(start.y, end.y)]);
+
+    // Through our own reader rather than straight into a LngLatBounds: it carries an east edge past
+    // its west the way a box crossing the antimeridian is written, and it answers with nothing for a
+    // pair MapLibre would throw on - a latitude past a pole, which a flat map's unproject can hand
+    // back. boundsToBbox then brings both edges into range, so what comes out can be stated in a query.
+    const area = readBounds([northWest.lng, southEast.lat, southEast.lng, northWest.lat]);
+    if (!area) return console.warn('Could not read the area searched:', northWest, southEast);
+
+    this.boundsChange.emit(boundsToBbox(area));
   }
 
   @Watch('records')
   @Watch('previewers')
   protected async onRecordsChange() {
-    await this.clear();
-    await this.draw();
+    await this.load();
   }
 
-  // A camera moved after the map opened. Nothing is redrawn: what is on the map stays where it is,
-  // and only the view of it changes - including back to the whole of it, if the camera is withdrawn.
+  // The area being searched has changed. The box that says where it is has to go on again, but
+  // nothing about the results has moved, so nobody is asked for their extent a second time.
   @Watch('bounds')
   protected async onBoundsChange() {
+    this.readSearchFilter();
+    this.draw();
     await this.frame();
   }
 
-  // When the theme changes, swap the basemap to match, then draw the same records into the style
+  // A highlight arriving from outside. Only the marker and the box around its extent change, and the
+  // camera is left exactly where it is: something on the page has said which result matters, not
+  // where to look, and flying the map at a row the reader happened to hover is not what they asked
+  // for.
+  @Watch('highlighted')
+  protected onHighlightedChange() {
+    this.draw();
+  }
+
+  // When the theme changes, swap the basemap to match, then draw the same results into the style
   // document the swap just emptied.
   @Watch('theme')
   protected async onThemeChange() {
@@ -167,70 +295,105 @@ export class OgmOverview {
     // to do here but let it. Kept as an await so a caller can wait for the swap to finish.
   }
 
-  // Put every record's extent on the map, number them, and point the map at them.
-  private async draw() {
-    if (!this.map || !this.mapStyleLoaded) return;
-
-    // Only known now: the colors come out of the theme, and the theme can change under records
-    // that are already on screen.
-    const style = this.mapTheme.getStyle();
-    this.drawn = this.previewers ?? locationsFor(this.records ?? []);
-
-    // In the order given, so the boxes are painted in the same order they're numbered. Nothing here
-    // reaches the network - a LocationResource is built from a shape rather than a URL - so
-    // drawing them one after another costs nothing.
-    for (const previewer of this.drawn) await previewer?.attach(this.map, style).preview();
-
+  // Everything, in the order it has to happen: what area is being searched, where the results are,
+  // what goes on the map, and then where the camera looks.
+  private async load() {
+    this.readSearchFilter();
+    await this.measure();
+    this.draw();
     await this.frame();
   }
 
-  // Point the map at what should be in view: the camera an embedder stated, or the whole of what is
-  // drawn. Last, so every number sits over every box.
+  // The area a search is filtered to, if this map can read what it was given. Read once per load
+  // rather than at each of the two places that want it, so an unreadable one is reported once.
+  private readSearchFilter() {
+    this.searchFilter = this.bounds === undefined ? undefined : readBounds(this.bounds);
+    if (this.bounds !== undefined && !this.searchFilter) console.warn('Could not read bounds:', this.bounds);
+  }
+
+  // Where every result is, and what each of them is called.
+  //
+  // Both are counted over, which is why both are kept: the extents are what get a number and a place
+  // on the map, and the ids are what a highlight names when it names one by id rather than by place. A
+  // record nobody could place holds its position in each, so the two stay in step with the list a
+  // reader is reading beside the map.
+  private async measure() {
+    const previewers = this.previewers ?? locationsFor(this.records ?? []);
+    this.ids = this.previewers ? this.previewers.map(previewer => previewer.resourceId) : (this.records ?? []).map(record => record.id);
+
+    // Asked of the previewers rather than read off the records, so an extent handed over and one
+    // worked out here arrive by the same route - and so a geometry is squared off to its envelope in
+    // one place. Nothing here reaches the network, since a LocationResource is built from a shape
+    // rather than a URL, so all of them at once costs nothing.
+    this.extents = await Promise.all(previewers.map(previewer => previewer?.getBounds()));
+  }
+
+  // Put the results on the map: their numbers, the highlighted one's own extent, and the area being
+  // searched. See drawResults, which is where the order all of that goes on in lives.
+  private draw() {
+    if (!this.map || !this.mapStyleLoaded) return;
+
+    // Only known now: the colors come out of the theme, and the theme can change under results that
+    // are already on screen.
+    drawResults(this.map, this.mapTheme.getStyle(), {
+      extents: this.extents,
+      highlighted: this.highlightedPosition(),
+      searchBounds: this.searchFilter,
+    });
+  }
+
+  // Point the camera at what should be in view: the area a search is filtered to, or the whole of
+  // what is drawn.
   private async frame() {
     if (!this.map || !this.mapStyleLoaded) return;
 
-    const stated = this.bounds === undefined ? undefined : readBounds(this.bounds);
-    if (this.bounds !== undefined && !stated) console.warn('Could not read bounds:', this.bounds);
-
-    const extents = await Promise.all(this.drawn.map(previewer => previewer?.getBounds()));
-
-    // A globe when there is one place to look at, and a flat map when there are several - or whenever
-    // the camera was stated, since a globe can't be pointed at every box one might name: see
-    // clampToHemisphere, which would answer a stated camera with half of what it asked for.
-    const placed = extents.filter(extent => extent !== undefined);
-    const globe = !stated && placed.length === 1;
-    this.map.setProjection({ type: globe ? 'globe' : 'mercator' });
-
-    // Zoom to the superset of all bounds (or the whole world if none), unless a camera says otherwise.
-    // For a globe, clamp to a hemisphere so that the camera can properly frame it.
-    const target = stated ?? unionBounds(extents) ?? WORLD;
-    await fitBounds(this.map, this.mapTheme, globe ? clampToHemisphere(target) : target, this.camera(stated));
+    // Everywhere the results cover, or the whole world if none of them said where they are
+    const target = this.searchFilter ?? unionBounds(this.extents) ?? WORLD;
+    await frameLocation(this.map, this.mapTheme, target, this.projection === 'globe', this.camera());
   }
 
-  // What the camera is allowed to do with what it was pointed at.
+  // What the camera is allowed to do with what it was pointed at. The gap comes from frameLocation,
+  // which both of these maps share; this is the part that differs.
   //
-  // A stated one is framed as given, because an embedder naming an area has already said what they
-  // want on screen: no gap, so the area named is the area seen and handing back what boundsChange
-  // reported is a camera that doesn't move, and no zoom limit, so a reader who searched a single
-  // street doesn't come back to a view of the city.
-  //
-  // Records get both. The theme's overview gap rather than the one a preview gets, since this is a
-  // whole map read at once rather than a pane filled with one record, and a box drawn against its
-  // edge reads as running off it - on a globe, that edge is where the sphere turns away. And no closer
-  // than city scale, because there may be nothing named on the basemap to place a box any closer by.
-  private camera(stated?: maplibregl.LngLatBounds): maplibregl.FitBoundsOptions {
-    if (stated) return { padding: 0 };
-    return { maxZoom: MAX_ZOOM, padding: this.mapTheme.getOverviewPadding() };
+  // A zoom limit only for what was drawn, because there may be nothing named on the basemap to place
+  // a page of results any closer by. An area a search is filtered to gets none: a reader who searched
+  // a single street shouldn't come back to a view of the city.
+  private camera(): maplibregl.FitBoundsOptions {
+    return this.searchFilter ? {} : { maxZoom: LOCATION_MAX_ZOOM };
   }
 
-  // Take the last set of records back off the map
-  private async clear() {
-    await Promise.all(this.drawn.map(previewer => previewer?.clearPreview()));
-    this.drawn = [];
+  /**
+   * Which result the highlight names, counted from one.
+   *
+   * A number is a place in the list, and a string is an id - unless it is a place written down, which
+   * is what an attribute hands over for either, since an attribute is always a string. An id is tried
+   * first, because an id we hold is a match and a place is only a count: a page whose records are
+   * named "1", "2", "3" means the record rather than the row.
+   *
+   * Counted over every result, including the ones nobody could place. The number is the row a reader
+   * sees beside the map, so closing the gap a record with no bounding box leaves would point every
+   * result after it at the wrong row - and a highlight that lands on one of those gaps draws nothing,
+   * which is the truth. Nothing at all for a value naming neither an id nor a row, which is a map with
+   * no highlight rather than one with the wrong highlight.
+   */
+  private highlightedPosition(): number | undefined {
+    if (this.highlighted === undefined) return undefined;
+    if (typeof this.highlighted === 'number') return this.position(this.highlighted);
+
+    const named = this.ids.indexOf(this.highlighted);
+    if (named >= 0) return named + 1;
+
+    return this.position(Number(this.highlighted));
+  }
+
+  // A place in the list, if it is one at all. Bounded by what we hold, because a place past the end
+  // names no result: Number('') is 0 and Number('somewhere') is NaN, and neither is a row.
+  private position(place: number): number | undefined {
+    return Number.isInteger(place) && place >= 1 && place <= this.extents.length ? place : undefined;
   }
 
   // Web Awesome is linked even though nothing here renders a wa-* element: MapLibreTheme reads
-  // --wa-color-* tokens for the boxes and the numbers, and this component is meant to be used on
+  // --wa-color-* tokens for the numbers and the boxes, and this component is meant to be used on
   // its own, so it is the one that has to establish them.
   render() {
     return (

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -3,7 +3,7 @@ import type maplibregl from 'maplibre-gl';
 
 import { getElement } from '../../lib/elements';
 import GeosearchControl from '../../lib/geosearch-control';
-import { boundsToBbox, clampToHemisphere, unionBounds, WORLD } from '../../lib/geometry';
+import { boundsToBbox, clampToHemisphere, readBounds, unionBounds, WORLD } from '../../lib/geometry';
 import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
 import { createMap, fitBounds, setBasemap, whenSized } from '../../lib/maps';
 import LocationPreviewer, { locationsFor } from '../../lib/previewers/location';
@@ -29,17 +29,12 @@ export class OgmOverview {
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() records?: OgmRecord[];
   @Prop() previewers?: LocationPreviewer[];
-
-  // Whether to offer to search the area on screen, and which of the two ways to start out doing it:
-  // 'auto' searches every view the reader comes to rest in, 'manual' only the ones they ask about.
-  // Left unset there is no control and no event, which is what an overview that isn't a set of search
-  // results wants.
   @Prop() geosearch?: 'auto' | 'manual';
-
-  // What that control says in each mode. Given rather than fixed because GeoBlacklight already
-  // translates both before handing them to the Leaflet control this one stands in for.
   @Prop() searchHereText: string = 'Search here';
   @Prop() searchOnMoveText: string = 'Search when I move the map';
+
+  // Where to point the camera, provided externally
+  @Prop() bounds?: maplibregl.LngLatBoundsLike | string;
 
   // Where the reader has asked to search, as the west, south, east, north degrees a query states -
   // see boundsToBbox. Nothing here answers it: what a new area means is the embedding page's to say.
@@ -153,6 +148,13 @@ export class OgmOverview {
     await this.draw();
   }
 
+  // A camera moved after the map opened. Nothing is redrawn: what is on the map stays where it is,
+  // and only the view of it changes - including back to the whole of it, if the camera is withdrawn.
+  @Watch('bounds')
+  protected async onBoundsChange() {
+    await this.frame();
+  }
+
   // When the theme changes, swap the basemap to match, then draw the same records into the style
   // document the swap just emptied.
   @Watch('theme')
@@ -165,7 +167,7 @@ export class OgmOverview {
     // to do here but let it. Kept as an await so a caller can wait for the swap to finish.
   }
 
-  // Put every record's extent on the map, number them, and zoom to fit.
+  // Put every record's extent on the map, number them, and point the map at them.
   private async draw() {
     if (!this.map || !this.mapStyleLoaded) return;
 
@@ -174,27 +176,51 @@ export class OgmOverview {
     const style = this.mapTheme.getStyle();
     this.drawn = this.previewers ?? locationsFor(this.records ?? []);
 
-    // In the order given, so the boxes are painted in the same order they're numbered. Nothing here
+  // In the order given, so the boxes are painted in the same order they're numbered. Nothing hereread
     // reaches the network - a LocationResource is built from a shape rather than a URL - so
     // drawing them one after another costs nothing.
     for (const previewer of this.drawn) await previewer?.attach(this.map, style).preview();
 
-    // Last, so every number sits over every box
+    await this.frame();
+  }
+
+  // Point the map at what should be in view: the camera an embedder stated, or the whole of what is
+  // drawn. Last, so every number sits over every box.
+  private async frame() {
+    if (!this.map || !this.mapStyleLoaded) return;
+
+    const stated = this.bounds === undefined ? undefined : readBounds(this.bounds);
+    if (this.bounds !== undefined && !stated) console.warn('Could not read bounds:', this.bounds);
+
     const extents = await Promise.all(this.drawn.map(previewer => previewer?.getBounds()));
 
-    // A globe when there is one place to look at, and a flat map when there are several
+    // A globe when there is one place to look at, and a flat map when there are several - or whenever
+    // the camera was stated, since a globe can't be pointed at every box one might name: see
+    // clampToHemisphere, which would answer a stated camera with half of what it asked for.
     const placed = extents.filter(extent => extent !== undefined);
-    const globe = placed.length === 1;
+    const globe = !stated && placed.length === 1;
     this.map.setProjection({ type: globe ? 'globe' : 'mercator' });
 
-    // Zoom to the superset of all bounds (or the whole world if none).
+    // Zoom to the superset of all bounds (or the whole world if none), unless a camera says otherwise.
     // For a globe, clamp to a hemisphere so that the camera can properly frame it.
-    //
-    // The theme's overview gap rather than the one a preview gets: this is a whole map read at once
-    // rather than a pane filled with one record, and a box drawn against its edge reads as running
-    // off it - on a globe, that edge is where the sphere turns away.
-    const target = unionBounds(extents) ?? WORLD;
-    await fitBounds(this.map, this.mapTheme, globe ? clampToHemisphere(target) : target, { maxZoom: MAX_ZOOM, padding: style.overviewPadding });
+    const target = stated ?? unionBounds(extents) ?? WORLD;
+    await fitBounds(this.map, this.mapTheme, globe ? clampToHemisphere(target) : target, this.camera(stated));
+  }
+
+  // What the camera is allowed to do with what it was pointed at.
+  //
+  // A stated one is framed as given, because an embedder naming an area has already said what they
+  // want on screen: no gap, so the area named is the area seen and handing back what boundsChange
+  // reported is a camera that doesn't move, and no zoom limit, so a reader who searched a single
+  // street doesn't come back to a view of the city.
+  //
+  // Records get both. The theme's overview gap rather than the one a preview gets, since this is a
+  // whole map read at once rather than a pane filled with one record, and a box drawn against its
+  // edge reads as running off it - on a globe, that edge is where the sphere turns away. And no closer
+  // than city scale, because there may be nothing named on the basemap to place a box any closer by.
+  private camera(stated?: maplibregl.LngLatBounds): maplibregl.FitBoundsOptions {
+    if (stated) return { padding: 0 };
+    return { maxZoom: MAX_ZOOM, padding: this.mapTheme.getOverviewPadding() };
   }
 
   // Take the last set of records back off the map

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -82,6 +82,21 @@ export class OgmOverview {
   // see boundsToBbox. Nothing here answers it: what a new area means is the embedding page's to say.
   @Event() boundsChange: EventEmitter<[number, number, number, number]>;
 
+  /**
+   * Which result the reader's pointer is over: its place in the list counted from one, and the id of
+   * the record - or of the resource a previewer draws - it came from. Null once the pointer has left
+   * every number.
+   *
+   * Both terms, because a page holds its results in one or the other, and either is enough to light up
+   * the row the reader is pointing at - which is the whole of what this is for:
+   *
+   *   overview.addEventListener('highlightChange', event => mark(event.detail?.id));
+   *
+   * The reader's own pointer only. Setting `highlighted` doesn't come back out: a page that has said
+   * which result matters already knows, and reporting it would be a loop waiting to be wired.
+   */
+  @Event() highlightChange: EventEmitter<{ place: number; id: string } | null>;
+
   private map: maplibregl.Map;
   private mapTheme: MapLibreTheme;
   private geosearchControl?: GeosearchControl;
@@ -191,11 +206,20 @@ export class OgmOverview {
 
   private handlePointerOut = () => this.setHovered(undefined);
 
-  // Redrawn only when the answer changes, since the pointer reports every pixel it crosses
+  // Redrawn, and the page told, only when the answer changes - the pointer reports every pixel it
+  // crosses, and a marker is a good many pixels wide.
   private setHovered(place: number | undefined) {
     if (this.hovered === place) return;
     this.hovered = place;
+    this.highlightChange.emit(this.hoveredResult());
     this.draw();
+  }
+
+  // What the pointer is over, in both of the terms a page might hold its results in. Null rather than
+  // undefined, because that is what a CustomEvent carries either way: WebIDL reads an undefined
+  // `detail` as one that was never given and hands the reader the default, which is null.
+  private hoveredResult(): { place: number; id: string } | null {
+    return this.hovered === undefined ? null : { place: this.hovered, id: this.ids[this.hovered - 1] ?? '' };
   }
 
   // Zoom buttons and the projection toggle, plus the search hint if one was asked for
@@ -319,7 +343,10 @@ export class OgmOverview {
   protected async onRecordsChange() {
     // Whatever the pointer was over is gone, and the place it named now names a different result. It
     // can't be re-asked either: MapLibre reports a pointer that moves, and this one is holding still.
-    this.hovered = undefined;
+    // Through the same door as everything else, so the row a page lit up goes out with the marker - the
+    // draw it costs is against extents that are about to be replaced by the load below, in the same
+    // task, so nothing is ever drawn from it.
+    this.setHovered(undefined);
     await this.load();
   }
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -9,7 +9,7 @@ import { addLocationControls, createMap, disableRotation, frameLocation, LOCATIO
 import LocationPreviewer, { locationsFor } from '../../lib/previewers/location';
 import type { MapProjection } from '../../lib/previewers/map';
 import type OgmRecord from '../../lib/record';
-import { drawResults } from '../../lib/results';
+import { drawResults, RESULT_MARKERS } from '../../lib/results';
 import MapLibreTheme from '../../lib/themes/maplibre';
 
 // How far a shift-drag has to go before it counts as asking about an area, in pixels. MapLibre's own
@@ -49,6 +49,10 @@ export class OgmOverview {
    *
    * The marker changes color and comes to the front, and the result's own extent is drawn around it.
    * The camera doesn't move: something on the page has said which result matters, not where to look.
+   *
+   * A reader's pointer over a number does the same thing without being asked, so both can be true at
+   * once - of two different results, if a page names one while the pointer is over another. Each is a
+   * way of saying the same thing about a row, so each gets the same drawing; see draw.
    */
   @Prop() highlighted?: number | string;
 
@@ -100,6 +104,10 @@ export class OgmOverview {
   // twice would report an unreadable one twice as well.
   private searchFilter?: maplibregl.LngLatBounds;
 
+  // Which result the reader's pointer is over, as its place in the list counted from one. Ours rather
+  // than the page's: nothing outside can see a pointer land on a number drawn inside this shadow root.
+  private hovered?: number;
+
   async componentDidLoad() {
     const container = getElement(this.el, '#map');
 
@@ -136,8 +144,10 @@ export class OgmOverview {
     });
     disableRotation(this.map);
 
-    // Before the style loads, because none of these writes anything into it
+    // Before the style loads, because none of these writes anything into it - and the pointer can be
+    // followed before there are any markers for it to find, since a layer listener is the map's own
     this.addControls();
+    this.followPointer();
 
     // A reader reaching for the globe button, which is worth a fresh camera: what a globe can be
     // pointed at is not what a flat map can - see frameLocation - so flattening one is how a reader
@@ -152,6 +162,40 @@ export class OgmOverview {
   // Clean up the map to prevent warnings/errors when removed from the DOM
   disconnectedCallback() {
     if (this.map) this.map.remove();
+  }
+
+  /**
+   * Highlight whichever number the reader's pointer is over.
+   *
+   * Bound to the layer rather than to the map, so MapLibre does the hit testing against the symbols it
+   * actually placed - and bound once, before any of them exist, because a layer listener is the map's
+   * own and goes on answering for every style document that follows. Nothing here moves the camera or
+   * tells the page: a pointer resting on a number is a question about that number, not a click.
+   *
+   * mousemove rather than mouseenter, because the pointer can cross from one marker straight onto the
+   * next without ever leaving the layer, and mouseenter is only offered the first of those.
+   */
+  private followPointer() {
+    this.map.on('mousemove', RESULT_MARKERS, this.handlePointerOver);
+    this.map.on('mouseleave', RESULT_MARKERS, this.handlePointerOut);
+  }
+
+  // The number under the pointer, which is the one the reader can see: markers overlap, and the one
+  // drawn on top is the earliest, since that is how they are sorted - see resultMarkersLayer. MapLibre
+  // hands back everything under the pointer without promising an order, so the choice is made here
+  // rather than taken from the first of them.
+  private handlePointerOver = (event: maplibregl.MapLayerMouseEvent) => {
+    const places = (event.features ?? []).map(feature => Number(feature.properties?.label)).filter(place => Number.isInteger(place));
+    this.setHovered(places.length ? Math.min(...places) : undefined);
+  };
+
+  private handlePointerOut = () => this.setHovered(undefined);
+
+  // Redrawn only when the answer changes, since the pointer reports every pixel it crosses
+  private setHovered(place: number | undefined) {
+    if (this.hovered === place) return;
+    this.hovered = place;
+    this.draw();
   }
 
   // Zoom buttons and the projection toggle, plus the search hint if one was asked for
@@ -273,6 +317,9 @@ export class OgmOverview {
   @Watch('records')
   @Watch('previewers')
   protected async onRecordsChange() {
+    // Whatever the pointer was over is gone, and the place it named now names a different result. It
+    // can't be re-asked either: MapLibre reports a pointer that moves, and this one is holding still.
+    this.hovered = undefined;
     await this.load();
   }
 
@@ -354,7 +401,7 @@ export class OgmOverview {
     // are already on screen.
     drawResults(this.map, this.mapTheme.getStyle(), {
       extents: this.extents,
-      highlighted: this.highlightedPosition(),
+      highlighted: this.highlightedPositions(),
       searchBounds: this.searchFilter,
     });
   }
@@ -377,6 +424,15 @@ export class OgmOverview {
   // a single street shouldn't come back to a view of the city.
   private camera(): maplibregl.FitBoundsOptions {
     return this.searchFilter ? {} : { maxZoom: LOCATION_MAX_ZOOM };
+  }
+
+  // Every result to draw as highlighted, counted from one: the one the page named and the one the
+  // reader's pointer is over. Both, rather than one winning, because they are two separate statements
+  // and neither is a correction of the other - though in practice they are the same result or there is
+  // only one of them, since a pointer cannot be over a row beside the map and a number on it at once.
+  private highlightedPositions(): number[] {
+    const places = [this.highlightedPosition(), this.hovered].filter(place => place !== undefined);
+    return [...new Set(places)];
   }
 
   /**

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -5,7 +5,7 @@ import { getElement } from '../../lib/elements';
 import GeosearchControl from '../../lib/geosearch-control';
 import { boundsToBbox, readBounds, unionBounds, WORLD } from '../../lib/geometry';
 import { themePreference, waScope, webAwesomeReady, webAwesomeStylesheet } from '../../lib/init';
-import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, setBasemap, whenSized } from '../../lib/maps';
+import { addLocationControls, createMap, disableRotation, frameLocation, LOCATION_MAP, LOCATION_MAX_ZOOM, readProjection, setBasemap, whenSized } from '../../lib/maps';
 import LocationPreviewer, { locationsFor } from '../../lib/previewers/location';
 import type { MapProjection } from '../../lib/previewers/map';
 import type OgmRecord from '../../lib/record';
@@ -104,9 +104,9 @@ export class OgmOverview {
   // Used to prevent drawing into a style document that isn't there yet
   private mapStyleLoaded: boolean = false;
 
-  // Which projection the map is in, as the reader last left it. Held rather than read off the map,
-  // because the map forgets: a style document carries its own projection and neither basemap names
-  // one, so every theme swap arrives flat and would take a globe the reader had chosen with it.
+  // Which projection to open a new style document in. Held only for that: a swap arrives flat,
+  // because a style carries its own projection and neither basemap names one, so the map forgets what
+  // the reader was looking at. Everything else asks the map - see readProjection.
   private projection: MapProjection = 'globe';
 
   // Where every result is and what each of them is called, in the order they were given - including
@@ -244,20 +244,19 @@ export class OgmOverview {
     await this.load();
   }
 
-  // The reader reaching for the globe button.
-  //
-  // Held to a style document that is already up, because a style loading is itself two of these: it
-  // ends by setting whatever projection it names, which is mercator for both basemaps, and then
-  // handleStyleLoad above puts the reader's choice back. Neither is a choice, and taking the first for
-  // one would flatten a globe on every theme swap.
-  private handleProjectionTransition = async (event: maplibregl.MapProjectionEvent) => {
+  /**
+   * The projection changing under the camera, which is worth a fresh one: what a globe can be pointed
+   * at is not what a flat map can - see frameLocation - so flattening one is how a reader sees the
+   * whole of something too wide to fit on a sphere.
+   *
+   * Nothing is remembered here, because this event can't say who caused it. A reader pressing the
+   * globe button and a style document naming its own projection on the way in arrive as the same
+   * thing, and no flag holds them apart: a swap asked for while the map is still loading the document
+   * before it lands that reset squarely inside any window this could call the reader's. What to put
+   * back after a swap is read off the map instead, at the point the swap starts - see onThemeChange.
+   */
+  private handleProjectionTransition = async () => {
     if (!this.mapStyleLoaded) return;
-
-    // Anything that isn't flat is a globe as far as the camera is concerned. MapLibre has two names
-    // for one: 'globe' is the projection that draws as a sphere until it is zoomed in past the point
-    // where a sphere and a flat map are the same picture, and 'vertical-perspective' is the one that
-    // stays a sphere throughout.
-    this.projection = event.newProjection === 'mercator' ? 'mercator' : 'globe';
     await this.frame();
   };
 
@@ -376,6 +375,11 @@ export class OgmOverview {
   protected async onThemeChange() {
     if (!this.map) return;
     this.mapTheme.theme = this.theme;
+
+    // Read now, while the map still knows: the document replacing this one names its own projection
+    // and neither basemap names anything, so the map comes back flat unless it is put back.
+    this.projection = readProjection(this.map) ?? this.projection;
+
     this.mapStyleLoaded = false;
     await setBasemap(this.map, this.mapTheme);
     // style.load has already fired by the time this resolves, and it draws - so there is nothing
@@ -441,7 +445,14 @@ export class OgmOverview {
 
     // Everywhere the results cover, or the whole world if none of them said where they are
     const target = this.searchFilter ?? unionBounds(this.extents) ?? WORLD;
-    await frameLocation(this.map, this.mapTheme, target, this.projection === 'globe', this.camera());
+    await frameLocation(this.map, this.mapTheme, target, this.globe(), this.camera());
+  }
+
+  // Whether the camera is pointing at a sphere, which is what decides whether what it is pointed at
+  // has to be held to the half of the world facing it. Asked of the map, because the map is the one
+  // that knows: a reader can change this without anything here being told which way it went.
+  private globe(): boolean {
+    return (readProjection(this.map) ?? this.projection) === 'globe';
   }
 
   // What the camera is allowed to do with what it was pointed at. The gap comes from frameLocation,

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -37,7 +37,10 @@ export class OgmOverview {
   @Element() el: HTMLElement;
   @Prop() theme: 'light' | 'dark' = themePreference();
   @Prop() records?: OgmRecord[];
-  @Prop() previewers?: LocationPreviewer[];
+
+  // Holes and all, because that is what `locationsFor` hands back: a record with nothing to place it
+  // by still holds its position, since that position is the number a reader sees beside the map.
+  @Prop() previewers?: (LocationPreviewer | undefined)[];
 
   /**
    * Which result to bring forward, as either its place in the list counted from one or the id of the
@@ -242,12 +245,20 @@ export class OgmOverview {
    * On a globe those two corners aren't the corners of a rectangle at all - the top edge of a screen
    * box isn't a line of latitude - but they are what the reader enclosed, and they are the same two
    * points MapLibre's own box zoom would have fitted.
+   *
+   * The latitudes are sorted afterwards, unlike the longitudes. Screen y and latitude only run
+   * together while the pole is off screen: pan one into view on a globe and a line of pixels crosses
+   * it, so the higher pixel can be the lower latitude, and a box dragged over the pole would come out
+   * with its south edge north of its north edge. Nothing rejects that - LngLatBounds holds whichever
+   * corners it is given - so it would leave here as a bbox no query can answer.
    */
   private search(start: maplibregl.Point, end: maplibregl.Point) {
     if (start.dist(end) < MIN_SEARCH_DRAG) return;
 
-    const northWest = this.map.unproject([Math.min(start.x, end.x), Math.min(start.y, end.y)]);
-    const southEast = this.map.unproject([Math.max(start.x, end.x), Math.max(start.y, end.y)]);
+    const topLeft = this.map.unproject([Math.min(start.x, end.x), Math.min(start.y, end.y)]);
+    const bottomRight = this.map.unproject([Math.max(start.x, end.x), Math.max(start.y, end.y)]);
+    const northWest = { lng: topLeft.lng, lat: Math.max(topLeft.lat, bottomRight.lat) };
+    const southEast = { lng: bottomRight.lng, lat: Math.min(topLeft.lat, bottomRight.lat) };
 
     // Through our own reader rather than straight into a LngLatBounds: it carries an east edge past
     // its west the way a box crossing the antimeridian is written, and it answers with nothing for a
@@ -319,7 +330,12 @@ export class OgmOverview {
   // reader is reading beside the map.
   private async measure() {
     const previewers = this.previewers ?? locationsFor(this.records ?? []);
-    this.ids = this.previewers ? this.previewers.map(previewer => previewer.resourceId) : (this.records ?? []).map(record => record.id);
+
+    // A hole keeps its place here as well, as the empty string, so the two lists stay the same length
+    // and a highlight named by id lands on the right row. Nothing shows for the empty string itself:
+    // it lands on the row of a result there was nothing to draw, which looks the same as asking for a
+    // name nothing carries.
+    this.ids = this.previewers ? this.previewers.map(previewer => previewer?.resourceId ?? '') : (this.records ?? []).map(record => record.id);
 
     // Asked of the previewers rather than read off the records, so an extent handed over and one
     // worked out here arrive by the same route - and so a geometry is squared off to its envelope in

--- a/src/index.html
+++ b/src/index.html
@@ -80,7 +80,8 @@
       }
 
       /* The row the map says the reader is pointing at; see the highlightChange listener */
-      .results li.highlighted button {
+      .results li.highlighted button,
+      .results li:hover button {
         background: #7fd6ec;
         color: #000;
       }
@@ -98,7 +99,7 @@
     </style>
 
     <script type="module">
-      import { OgmRecord } from './build/index.esm.js';
+      import { OgmRecord, locationsFor, unionBounds } from './build/index.esm.js';
 
       function parseCsvRecords(csvText) {
         const rows = [];
@@ -227,20 +228,18 @@
           const record = new OgmRecord(recordJson);
 
           if (recordUrl) viewer.recordUrl = recordUrl;
-          if (record) overview.records = [record];
           if (record) locator.record = record;
-          if (record) renderResults([record]);
+          if (record) await loadRecords([record]);
         });
 
         // Clear record button
         const clearRecordButton = document.getElementById('clearRecord');
-        clearRecordButton.addEventListener('click', () => {
+        clearRecordButton.addEventListener('click', async () => {
           recordInput.value = '';
           recordSelector.value = '';
           viewer.loadRecord(null);
-          overview.records = [];
           locator.record = undefined;
-          renderResults([]);
+          await loadRecords([]);
         });
 
         // Toggle theme button
@@ -263,9 +262,53 @@
         const boundsOut = document.getElementById('boundsOut');
         const clearFilterButton = document.getElementById('clearFilter');
 
+        // Every result the page is holding, each with the extent a search is answered from, and the area
+        // a search is filtered to. Read once as the records arrive, through the same previewers the map
+        // reads them through - so the boxes searched against are the boxes the numbers are drawn at.
+        let loaded = [];
+        let filter;
+
+        // Whether two areas meet at all, which is the whole of what filtering by a bounding box is.
+        // Latitudes are a plain comparison. Longitudes have to be squared up first, because either box
+        // can be written across the antimeridian: a search dragged over it comes back as west 175 and
+        // east -175, and a record's own extent carries its east edge past 180 instead. Each is turned
+        // into a span that starts at its west edge and runs east, and then it is a question of whether
+        // either span reaches the other - at any of the three turns of the world where they could.
+        const span = (west, east) => (east < west ? [west, east + 360] : [west, east]);
+        const meets = (search, extent) => {
+          const [searchWest, searchSouth, searchEast, searchNorth] = search;
+          if (extent.getNorth() < searchSouth || searchNorth < extent.getSouth()) return false;
+
+          const [west, east] = span(searchWest, searchEast);
+          const [extentWest, extentEast] = span(extent.getWest(), extent.getEast());
+          return [-360, 0, 360].some(turn => west <= extentEast + turn && extentWest + turn <= east);
+        };
+
+        // The results the filter leaves, handed to the map and to the list together so that the numbers
+        // on one are the rows of the other - which is what a page does with a search: a new set of
+        // results, numbered from one. A record with no extent has nothing to search by, so a filter
+        // drops it; with no filter, every record is a result.
+        const applyFilter = () => {
+          const kept = filter ? loaded.filter(({ extent }) => extent && meets(filter, extent)) : loaded;
+          overview.records = kept.map(({ record }) => record);
+          renderResults(kept.map(({ record }) => record));
+        };
+
+        // Records arriving, measured once. locationsFor leaves a gap where a record says nothing about
+        // where it is, which is the same gap <ogm-overview> would have found for itself. Each extent
+        // comes back as anything MapLibre reads as bounds, so it goes through unionBounds to arrive as
+        // one thing with edges that can be asked for.
+        const loadRecords = async records => {
+          const extents = await Promise.all(locationsFor(records).map(previewer => previewer?.getBounds()));
+          loaded = records.map((record, index) => ({ record, extent: unionBounds([extents[index]]) }));
+          applyFilter();
+        };
+
         const setFilter = bounds => {
+          filter = bounds;
           overview.bounds = bounds;
           boundsOut.textContent = bounds ? bounds.map(degrees => degrees.toFixed(3)).join(' ') : '';
+          applyFilter();
         };
 
         geosearchSelect.addEventListener('change', () => {
@@ -308,8 +351,7 @@
         loadAllButton.addEventListener('click', async () => {
           const urls = [...recordSelector.options].map(option => option.value).filter(Boolean);
           const records = await Promise.all(urls.map(async url => new OgmRecord(await (await fetch(url)).json())));
-          overview.records = records;
-          renderResults(records);
+          await loadRecords(records);
         });
       });
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -79,6 +79,12 @@
         text-align: start;
       }
 
+      /* The row the map says the reader is pointing at; see the highlightChange listener */
+      .results li.highlighted button {
+        background: #7fd6ec;
+        color: #000;
+      }
+
       ogm-viewer,
       ogm-overview,
       ogm-locator {
@@ -272,6 +278,13 @@
         overview.addEventListener('boundsChange', event => setFilter(event.detail));
 
         clearFilterButton.addEventListener('click', () => setFilter(undefined));
+
+        // The row the map says the reader's pointer is over, marked the way a page would mark it. The
+        // other direction from `highlighted` below: this one is the map telling the list.
+        overview.addEventListener('highlightChange', event => {
+          const pointed = event.detail?.place;
+          [...results.children].forEach((item, index) => item.classList.toggle('highlighted', index + 1 === pointed));
+        });
 
         // A row per result, the way a page would render them beside the map. Hovering one drives
         // `highlighted` by id, which is what a page holding records has to hand.

--- a/src/index.html
+++ b/src/index.html
@@ -274,7 +274,7 @@
         clearFilterButton.addEventListener('click', () => setFilter(undefined));
 
         // A row per result, the way a page would render them beside the map. Hovering one drives
-        // `highlighted` by id, which is the half of it an attribute can't reach.
+        // `highlighted` by id, which is what a page holding records has to hand.
         const renderResults = records => {
           results.innerHTML = '';
           records.forEach((record, index) => {

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,8 @@
       }
 
       ogm-viewer,
-      ogm-overview {
+      ogm-overview,
+      ogm-locator {
         display: block;
         height: 500px;
         flex: auto;
@@ -155,28 +156,28 @@
         const overview = document.querySelector('ogm-overview');
         const recordInput = document.getElementById('recordUrl');
         const loadRecordButton = document.getElementById('loadRecord');
+        const locator = document.querySelector('ogm-locator');
         const switchOverviewButton = document.getElementById('switch-overview');
         const switchViewerButton = document.getElementById('switch-viewer');
+        const switchLocatorButton = document.getElementById('switch-locator');
         const hideTitle = document.querySelector('.hideTitle');
         const geosearch = document.querySelector('.geosearch');
 
-        switchOverviewButton.addEventListener('click', () => {
-          overview.style.display = 'flex';
-          viewer.style.display = 'none';
-          switchOverviewButton.style.display = 'none';
-          switchViewerButton.style.display = 'inline-block';
-          hideTitle.style.display = 'none';
-          geosearch.style.display = 'inline-flex';
-        });
+        // Which of the three is on screen, and which of the controls belong to it
+        const show = which => {
+          viewer.style.display = which === 'viewer' ? 'block' : 'none';
+          overview.style.display = which === 'overview' ? 'flex' : 'none';
+          locator.style.display = which === 'locator' ? 'block' : 'none';
+          switchViewerButton.style.display = which === 'viewer' ? 'none' : 'inline-block';
+          switchOverviewButton.style.display = which === 'overview' ? 'none' : 'inline-block';
+          switchLocatorButton.style.display = which === 'locator' ? 'none' : 'inline-block';
+          hideTitle.style.display = which === 'viewer' ? 'inline-block' : 'none';
+          geosearch.style.display = which === 'overview' ? 'inline-flex' : 'none';
+        };
 
-        switchViewerButton.addEventListener('click', () => {
-          overview.style.display = 'none';
-          viewer.style.display = 'block';
-          switchOverviewButton.style.display = 'inline-block';
-          switchViewerButton.style.display = 'none';
-          hideTitle.style.display = 'inline-block';
-          geosearch.style.display = 'none';
-        });
+        switchViewerButton.addEventListener('click', () => show('viewer'));
+        switchOverviewButton.addEventListener('click', () => show('overview'));
+        switchLocatorButton.addEventListener('click', () => show('locator'));
 
         // Dynamically populate the selector
         try {
@@ -195,6 +196,7 @@
 
           if (recordUrl) viewer.recordUrl = recordUrl;
           if (record) overview.records = [record];
+          if (record) locator.record = record;
         });
 
         // Clear record button
@@ -204,6 +206,7 @@
           recordSelector.value = '';
           viewer.loadRecord(null);
           overview.records = [];
+          locator.record = undefined;
         });
 
         // Toggle theme button
@@ -212,6 +215,7 @@
           const theme = viewer.theme === 'light' ? 'dark' : 'light';
           viewer.theme = theme;
           overview.theme = theme;
+          locator.theme = theme;
         });
 
         // Hide title checkbox
@@ -250,6 +254,7 @@
       <div class="props">
         <button id="toggleTheme">Toggle Theme</button>
         <button id="switch-overview">Switch to overview</button>
+        <button id="switch-locator">Switch to locator</button>
         <button id="switch-viewer" style="display: none">Switch to viewer</button>
         <label class="hideTitle">Hide Title <input type="checkbox" id="hideTitle" /></label>
         <span class="geosearch" style="display: none">
@@ -261,5 +266,6 @@
 
     <ogm-viewer></ogm-viewer>
     <ogm-overview style="display: none"></ogm-overview>
+    <ogm-locator style="display: none"></ogm-locator>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,28 @@
         font-size: 0.85rem;
       }
 
+      .results {
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.75rem;
+        margin: 0.5rem 0 0;
+        padding: 0;
+        width: min(90vw, 800px);
+        font-size: 0.85rem;
+      }
+
+      .results button {
+        appearance: none;
+        background: none;
+        border: 0;
+        padding: 0;
+        font: inherit;
+        color: #06c;
+        cursor: pointer;
+        text-align: start;
+      }
+
       ogm-viewer,
       ogm-overview,
       ogm-locator {
@@ -162,6 +184,8 @@
         const switchLocatorButton = document.getElementById('switch-locator');
         const hideTitle = document.querySelector('.hideTitle');
         const geosearch = document.querySelector('.geosearch');
+        const loadAllButton = document.getElementById('loadAll');
+        const results = document.getElementById('results');
 
         // Which of the three is on screen, and which of the controls belong to it
         const show = which => {
@@ -173,6 +197,8 @@
           switchLocatorButton.style.display = which === 'locator' ? 'none' : 'inline-block';
           hideTitle.style.display = which === 'viewer' ? 'inline-block' : 'none';
           geosearch.style.display = which === 'overview' ? 'inline-flex' : 'none';
+          loadAllButton.style.display = which === 'overview' ? 'inline-block' : 'none';
+          results.style.display = which === 'overview' ? 'flex' : 'none';
         };
 
         switchViewerButton.addEventListener('click', () => show('viewer'));
@@ -197,6 +223,7 @@
           if (recordUrl) viewer.recordUrl = recordUrl;
           if (record) overview.records = [record];
           if (record) locator.record = record;
+          if (record) renderResults([record]);
         });
 
         // Clear record button
@@ -207,6 +234,7 @@
           viewer.loadRecord(null);
           overview.records = [];
           locator.record = undefined;
+          renderResults([]);
         });
 
         // Toggle theme button
@@ -227,14 +255,48 @@
         // Geosearch and bounds display
         const geosearchSelect = document.getElementById('geosearch');
         const boundsOut = document.getElementById('boundsOut');
+        const clearFilterButton = document.getElementById('clearFilter');
+
+        const setFilter = bounds => {
+          overview.bounds = bounds;
+          boundsOut.textContent = bounds ? bounds.map(degrees => degrees.toFixed(3)).join(' ') : '';
+        };
+
         geosearchSelect.addEventListener('change', () => {
-          const active = geosearchSelect.checked;
-          if (!active) boundsOut.textContent = '';
-          overview.geosearch = active ? 'auto' : undefined;
+          overview.geosearch = geosearchSelect.checked;
+          if (!geosearchSelect.checked) setFilter(undefined);
         });
 
-        overview.addEventListener('boundsChange', event => {
-          boundsOut.textContent = event.detail.map(degrees => degrees.toFixed(3)).join(' ');
+        // Straight back as the active filter, which is the round trip an embedding app makes - and
+        // the only way to see the area being searched drawn on the map
+        overview.addEventListener('boundsChange', event => setFilter(event.detail));
+
+        clearFilterButton.addEventListener('click', () => setFilter(undefined));
+
+        // A row per result, the way a page would render them beside the map. Hovering one drives
+        // `highlighted` by id, which is the half of it an attribute can't reach.
+        const renderResults = records => {
+          results.innerHTML = '';
+          records.forEach((record, index) => {
+            const item = document.createElement('li');
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = `${index + 1}. ${record.title ?? record.id}`;
+            button.addEventListener('mouseenter', () => (overview.highlighted = record.id));
+            button.addEventListener('focus', () => (overview.highlighted = record.id));
+            button.addEventListener('mouseleave', () => (overview.highlighted = undefined));
+            button.addEventListener('blur', () => (overview.highlighted = undefined));
+            item.appendChild(button);
+            results.appendChild(item);
+          });
+        };
+
+        // Every record in the selector at once, so there is something to number
+        loadAllButton.addEventListener('click', async () => {
+          const urls = [...recordSelector.options].map(option => option.value).filter(Boolean);
+          const records = await Promise.all(urls.map(async url => new OgmRecord(await (await fetch(url)).json())));
+          overview.records = records;
+          renderResults(records);
         });
       });
     </script>
@@ -257,12 +319,16 @@
         <button id="switch-locator">Switch to locator</button>
         <button id="switch-viewer" style="display: none">Switch to viewer</button>
         <label class="hideTitle">Hide Title <input type="checkbox" id="hideTitle" /></label>
+        <button id="loadAll" style="display: none">Load all records</button>
         <span class="geosearch" style="display: none">
           <label>Geosearch <input type="checkbox" id="geosearch" /></label>
           <code id="boundsOut"></code>
+          <button id="clearFilter">Clear filter</button>
         </span>
       </div>
     </div>
+
+    <ol class="results" id="results" style="display: none"></ol>
 
     <ogm-viewer></ogm-viewer>
     <ogm-overview style="display: none"></ogm-overview>

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,7 @@
         display: flex;
         flex-direction: column;
         align-items: center;
+        overflow: hidden;
       }
 
       h1 {
@@ -61,6 +62,7 @@
         list-style: none;
         display: flex;
         flex-wrap: wrap;
+        flex-direction: column;
         gap: 0.25rem 0.75rem;
         margin: 0.5rem 0 0;
         padding: 0;
@@ -73,8 +75,8 @@
         background: none;
         border: 0;
         padding: 0;
-        font: inherit;
-        color: #06c;
+        font-family: sans-serif;
+        font-size: 1.5rem;
         cursor: pointer;
         text-align: start;
       }
@@ -383,10 +385,9 @@
       </div>
     </div>
 
-    <ol class="results" id="results" style="display: none"></ol>
-
     <ogm-viewer></ogm-viewer>
-    <ogm-overview style="display: none"></ogm-overview>
     <ogm-locator style="display: none"></ogm-locator>
+    <ogm-overview style="display: none"></ogm-overview>
+    <ol class="results" id="results" style="display: none"></ol>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,8 @@ export { default as GeoJsonPreviewer, type AddGeoJsonSourceObject } from './lib/
 export { default as ImagePreviewer } from './lib/previewers/image';
 // `locationsFor` is what <ogm-overview> turns records into: one extent apiece, keeping the place of
 // a record it can't put anywhere, since that place is the number a reader sees on the map.
-export { default as LocationPreviewer, locationsFor } from './lib/previewers/location';
+// `locationFor` is the one of them <ogm-locator> draws.
+export { default as LocationPreviewer, locationFor, locationsFor } from './lib/previewers/location';
 export { default as OpenIndexMapPreviewer } from './lib/previewers/openindexmap';
 export { default as PMTilesRasterPreviewer } from './lib/previewers/pmtiles-raster';
 export { default as PMTilesVectorPreviewer } from './lib/previewers/pmtiles-vector';

--- a/src/lib/attribution-control.test.ts
+++ b/src/lib/attribution-control.test.ts
@@ -1,0 +1,110 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect } from 'vitest';
+import type { Map } from 'maplibre-gl';
+
+import AttributionControl from './attribution-control';
+
+// Enough of a map for MapLibre's own attribution to build itself against: it asks for the strings to
+// label the toggle with, for the element it measures to decide whether to be compact at all, and for
+// the style document it reads the credits out of. It also binds to the events that keep those credits
+// in step, which is what `credit` below fires.
+const fakeMap = () => {
+  const listeners: Record<string, ((event: unknown) => void)[]> = {};
+
+  return {
+    listeners,
+    style: { stylesheet: undefined as unknown, tileManagers: {} as Record<string, unknown> },
+    getCanvasContainer: () => document.createElement('div'),
+    _getUIString: (key: string) => key,
+    on(event: string, listener: (event: unknown) => void) {
+      (listeners[event] ??= []).push(listener);
+    },
+    off(event: string, listener: (event: unknown) => void) {
+      listeners[event] = (listeners[event] ?? []).filter(bound => bound !== listener);
+    },
+    fire(event: string, data: unknown = {}) {
+      [...(listeners[event] ?? [])].forEach(listener => listener(data));
+    },
+  };
+};
+
+const addControl = () => {
+  const map = fakeMap();
+  const control = new AttributionControl({ compact: true });
+  const container = control.onAdd(map as unknown as Map) as HTMLDetailsElement;
+  document.body.appendChild(container);
+  return { map, control, container, button: container.querySelector('summary') as HTMLElement };
+};
+
+// The basemap's own credit arriving, which is the moment MapLibre would otherwise open the panel.
+// CARTO's style names no attribution of its own, only a source to fetch, so this lands with that
+// fetch rather than with the style.
+const credit = (map: ReturnType<typeof fakeMap>) => {
+  map.style.stylesheet = {};
+  map.style.tileManagers = { basemap: { used: true, getSource: () => ({ attribution: '© CARTO' }) } };
+  map.fire('sourcedata', { dataType: 'source', sourceDataType: 'metadata' });
+};
+
+const shown = (container: HTMLElement) => container.classList.contains('maplibregl-compact-show');
+
+describe('AttributionControl', () => {
+  // Everything visible is MapLibre's; this only checks its work was passed through rather than
+  // replaced, since a subclass that forgot to return super's element would leave nothing on the map
+  it("hands back MapLibre's own attribution", () => {
+    const { container, button } = addControl();
+
+    expect(container.tagName).toEqual('DETAILS');
+    expect(container.className).toContain('maplibregl-ctrl-attrib');
+    expect(button.className).toContain('maplibregl-ctrl-attrib-button');
+    expect(button.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  // MapLibre's own way of keeping an empty credit out of the corner
+  it('credits nothing until there is something to credit', () => {
+    const { container } = addControl();
+
+    expect(container.classList.contains('maplibregl-attrib-empty')).toBe(true);
+  });
+
+  it('starts as the "i" rather than as the open panel', () => {
+    const { map, container } = addControl();
+    credit(map);
+
+    expect(container.classList.contains('maplibregl-compact')).toBe(true);
+    expect(shown(container)).toBe(false);
+    expect(container.textContent).toContain('CARTO');
+  });
+
+  it('opens when the reader asks, and closes again', () => {
+    const { map, container, button } = addControl();
+    credit(map);
+
+    button.click();
+    expect(shown(container)).toBe(true);
+
+    button.click();
+    expect(shown(container)).toBe(false);
+  });
+
+  // The load-bearing one: trackContainerSize calls map.resize() on every container change, and a
+  // resize is one of the things that re-runs MapLibre's own decision about the panel.
+  it('stays closed when the map is resized', () => {
+    const { map, container } = addControl();
+    credit(map);
+
+    map.fire('resize');
+
+    expect(shown(container)).toBe(false);
+  });
+
+  it('leaves a panel the reader opened open', () => {
+    const { map, container, button } = addControl();
+    credit(map);
+    button.click();
+
+    map.fire('resize');
+    map.fire('styledata', { dataType: 'style' });
+
+    expect(shown(container)).toBe(true);
+  });
+});

--- a/src/lib/attribution-control.ts
+++ b/src/lib/attribution-control.ts
@@ -1,0 +1,33 @@
+import { AttributionControl as MapLibreAttributionControl, type Map } from 'maplibre-gl';
+
+/**
+ * MapLibre's attribution, opening as the "i" in the corner rather than as the panel behind it.
+ *
+ * Compact names the shape the credit can collapse to, not the shape it starts in: MapLibre opens the
+ * panel as soon as there is something to credit, and only shrinks it to the "i" once the reader drags
+ * the map. On a map the size of a locator that is most of one corner spent on a line nobody came to
+ * read. The credit itself isn't optional - the basemaps are CARTO's over OpenStreetMap data and both
+ * require it - so the pill stays and starts small instead.
+ *
+ * `maplibregl-compact` is the class the collapsed pill is drawn from, and MapLibre only ever adds it
+ * in the same breath as `maplibregl-compact-show`, the class that opens the panel, and only when the
+ * container isn't already carrying it. So claiming it here is the whole mechanism: what MapLibre
+ * finds afterwards is exactly the state its own first pass would have left, and its toggle, its
+ * collapse-on-drag and its own resize pass all still work.
+ *
+ * The other way round - taking the show class off once it appears - has no good moment to happen in.
+ * Not as the control is added, because the container is `maplibregl-attrib-empty` then, and that is
+ * the very class blocking the branch that would open it. Not on style.load either: CARTO's style
+ * names no attribution of its own, only a source to fetch, so the credit line lands with that fetch
+ * some way after the style is up. And anything late enough to catch it has to be careful not to fire
+ * twice, because our own observer calls map.resize() whenever the container changes and a resize runs
+ * the same code - which would shut a panel the reader had just opened.
+ */
+export default class AttributionControl extends MapLibreAttributionControl {
+  // After MapLibre's own onAdd rather than before it, because the container is what that hands back
+  onAdd(map: Map): HTMLElement {
+    const container = super.onAdd(map);
+    container.classList.add('maplibregl-compact');
+    return container;
+  }
+}

--- a/src/lib/geometry.test.ts
+++ b/src/lib/geometry.test.ts
@@ -11,6 +11,7 @@ import {
   mercatorGeomToLngLat,
   mercatorToLngLat,
   pixelWindowCenter,
+  readBounds,
   unionBounds,
   WORLD,
 } from './geometry';
@@ -137,6 +138,63 @@ describe('boundsToBbox', () => {
   // A globe with a pole facing the camera reports exactly the pole, which is a latitude Solr takes
   it('should leave a view that reaches a pole alone', () => {
     expect(boundsToBbox(new LngLatBounds([-30, -90], [30, 90]))).toEqual([-30, -90, 30, 90]);
+  });
+});
+
+describe('readBounds', () => {
+  // The four numbers in the order every other bbox here is written in
+  it('should read a west, south, east, north list', () => {
+    expect(readBounds([-124.41, 32.53, -114.13, 42.01])?.toArray()).toEqual([
+      [-124.41, 32.53],
+      [-114.13, 42.01],
+    ]);
+  });
+
+  it('should read a list written out as a string, however it is separated', () => {
+    expect(readBounds('-124.41 32.53 -114.13 42.01')?.toArray()).toEqual(readBounds('-124.41,32.53,-114.13,42.01')?.toArray());
+    expect(readBounds('-124.41 32.53 -114.13 42.01')?.getWest()).toEqual(-124.41);
+  });
+
+  // The form dcat_bbox is written in, so a record's own box can be handed over as it stands
+  it('should read an ENVELOPE string', () => {
+    expect(readBounds('ENVELOPE(-124.41,-114.13,42.01,32.53)')?.toArray()).toEqual([
+      [-124.41, 32.53],
+      [-114.13, 42.01],
+    ]);
+  });
+
+  it('should read anything else MapLibre reads as bounds', () => {
+    const bounds = new LngLatBounds([-10, 0], [-5, 5]);
+    expect(readBounds(bounds)?.toArray()).toEqual(bounds.toArray());
+    expect(
+      readBounds([
+        [-10, 0],
+        [-5, 5],
+      ])?.toArray(),
+    ).toEqual(bounds.toArray());
+  });
+
+  // The inverse of boundsToBbox, which is what lets an area a reader asked to search be handed back
+  // to hold the map there. The east edge is carried past 180 again on the way in, so the camera frames
+  // the 30 degrees of the Pacific the view covered rather than the 330 degrees of everywhere else.
+  it('should undo what boundsToBbox did to a view across the antimeridian', () => {
+    const view = new LngLatBounds([530, -10], [560, 10]);
+    const read = readBounds(boundsToBbox(view))!;
+
+    expect([read.getWest(), read.getSouth(), read.getEast(), read.getNorth()]).toEqual([170, -10, 200, 10]);
+    expect(read.getEast() - read.getWest()).toEqual(view.getEast() - view.getWest());
+  });
+
+  it('should read nothing from a string that says something else', () => {
+    expect(readBounds('POINT(-122.17 37.43)')).toBeUndefined();
+    expect(readBounds('-124.41 32.53 -114.13')).toBeUndefined();
+    expect(readBounds('west south east north')).toBeUndefined();
+    expect(readBounds('')).toBeUndefined();
+  });
+
+  // MapLibre throws on these rather than saying so, and a camera nobody can point is worth reporting
+  it('should read nothing from a box that reaches past a pole', () => {
+    expect(readBounds([-30, -100, 30, 100])).toBeUndefined();
   });
 });
 

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -73,6 +73,41 @@ export const bboxToBounds = (bbox: string) => {
   return new LngLatBounds([parseFloat(west), parseFloat(south)], [unwrapEast(parseFloat(west), parseFloat(east)), parseFloat(north)]);
 };
 
+/**
+ * A camera stated in whichever form one can be given in: the west, south, east, north list
+ * boundsToBbox hands back, an ENVELOPE string as `dcat_bbox` holds one, or anything else MapLibre
+ * reads as bounds. Nothing at all for a string that says something else, or for numbers that don't
+ * describe a box - a camera that can't be pointed is worth reporting rather than guessing at.
+ *
+ * The east edge is carried past the west the way unwrapEast does, which makes this the inverse of
+ * boundsToBbox: a box that crosses the antimeridian is read back as the strait it covers rather than
+ * as the rest of the world, so an area a reader asked to search can be handed straight back.
+ */
+export const readBounds = (bounds: LngLatBoundsLike | string): LngLatBounds | undefined => {
+  const read = typeof bounds === 'string' ? (bboxToBounds(bounds) ?? boundsFromList(bounds)) : convertBounds(bounds);
+  if (!read) return undefined;
+
+  const west = read.getWest();
+  return new LngLatBounds([west, read.getSouth()], [unwrapEast(west, read.getEast()), read.getNorth()]);
+};
+
+// The four numbers of a bbox written out, in the west, south, east, north order MapLibre uses for
+// one everywhere else, separated by commas or spaces - the two ways a bbox is written down.
+const boundsFromList = (bbox: string): LngLatBounds | undefined => {
+  const edges = bbox.split(/[\s,]+/).filter(edge => edge !== '');
+  if (edges.length !== 4 || !edges.every(edge => Number.isFinite(Number(edge)))) return undefined;
+  return convertBounds(edges.map(Number) as [number, number, number, number]);
+};
+
+// MapLibre throws on a box it can't read - a latitude past a pole, say - rather than saying so
+const convertBounds = (bounds: LngLatBoundsLike): LngLatBounds | undefined => {
+  try {
+    return LngLatBounds.convert(bounds);
+  } catch {
+    return undefined;
+  }
+};
+
 // A longitude already in range is handed back exactly as it came, rather than put through MapLibre's
 // own wrap. That one ends `w === min ? max : w`, so it answers 180 for an edge sitting on -180 - which
 // would flip the west edge of a world-wide box to the far side of the world - and it costs a float's

--- a/src/lib/geosearch-control.test.ts
+++ b/src/lib/geosearch-control.test.ts
@@ -77,6 +77,18 @@ describe('GeosearchControl', () => {
     expect(container.hidden).toBe(false);
   });
 
+  // MapLibre calls every handler off when the window loses focus, and does it by resetting them - so
+  // the rectangle goes and neither boxzoomend nor boxzoomcancel is fired. Without this, coming back
+  // to the tab would mean coming back to a map with no help text on it.
+  it('should come back when the reader walks away partway through a box', () => {
+    const { container, map } = addControl();
+
+    map.fire('boxzoomstart');
+    window.dispatchEvent(new Event('blur'));
+
+    expect(container.hidden).toBe(false);
+  });
+
   it('should let go of the map when removed', () => {
     const { control, container, map } = addControl();
     control.onRemove(map as unknown as Map);
@@ -85,6 +97,11 @@ describe('GeosearchControl', () => {
     expect(map.bound('boxzoomend')).toEqual(0);
     expect(map.bound('boxzoomcancel')).toEqual(0);
     expect(container.parentNode).toBeNull();
+
+    // And the window with it, or a control taken off the map would still be answering for one
+    container.hidden = true;
+    window.dispatchEvent(new Event('blur'));
+    expect(container.hidden).toBe(true);
   });
 
   // Nothing retexts one before it is on a map, but a control with no element to write into shouldn't

--- a/src/lib/geosearch-control.test.ts
+++ b/src/lib/geosearch-control.test.ts
@@ -1,13 +1,14 @@
 /** @vitest-environment happy-dom */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Map } from 'maplibre-gl';
 
-import GeosearchControl, { type GeosearchMode } from './geosearch-control';
+import GeosearchControl from './geosearch-control';
 
-const LABELS = { searchHere: 'Search here', searchOnMove: 'Search when I move the map' };
+const HELP = 'Shift + drag to search an area';
 
-// Enough of a map to bind to and to fire at. The control reads nothing off it - the bounds are the
-// component's to fetch once the callback comes - so a stand-in only has to remember what was bound.
+// Enough of a map to bind to and to fire at. The control reads nothing off it - the gesture is
+// MapLibre's own and the callback behind it is the component's - so a stand-in only has to remember
+// what was bound.
 const fakeMap = () => {
   const listeners: Record<string, ((event: unknown) => void)[]> = {};
   return {
@@ -22,225 +23,73 @@ const fakeMap = () => {
   };
 };
 
-// The reader's own hand on the camera, and something else pointing it; see handleCameraEnd
-const DROVE = { originalEvent: new MouseEvent('mouseup') };
-const POINTED = {};
-
-const addControl = (mode: GeosearchMode = 'auto') => {
-  const onSearch = vi.fn();
+const addControl = (text = HELP) => {
   const map = fakeMap();
-  const control = new GeosearchControl(onSearch, LABELS, mode);
+  const control = new GeosearchControl(text);
   const container = control.onAdd(map as unknown as Map);
-
-  // On the page, so the focus a mode swap follows has somewhere to be
   document.body.appendChild(container);
 
-  return {
-    control,
-    container,
-    map,
-    onSearch,
-    label: container.querySelector('label') as HTMLLabelElement,
-    checkbox: container.querySelector('input') as HTMLInputElement,
-    button: container.querySelector('button') as HTMLButtonElement,
-  };
+  return { control, container, map };
 };
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-  document.body.replaceChildren();
-});
-
 describe('GeosearchControl', () => {
-  // The control carries no styling of its own: every rule that makes it look like map chrome, in both
-  // themes, selects these class names. It stays out of maplibregl-ctrl-group on purpose - see onAdd.
-  it('builds the DOM its styling selects', () => {
-    const { container, label, checkbox, button } = addControl();
+  // The class is what the component's own stylesheet selects on, and .maplibregl-ctrl is what gives
+  // it the float and the inset from the corner
+  it('should build the DOM its styling selects', () => {
+    const { container } = addControl();
 
     expect(container.className).toEqual('maplibregl-ctrl maplibregl-ctrl-geosearch');
-    expect(container.classList.contains('maplibregl-ctrl-group')).toBe(false);
-    expect(label.className).toEqual('on-move');
-    expect(checkbox.type).toEqual('checkbox');
-    expect(button.className).toEqual('search-here');
-    expect(button.type).toEqual('button');
+    expect(container.children).toHaveLength(0);
   });
 
-  // The words are the checkbox's accessible name, so there is no aria-label to check against them
-  it('says what it will do in whichever mode it is in', () => {
-    const { label, checkbox, button } = addControl();
-
-    expect(label.hidden).toBe(false);
-    expect(checkbox.checked).toBe(true);
-    expect(label.textContent).toEqual('Search when I move the map');
-    expect(button.hidden).toBe(true);
-    expect(button.textContent).toEqual('Search here');
+  // Given rather than baked in, because GeoBlacklight runs the strings for the control this replaces
+  // through Rails I18n
+  it('should say how to search, in the words it was given', () => {
+    expect(addControl('Cerca arrossegant amb la tecla de majúscules').container.textContent).toEqual('Cerca arrossegant amb la tecla de majúscules');
   });
 
-  it('opens ready to be asked, when that is the mode it was built for', () => {
-    const { label, checkbox, button } = addControl('manual');
+  it('should be retexted where it stands', () => {
+    const { control, container } = addControl();
+    control.setText('Search by dragging');
 
-    expect(button.hidden).toBe(false);
-    expect(label.hidden).toBe(true);
-    expect(checkbox.checked).toBe(false);
+    expect(container.textContent).toEqual('Search by dragging');
+    expect(container.parentNode).toEqual(document.body);
   });
 
-  it('takes its wording from what it was given, and is retexted where it stands', () => {
-    const { control, label, button } = addControl();
+  // It is the only thing of ours over the drawing surface, and the gesture it describes is the one
+  // thing that draws across it
+  it('should get out of the way while a box is being drawn, and come back', () => {
+    const { container, map } = addControl();
 
-    control.setLabels({ searchHere: 'Cerca aquí', searchOnMove: 'Cerca quan moc el mapa' });
+    map.fire('boxzoomstart');
+    expect(container.hidden).toBe(true);
 
-    expect(label.textContent).toEqual('Cerca quan moc el mapa');
-    expect(button.textContent).toEqual('Cerca aquí');
+    map.fire('boxzoomend');
+    expect(container.hidden).toBe(false);
   });
 
-  it('asks for a search once the map has been left alone', () => {
-    const { map, onSearch } = addControl();
+  it('should come back from a box the reader gave up on', () => {
+    const { container, map } = addControl();
 
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(799);
-    expect(onSearch).not.toHaveBeenCalled();
+    map.fire('boxzoomstart');
+    map.fire('boxzoomcancel');
 
-    vi.advanceTimersByTime(1);
-    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(container.hidden).toBe(false);
   });
 
-  it('asks about where the reader stopped rather than everywhere they passed through', () => {
-    const { map, onSearch } = addControl();
-
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(400);
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(400);
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).toHaveBeenCalledTimes(1);
-  });
-
-  // The case the originalEvent guard is for: trackContainerSize's map.resize() fires moveend on every
-  // reflow, and draw()'s fitBounds fires one on every record change. Neither is the reader asking.
-  it('says nothing about a camera it did not drive', () => {
-    const { map, onSearch } = addControl();
-
-    map.fire('moveend', POINTED);
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).not.toHaveBeenCalled();
-  });
-
-  // A container that resizes mid-drag calls Camera#stop, which fires dragend and swallows the moveend
-  it('asks for a search after a drag whose moveend went missing', () => {
-    const { map, onSearch } = addControl();
-
-    map.fire('dragend', DROVE);
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).toHaveBeenCalledTimes(1);
-  });
-
-  // A box zoom's camera is a fitScreenCoordinates call with no event data, so only the boxzoomend just
-  // before it says a shift-drag happened at all
-  it('asks for one search after a box zoom, whose own moveend arrives untagged', () => {
-    const { map, onSearch } = addControl();
-
-    map.fire('boxzoomend', DROVE);
-    map.fire('moveend', POINTED);
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).toHaveBeenCalledTimes(1);
-  });
-
-  it('searches nothing in manual mode, however far the map is moved', () => {
-    const { map, onSearch } = addControl('manual');
-
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).not.toHaveBeenCalled();
-  });
-
-  it('offers to search here instead, as soon as the reader stops wanting it done for them', () => {
-    const { checkbox, label, button } = addControl();
-
-    checkbox.click();
-
-    expect(checkbox.checked).toBe(false);
-    expect(label.hidden).toBe(true);
-    expect(button.hidden).toBe(false);
-  });
-
-  it('drops a search the reader has just called off', () => {
-    const { map, checkbox, onSearch } = addControl();
-
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(400);
-    checkbox.click();
-    vi.advanceTimersByTime(800);
-
-    expect(onSearch).not.toHaveBeenCalled();
-  });
-
-  it('searches at once when asked outright, then goes back to searching every view', () => {
-    const { map, checkbox, label, button, onSearch } = addControl('manual');
-
-    button.click();
-
-    expect(onSearch).toHaveBeenCalledTimes(1);
-    expect(checkbox.checked).toBe(true);
-    expect(label.hidden).toBe(false);
-    expect(button.hidden).toBe(true);
-
-    map.fire('moveend', DROVE);
-    vi.advanceTimersByTime(800);
-    expect(onSearch).toHaveBeenCalledTimes(2);
-  });
-
-  // Hiding what holds focus drops it to the body, so it is handed to whatever took its place. That move
-  // is also what announces the mode change, which is why nothing here says it out loud.
-  it('hands focus to whichever of the two it just showed', () => {
-    const { checkbox, button } = addControl();
-
-    checkbox.focus();
-    checkbox.click();
-    expect(document.activeElement).toEqual(button);
-
-    button.click();
-    expect(document.activeElement).toEqual(checkbox);
-  });
-
-  it('leaves focus alone when the reader was somewhere else entirely', () => {
-    const { checkbox, button } = addControl();
-    const elsewhere = document.createElement('input');
-    document.body.appendChild(elsewhere);
-    elsewhere.focus();
-
-    checkbox.click();
-
-    expect(document.activeElement).toEqual(elsewhere);
-    expect(button.hidden).toBe(false);
-  });
-
-  it('lets go of the map when removed, and of the search it was about to ask for', () => {
-    const { control, container, map, onSearch } = addControl();
-
-    map.fire('moveend', DROVE);
+  it('should let go of the map when removed', () => {
+    const { control, container, map } = addControl();
     control.onRemove(map as unknown as Map);
-    vi.advanceTimersByTime(800);
 
-    expect(onSearch).not.toHaveBeenCalled();
-    expect(map.bound('moveend')).toEqual(0);
-    expect(map.bound('dragend')).toEqual(0);
+    expect(map.bound('boxzoomstart')).toEqual(0);
     expect(map.bound('boxzoomend')).toEqual(0);
+    expect(map.bound('boxzoomcancel')).toEqual(0);
     expect(container.parentNode).toBeNull();
   });
 
-  // Nothing calls it before the map has its controls, but a control that isn't on a map has nothing to
-  // retext and shouldn't throw looking for it
-  it('does nothing when retexted before it has been added to a map', () => {
-    expect(() => new GeosearchControl(vi.fn(), LABELS).setLabels(LABELS)).not.toThrow();
+  // Nothing retexts one before it is on a map, but a control with no element to write into shouldn't
+  // throw looking for one
+  it('should do nothing when retexted before it has been added to a map', () => {
+    expect(() => new GeosearchControl(HELP).setText('Search here')).not.toThrow();
   });
 });

--- a/src/lib/geosearch-control.ts
+++ b/src/lib/geosearch-control.ts
@@ -34,6 +34,13 @@ export default class GeosearchControl implements IControl {
     map.on('boxzoomend', this.show);
     map.on('boxzoomcancel', this.show);
 
+    // A gesture the reader walked away from. MapLibre calls every handler off when the window loses
+    // focus - alt-tab partway through a drag and the rectangle goes - but it does that by resetting
+    // the handler, which fires neither of the two events above. Left to those alone, coming back to
+    // the tab would mean coming back to a map with no help text on it, and nothing short of another
+    // whole drag would bring it back.
+    window.addEventListener('blur', this.show);
+
     return this.container;
   }
 
@@ -41,6 +48,7 @@ export default class GeosearchControl implements IControl {
     map.off('boxzoomstart', this.hide);
     map.off('boxzoomend', this.show);
     map.off('boxzoomcancel', this.show);
+    window.removeEventListener('blur', this.show);
 
     this.container?.remove();
     this.container = undefined;

--- a/src/lib/geosearch-control.ts
+++ b/src/lib/geosearch-control.ts
@@ -1,184 +1,63 @@
-import type { IControl, Map, MapEventType } from 'maplibre-gl';
-
-// What the control says it will do, in each of its two modes. Given rather than baked in because
-// GeoBlacklight already runs both strings through Rails I18n before handing them to the Leaflet
-// control this one replaces, and a translated reader shouldn't lose them in the swap.
-export type GeosearchLabels = {
-  searchHere: string;
-  searchOnMove: string;
-};
-
-// Whether the control searches every view the reader comes to rest in, or only the one they ask about
-export type GeosearchMode = 'auto' | 'manual';
-
-// How long to leave after the reader stops moving the map before searching where they stopped.
-// GeoBlacklight's own wait. MapLibre already folds a gesture and its inertia into a single moveend, so
-// this isn't there to coalesce one gesture: it's for the reader who pans twice, holds an arrow key, or
-// turns a wheel, none of whom meant to ask about anywhere they passed through on the way.
-const SEARCH_DELAY = 800;
-
-// The camera settling under the reader's own hand, as against one something else pointed. MapLibre
-// threads the DOM event behind a gesture through to whatever the camera fires, and leaves it off every
-// camera it moves itself, so this is the whole of how the two are told apart - see handleCameraEnd.
-//
-// `moveend` is the one that matters and would almost do alone: unlike Leaflet's dragend, which is why
-// GeoBlacklight debounces at all, it fires once per interaction with inertia already spent. The other
-// two are each here for a case it misses:
-//
-// - `dragend`, because a container that resizes mid-drag takes the drag's moveend with it. The resize
-//   calls Camera#stop, which reaches HandlerManager#stop(false), and with no end animation allowed
-//   that fires dragend and no moveend at all.
-// - `boxzoomend`, because a box zoom's camera is a fitScreenCoordinates call the handler returns
-//   without any event data, so its moveend arrives untagged and reads as one of ours. The boxzoomend
-//   just before it is tagged, and is the only notice of a shift-drag we get.
-//
-// Arming from any of them costs nothing, because the bounds are read when the wait ends rather than
-// when it starts: whichever arrives first, what gets searched is where the map came to rest.
-const CAMERA_END_EVENTS = ['moveend', 'dragend', 'boxzoomend'] as const;
+import type { IControl, Map } from 'maplibre-gl';
 
 /**
- * A control that asks for the area on screen to be searched: either whenever the reader stops moving
- * the map, or only when they press the button. Modelled on GeoBlacklight's Leaflet geosearch control.
+ * A line of text over the map saying how to search it: hold shift and drag a box.
  *
- * Like the other controls here it emits nothing itself - it calls what it was built with, and the
- * component that put it on the map is the one that owns an event.
+ * Saying so is all it does. The gesture itself is MapLibre's own BoxZoomHandler, and the component
+ * that put this on the map is the one holding the callback behind it - see <ogm-overview>. A control
+ * rather than something rendered into a shadow root, because MapLibre's control stack is what sets a
+ * corner aside and keeps the inset from the edge.
+ *
+ * The words are given rather than baked in, because GeoBlacklight already runs the strings for the
+ * Leaflet control this one replaces through Rails I18n, and a translated reader shouldn't lose them
+ * in the swap.
+ *
+ * It gets out of the way while a box is being drawn: it is the only thing of ours sitting over the
+ * drawing surface, and the gesture it describes is the one thing that draws across it.
  */
 export default class GeosearchControl implements IControl {
   private container: HTMLElement | undefined;
-  private label: HTMLLabelElement | undefined;
-  private checkbox: HTMLInputElement | undefined;
-  private text: HTMLSpanElement | undefined;
-  private button: HTMLButtonElement | undefined;
-  private timer: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(
-    private onSearch: () => void,
-    private labels: GeosearchLabels,
-    private mode: GeosearchMode = 'auto',
-  ) {}
+  constructor(private text: string) {}
 
   onAdd(map: Map): HTMLElement {
     this.container = document.createElement('div');
     // Deliberately not maplibregl-ctrl-group. That class carries MapLibre's white pill and the metrics
-    // for a 29px square icon button, and it's the selector <ogm-map> inverts wholesale in dark mode.
-    // This is a line of text, so it's drawn on the same surface tokens as the attribution and follows
-    // the mode without being inverted - which is what a checkbox's accent and a focus ring both need.
+    // for a 29px square icon button, and it's the selector the dark-mode rules invert wholesale. This
+    // is a line of text, so it's drawn on the same surface tokens as the attribution and follows the
+    // mode without being inverted. .maplibregl-ctrl on its own still gives the float and the 10px
+    // inset from the corner.
     this.container.className = 'maplibregl-ctrl maplibregl-ctrl-geosearch';
+    this.container.textContent = this.text;
 
-    this.checkbox = document.createElement('input');
-    this.checkbox.type = 'checkbox';
-    this.checkbox.addEventListener('change', this.handleToggle);
+    map.on('boxzoomstart', this.hide);
+    map.on('boxzoomend', this.show);
+    map.on('boxzoomcancel', this.show);
 
-    // The words are the checkbox's accessible name, so what it's called is always what it says. An
-    // aria-label here would be a second copy to fall out of step with - and the reason LayersControl
-    // needs one is that its button is a background image with no text to name it.
-    this.text = document.createElement('span');
-
-    this.label = document.createElement('label');
-    this.label.className = 'on-move';
-    this.label.append(this.checkbox, this.text);
-
-    this.button = document.createElement('button');
-    this.button.type = 'button';
-    this.button.className = 'search-here';
-    this.button.addEventListener('click', this.handleSearchHere);
-
-    this.container.append(this.label, this.button);
-    this.applyLabels();
-    this.setMode(this.mode);
-
-    for (const event of CAMERA_END_EVENTS) map.on(event, this.handleCameraEnd);
     return this.container;
   }
 
   onRemove(map: Map) {
-    // Before the container goes, so a wait already under way can't come due against a map that has
-    // been taken down - or, through the callback, against a component that has stopped rendering.
-    this.cancelSearch();
-    for (const event of CAMERA_END_EVENTS) map.off(event, this.handleCameraEnd);
+    map.off('boxzoomstart', this.hide);
+    map.off('boxzoomend', this.show);
+    map.off('boxzoomcancel', this.show);
 
     this.container?.remove();
     this.container = undefined;
-    this.label = undefined;
-    this.checkbox = undefined;
-    this.text = undefined;
-    this.button = undefined;
   }
 
-  // Retexted where it stands rather than rebuilt, so a change of wording doesn't take the mode, the
-  // pending wait, or the reader's place in the tab order with it.
-  setLabels(labels: GeosearchLabels) {
-    this.labels = labels;
-    this.applyLabels();
+  // Retexted where it stands rather than rebuilt, so a change of wording doesn't drop the control to
+  // the bottom of its corner or blank it out partway through a reader's gesture.
+  setText(text: string) {
+    this.text = text;
+    if (this.container) this.container.textContent = text;
   }
 
-  private applyLabels() {
-    if (!this.text || !this.button) return;
-    this.text.textContent = this.labels.searchOnMove;
-    this.button.textContent = this.labels.searchHere;
-  }
-
-  /**
-   * Show whichever of the two the given mode calls for, and answer to it from here on.
-   *
-   * Both stay on the map with one hidden, rather than one being built and the other thrown away: the
-   * reader may have arrived by keyboard, and focus has to have somewhere to land when what held it
-   * goes. Moving focus is also what announces the change - whichever control they land on names what
-   * pressing it will do - so there is nothing left for a live region to say.
-   */
-  private setMode(mode: GeosearchMode) {
-    this.mode = mode;
-    // A view the reader has stopped asking about. Without this, unticking within the wait still
-    // searches, and pressing the button searches twice.
-    this.cancelSearch();
-    if (!this.label || !this.checkbox || !this.button) return;
-
-    // Whether what is about to be hidden is what the reader is on. Asked of the root rather than the
-    // document, because from out here document.activeElement is the shadow host.
-    const root = this.container?.getRootNode() as Document | ShadowRoot | undefined;
-    const focused = !!root?.activeElement && !!this.container?.contains(root.activeElement);
-
-    const auto = mode === 'auto';
-    this.checkbox.checked = auto;
-    this.label.hidden = !auto;
-    this.button.hidden = auto;
-
-    if (focused) (auto ? this.checkbox : this.button).focus();
-  }
-
-  // Unticking is all the checkbox does; ticking it again is the button's job, once it has searched.
-  // Either way the mode follows what the box now reads.
-  private handleToggle = () => {
-    this.setMode(this.checkbox?.checked ? 'auto' : 'manual');
+  private hide = () => {
+    if (this.container) this.container.hidden = true;
   };
 
-  // Asked for outright, so it happens now rather than after the wait a moved map gets - and then the
-  // control goes back to searching every view, which is what the reader asking at all suggests they
-  // wanted. GeoBlacklight gets this from the full page reload its own search does.
-  private handleSearchHere = () => {
-    this.onSearch();
-    this.setMode('auto');
+  private show = () => {
+    if (this.container) this.container.hidden = false;
   };
-
-  private handleCameraEnd = (event: MapEventType[(typeof CAMERA_END_EVENTS)[number]]) => {
-    if (!event.originalEvent) return;
-    if (this.mode !== 'auto') return;
-    this.scheduleSearch();
-  };
-
-  // Trailing edge, unlike the throttle in maps.ts: reallocating a drawing buffer is worth doing on the
-  // way as well as at the end, but a search is a question somebody else has to answer, and the only
-  // view worth asking about is the one the reader stopped in.
-  private scheduleSearch() {
-    this.cancelSearch();
-    this.timer = setTimeout(() => {
-      this.timer = undefined;
-      this.onSearch();
-    }, SEARCH_DELAY);
-  }
-
-  private cancelSearch() {
-    clearTimeout(this.timer);
-    this.timer = undefined;
-  }
 }

--- a/src/lib/maps.test.ts
+++ b/src/lib/maps.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from '@stencil/vitest';
 
 import { WORLD } from './geometry';
-import { addLocationControls, disableRotation, fitBounds, frameLocation, trackContainerSize, whenSized } from './maps';
+import { addLocationControls, disableRotation, fitBounds, frameLocation, readProjection, trackContainerSize, whenSized } from './maps';
 import type Theme from './themes/theme';
 import type MapLibreTheme from './themes/maplibre';
 
@@ -353,6 +353,28 @@ const controllableMap = () => {
     touchZoomRotate: { disableRotation: vi.fn() },
   };
 };
+
+describe('readProjection', () => {
+  const inProjection = (type: string | undefined) => ({ getProjection: () => (type === undefined ? undefined : { type }) }) as unknown as maplibregl.Map;
+
+  it('should read a flat map as flat', () => {
+    expect(readProjection(inProjection('mercator'))).toEqual('mercator');
+  });
+
+  // Either name MapLibre has for a sphere is a globe as far as a camera is concerned: 'globe' draws
+  // as one until it is zoomed in far enough that a sphere and a flat map are the same picture, and
+  // 'vertical-perspective' stays one throughout.
+  it('should read either kind of sphere as a globe', () => {
+    expect(readProjection(inProjection('globe'))).toEqual('globe');
+    expect(readProjection(inProjection('vertical-perspective'))).toEqual('globe');
+  });
+
+  // A map has no projection until a style document has arrived to carry one, and that is not the same
+  // answer as flat: a caller with a projection of its own to fall back on has to be able to tell.
+  it('should answer with nothing before a style has arrived', () => {
+    expect(readProjection(inProjection(undefined))).toBeUndefined();
+  });
+});
 
 describe('disableRotation', () => {
   // `dragRotate: false` looks like it covers this and doesn't: the keyboard's shift+arrows and the

--- a/src/lib/maps.test.ts
+++ b/src/lib/maps.test.ts
@@ -1,7 +1,13 @@
+/** @vitest-environment happy-dom */
+// A DOM, for the controls at the bottom of the file: MapLibre's own build their buttons as they are
+// added, and there is no way to check what a map ends up offering without letting them. The same
+// reason globe-control.test.ts asks for one.
 import { describe, it, expect, vi, beforeEach, afterEach } from '@stencil/vitest';
 
-import { fitBounds, trackContainerSize, whenSized } from './maps';
+import { WORLD } from './geometry';
+import { addLocationControls, disableRotation, fitBounds, frameLocation, trackContainerSize, whenSized } from './maps';
 import type Theme from './themes/theme';
+import type MapLibreTheme from './themes/maplibre';
 
 const PADDING = 50;
 const theme = { getPadding: () => PADDING } as Theme;
@@ -12,10 +18,12 @@ const BOUNDS: [[number, number], [number, number]] = [
 ];
 
 // Enough of a MapLibre map to be pointed somewhere: it can work out a camera, it can be moved, and
-// it reports the move as having finished, which is what fitBounds waits for before resolving.
-const fittableMap = (cameraForBounds = vi.fn(() => ({ center: [0, 0], zoom: 4 }))) => ({
+// it reports the move as having finished, which is what fitBounds waits for before resolving. It also
+// answers how big its canvas is, since that is what decides how much of a gap it can spare.
+const fittableMap = (cameraForBounds = vi.fn(() => ({ center: [0, 0], zoom: 4 })), canvas = { clientWidth: 800, clientHeight: 600 }) => ({
   cameraForBounds,
   fitBounds: vi.fn(),
+  getCanvas: () => canvas,
   once: vi.fn((_event: string, listener: () => void) => listener()),
 });
 
@@ -45,6 +53,23 @@ describe('fitBounds', () => {
 
     expect(map.cameraForBounds).toHaveBeenCalledWith(BOUNDS, { padding: PADDING, maxZoom: 12 });
     expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: PADDING, maxZoom: 12 });
+  });
+
+  // MapLibre has no camera for bounds it can't fit the padding inside, and the guard below reads that
+  // as "leave the camera alone" - so without this a pane shorter than twice the gap would sit at
+  // whatever view it opened on, with what it was pointed at off screen and nothing saying so.
+  it('should give up the gap rather than the framing on a map too small for both', async () => {
+    const map = fittableMap(undefined, { clientWidth: 300, clientHeight: 120 });
+    await fitBounds(map as unknown as maplibregl.Map, theme, BOUNDS);
+
+    expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: 30 });
+  });
+
+  it('should ask for the whole gap on a map with room for it', async () => {
+    const map = fittableMap(undefined, { clientWidth: 800, clientHeight: 400 });
+    await fitBounds(map as unknown as maplibregl.Map, theme, BOUNDS);
+
+    expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: PADDING });
   });
 
   it('should leave the camera alone when there is no camera that would frame the bounds', async () => {
@@ -240,5 +265,129 @@ describe('whenSized', () => {
 
     await expect(sized).resolves.toBe(true);
     expect(observer.disconnected).toBe(true);
+  });
+});
+
+// A theme is only ever asked for the two gaps, and a location map is framed with the wider one
+const locationTheme = { getPadding: () => 8, getOverviewPadding: () => 64 } as MapLibreTheme;
+
+describe('frameLocation', () => {
+  it('should leave the overview gap around what it frames', async () => {
+    const map = fittableMap();
+    await frameLocation(map as unknown as maplibregl.Map, locationTheme, BOUNDS, false);
+
+    expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: 64 });
+  });
+
+  it('should carry the caller’s own camera options', async () => {
+    const map = fittableMap();
+    await frameLocation(map as unknown as maplibregl.Map, locationTheme, BOUNDS, false, { maxZoom: 12 });
+
+    expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: 64, maxZoom: 12 });
+  });
+
+  // A globe camera has no answer for anything wider than the half of the world facing it: it hands
+  // back nothing and the camera stays put, so half of a wide area is what gets framed instead.
+  it('should hold a globe camera to the half of the world it can face', async () => {
+    const map = fittableMap();
+    await frameLocation(map as unknown as maplibregl.Map, locationTheme, WORLD, true);
+
+    const [bounds] = map.fitBounds.mock.calls[0] as unknown as [maplibregl.LngLatBounds];
+    expect(bounds.getEast() - bounds.getWest()).toEqual(180);
+    expect(bounds.getCenter().lng).toEqual(0);
+  });
+
+  it('should point a flat map at the whole of the same area', async () => {
+    const map = fittableMap();
+    await frameLocation(map as unknown as maplibregl.Map, locationTheme, WORLD, false);
+
+    expect(map.fitBounds).toHaveBeenCalledWith(WORLD, { padding: 64 });
+  });
+
+  // Nothing to clamp, so a globe gets what it was given
+  it('should leave an area a globe can face where it is', async () => {
+    const map = fittableMap();
+    await frameLocation(map as unknown as maplibregl.Map, locationTheme, BOUNDS, true);
+
+    const [bounds] = map.fitBounds.mock.calls[0] as unknown as [maplibregl.LngLatBounds];
+    expect([bounds.getWest(), bounds.getEast()]).toEqual([-124.41, -114.13]);
+  });
+});
+
+// Enough of a map to hang controls on. MapLibre's own read all of this as they are added: the
+// navigation control asks for its titles and for the zoom limits to grey its buttons at, and the
+// globe control asks which projection it should be showing.
+const controllableMap = () => {
+  const controls: { control: maplibregl.IControl; element: HTMLElement }[] = [];
+  const pending: Record<string, (() => void)[]> = {};
+
+  return {
+    controls,
+    addControl(control: maplibregl.IControl) {
+      controls.push({ control, element: control.onAdd(this as unknown as maplibregl.Map) });
+    },
+    // Held rather than run, so a test can say when the style arrives
+    once(event: string, listener: () => void) {
+      (pending[event] ??= []).push(listener);
+    },
+    fire(event: string) {
+      (pending[event] ?? []).splice(0).forEach(listener => listener());
+    },
+    on: () => {},
+    off: () => {},
+    _getUIString: (key: string) => key,
+    getZoom: () => 4,
+    getMinZoom: () => 0,
+    getMaxZoom: () => 22,
+    getProjection: () => ({ type: 'globe' }),
+    keyboard: { disableRotation: vi.fn() },
+    touchZoomRotate: { disableRotation: vi.fn() },
+  };
+};
+
+describe('disableRotation', () => {
+  // `dragRotate: false` looks like it covers this and doesn't: the keyboard's shift+arrows and the
+  // two-finger pinch-rotate are each a handler of their own.
+  it('should turn off the two gestures a map option cannot name', () => {
+    const map = controllableMap();
+    disableRotation(map as unknown as maplibregl.Map);
+
+    expect(map.keyboard.disableRotation).toHaveBeenCalled();
+    expect(map.touchZoomRotate.disableRotation).toHaveBeenCalled();
+  });
+});
+
+describe('addLocationControls', () => {
+  it('should offer zoom buttons and no compass', () => {
+    const map = controllableMap();
+    addLocationControls(map as unknown as maplibregl.Map);
+
+    const { element } = map.controls[0];
+    expect(Array.from(element.querySelectorAll('button'), button => button.className)).toEqual(['maplibregl-ctrl-zoom-in', 'maplibregl-ctrl-zoom-out']);
+    expect(element.querySelector('.maplibregl-ctrl-compass')).toBeNull();
+  });
+
+  // Its click reaches a style document, and asking one that isn't there yet throws. The window
+  // between building a map and the basemap's style landing is easy to click in on a map this small.
+  it('should wait for a style document before offering the projection toggle', () => {
+    const map = controllableMap();
+    addLocationControls(map as unknown as maplibregl.Map);
+
+    expect(map.controls).toHaveLength(1);
+
+    map.fire('style.load');
+
+    expect(map.controls).toHaveLength(2);
+    expect(map.controls[1].element.querySelector('[class^="maplibregl-ctrl-globe"]')).toBeTruthy();
+  });
+
+  // A theme swap brings a second style document with it, and the button is already on the map
+  it('should offer the projection toggle once, however many styles arrive', () => {
+    const map = controllableMap();
+    addLocationControls(map as unknown as maplibregl.Map);
+    map.fire('style.load');
+    map.fire('style.load');
+
+    expect(map.controls).toHaveLength(2);
   });
 });

--- a/src/lib/maps.test.ts
+++ b/src/lib/maps.test.ts
@@ -72,6 +72,15 @@ describe('fitBounds', () => {
     expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: PADDING });
   });
 
+  // Zero is not a small map, it is a map nobody can see: held to what a hidden one measures, the
+  // camera it settles on - the one still there when the pane is shown again - would have no gap at all
+  it('should ask for the whole gap on a map with no box to measure', async () => {
+    const map = fittableMap(undefined, { clientWidth: 0, clientHeight: 0 });
+    await fitBounds(map as unknown as maplibregl.Map, theme, BOUNDS);
+
+    expect(map.fitBounds).toHaveBeenCalledWith(BOUNDS, { padding: PADDING });
+  });
+
   it('should leave the camera alone when there is no camera that would frame the bounds', async () => {
     const map = fittableMap(vi.fn(() => undefined) as never);
     await fitBounds(map as unknown as maplibregl.Map, theme, BOUNDS);

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,5 +1,6 @@
 import maplibregl from 'maplibre-gl';
 
+import { clampToHemisphere } from './geometry';
 import type Theme from './themes/theme';
 import type MapLibreTheme from './themes/maplibre';
 
@@ -19,8 +20,11 @@ const RESIZE_PERIOD = 50;
 export const createMap = (container: HTMLElement, theme: MapLibreTheme, extras: MapExtras = {}): maplibregl.Map => {
   const map = new maplibregl.Map({
     container,
-    // The basemaps are CARTO's, over OpenStreetMap data; both require attribution. Compact so it
-    // is a single "i" in the corner until clicked, which is all an embedded map has room for.
+    // The basemaps are CARTO's, over OpenStreetMap data; both require attribution. Compact so that
+    // the panel can be put away, which is all an embedded map has room for - though MapLibre still
+    // opens it once there is something to credit, and only closes it when the reader drags the map.
+    // A caller that can't spare the corner at all hands over `attributionControl: false` and adds
+    // our own instead; see AttributionControl.
     attributionControl: { compact: true },
     style: theme.getBaseMapStyle(),
     center: [0, 0],
@@ -142,12 +146,30 @@ export const setBasemap = async (map: maplibregl.Map, theme: MapLibreTheme): Pro
  * camera including the ones a reader drives.
  */
 export const fitBounds = async (map: maplibregl.Map, theme: Theme, bounds: maplibregl.LngLatBoundsLike, extras: maplibregl.FitBoundsOptions = {}): Promise<void> => {
-  const options = { padding: theme.getPadding(), ...extras };
+  const options: maplibregl.FitBoundsOptions = { padding: theme.getPadding(), ...extras };
+  options.padding = fittablePadding(map, options.padding);
   if (!cameraForBounds(map, bounds, options)) return;
   return new Promise<void>(resolve => {
     map.once('moveend', () => resolve());
     map.fitBounds(bounds, options);
   });
+};
+
+// The gap asked for, held to what the canvas can actually spare.
+//
+// MapLibre has no camera for bounds it can't fit the padding inside - the width left over goes
+// negative and cameraForBounds hands back nothing - and the guard below reads that as "leave the
+// camera alone". So a pane shorter than twice the gap keeps whatever view it opened on, with what it
+// was pointed at somewhere off screen, and nothing anywhere says so. An overview's gap is 64, which
+// makes that any pane under 128 pixels: a locator beside a record's metadata, a map in a list.
+// The gap is the thing that should give way there, not the framing.
+//
+// Only a plain number is held down. `padding` can also name the four edges one at a time, and nothing
+// here does that - what a sidebar covers is set on the map rather than asked of one camera.
+const fittablePadding = (map: maplibregl.Map, padding: maplibregl.FitBoundsOptions['padding']): maplibregl.FitBoundsOptions['padding'] => {
+  if (typeof padding !== 'number') return padding;
+  const canvas = map.getCanvas();
+  return Math.min(padding, Math.floor(Math.min(canvas.clientWidth, canvas.clientHeight) / 4));
 };
 
 // Whether there is a camera that would frame these bounds at all - there isn't, if the padding
@@ -161,3 +183,78 @@ const cameraForBounds = (map: maplibregl.Map, bounds: maplibregl.LngLatBoundsLik
     return undefined;
   }
 };
+
+/**
+ * What a map that says where records are is allowed to do.
+ *
+ * Both of them take exactly this - a locator's one record and an overview's several - so a reader can
+ * pan and zoom and nothing else. These maps are read at a glance, and one that has been turned or
+ * tilted can't be compared with the next one, so neither is offered. Cooperative gestures because a
+ * small map inside a page must not eat the page's scroll, which is also why both of them carry zoom
+ * buttons: a wheel needs the command key once this is on. And below createMap's own floor of 2,
+ * because one record can cover the world, and an extent that wide framed with a gap around it inside
+ * a container this small wants a camera further out than a map of data ever does.
+ */
+export const LOCATION_MAP: MapExtras = {
+  cooperativeGestures: true,
+  dragRotate: false,
+  touchPitch: false,
+  minZoom: 0,
+};
+
+// MapLibre's two remaining ways to turn a map, neither of which LOCATION_MAP covers because neither
+// is an option a map option can name: `dragRotate: false` takes the ctrl-drag bearing and the
+// right-drag pitch with it and leaves the keyboard's shift+arrows and the two-finger pinch-rotate
+// alone. With these there is no gesture, key or control left that can produce a bearing or a pitch -
+// which is also why the navigation control below has no compass, since there would be nothing for it
+// to reset. setMaxPitch(0) would be a knob with nothing behind it; that one is <ogm-map>'s, where a
+// previewer names the limit.
+export const disableRotation = (map: maplibregl.Map) => {
+  map.keyboard.disableRotation();
+  map.touchZoomRotate.disableRotation();
+};
+
+/**
+ * Zoom buttons and the projection toggle, ordered from the top down.
+ *
+ * MapLibre's own globe control rather than ours: GlobeControl here exists to take itself off the map
+ * for a preview that can only be drawn flat, and a location can be drawn on anything.
+ *
+ * The globe button waits for a style document; the zoom buttons don't need one. Its click reaches
+ * Style.setProjection, which opens by checking that a style has loaded and throws when one hasn't -
+ * and on a map this small the window between building it and CARTO's style landing is easy to click
+ * in. Waiting also means the button reads the projection we set rather than the one a styleless map
+ * reports, so it opens showing the state it is actually in.
+ */
+export const addLocationControls = (map: maplibregl.Map) => {
+  map.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+  map.once('style.load', () => map.addControl(new maplibregl.GlobeControl()));
+};
+
+// How close either of these maps opens, whatever it was pointed at. Past city scale a basemap may
+// have nothing named left to place a shape against, and a shape that can't be placed is a location
+// nobody can read. It is also the only thing between a record whose location is a single point and a
+// camera at street level: a point is a box with no width, so the fit has nothing to divide by and
+// settles for whatever ceiling it was given - which, unasked, is the map's own maxZoom of 22.
+export const LOCATION_MAX_ZOOM = 12;
+
+/**
+ * Point the camera at an area, holding it to what the projection the map is in can face.
+ *
+ * A globe camera has no answer for a box wider than the half of the world facing it: the solve takes
+ * the flat answer and shrinks the globe until the box fits in front of it, and past 180 degrees no
+ * size does, so MapLibre warns and hands back nothing and the camera stays where it was. Half of a
+ * wide area is worth more than none of it, and the projection button is right there for a reader who
+ * wants the whole of it. A flat map has no such limit and gets what it was given.
+ *
+ * The theme's overview gap either way, rather than the one a preview gets: these are whole maps read
+ * at once rather than a pane filled with one record, and a shape drawn against the edge reads as
+ * running off it - on a globe, that edge is where the sphere turns away.
+ */
+export const frameLocation = async (
+  map: maplibregl.Map,
+  theme: MapLibreTheme,
+  target: maplibregl.LngLatBoundsLike,
+  globe: boolean,
+  extras: maplibregl.FitBoundsOptions = {},
+): Promise<void> => fitBounds(map, theme, globe ? clampToHemisphere(target) : target, { padding: theme.getOverviewPadding(), ...extras });

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,6 +1,7 @@
 import maplibregl from 'maplibre-gl';
 
 import { clampToHemisphere } from './geometry';
+import type { MapProjection } from './previewers/map';
 import type Theme from './themes/theme';
 import type MapLibreTheme from './themes/maplibre';
 
@@ -130,6 +131,24 @@ const throttle = (fn: () => void, period: number): (() => void) => {
  * document and takes every source and layer on it away. The listener goes on before the swap rather
  * than after, so a style that loads from cache can't be up before anyone is listening for it.
  */
+/**
+ * Which projection a map is in, or nothing at all before it has a style document to carry one.
+ *
+ * MapLibre has two names for a sphere: 'globe' draws as one until it is zoomed in far enough that a
+ * sphere and a flat map are the same picture, and 'vertical-perspective' stays one throughout. Either
+ * is a globe as far as a camera is concerned - see frameLocation - so either comes back as one.
+ *
+ * Asked of the map rather than remembered, because the map is the one that knows: a projection can
+ * change without anything here having asked for it. A style document names its own, and applying one
+ * announces the change as the same event a reader pressing the globe button does.
+ */
+export const readProjection = (map: maplibregl.Map): MapProjection | undefined => {
+  const type = map.getProjection()?.type;
+  if (type === undefined) return undefined;
+
+  return type === 'mercator' ? 'mercator' : 'globe';
+};
+
 export const setBasemap = async (map: maplibregl.Map, theme: MapLibreTheme): Promise<void> =>
   new Promise<void>(resolve => {
     map.once('style.load', () => resolve());

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -206,7 +206,7 @@ export const LOCATION_MAP: MapExtras = {
   cooperativeGestures: true,
   dragRotate: false,
   touchPitch: false,
-  minZoom: 0,
+  minZoom: 1,
 };
 
 // MapLibre's two remaining ways to turn a map, neither of which LOCATION_MAP covers because neither

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -168,8 +168,15 @@ export const fitBounds = async (map: maplibregl.Map, theme: Theme, bounds: mapli
 // here does that - what a sidebar covers is set on the map rather than asked of one camera.
 const fittablePadding = (map: maplibregl.Map, padding: maplibregl.FitBoundsOptions['padding']): maplibregl.FitBoundsOptions['padding'] => {
   if (typeof padding !== 'number') return padding;
+
+  // A map inside something hidden measures zero, and zero is not a small map: it is a map nobody can
+  // see. Held to what it measures, it would frame whatever it was pointed at with no gap at all, and
+  // that camera is the one still on screen when the pane is shown again.
   const canvas = map.getCanvas();
-  return Math.min(padding, Math.floor(Math.min(canvas.clientWidth, canvas.clientHeight) / 4));
+  const shortest = Math.min(canvas.clientWidth, canvas.clientHeight);
+  if (!shortest) return padding;
+
+  return Math.min(padding, Math.floor(shortest / 4));
 };
 
 // Whether there is a camera that would frame these bounds at all - there isn't, if the padding

--- a/src/lib/previewers/location.test.ts
+++ b/src/lib/previewers/location.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@stencil/vitest';
 
-import LocationPreviewer, { locationsFor } from './location';
+import LocationPreviewer, { locationFor, locationsFor } from './location';
 import GeoJsonPreviewer from './geojson';
 import LocationResource from '../resources/location';
 import GeoJsonResource from '../resources/geojson';
@@ -258,6 +258,34 @@ describe('LocationPreviewer inspection', () => {
     expect(map.layers.get(FILL).layout.visibility).toEqual('none');
     expect(map.layers.get(OUTLINE).layout.visibility).toEqual('none');
     expect(previewer.visibleLayerIds).toEqual([]);
+  });
+});
+
+describe('locationFor', () => {
+  const record = (fields: Partial<GeoBlacklightSchemaAardvark>) =>
+    new OgmRecord({
+      id: 'a-record',
+      dct_title_s: 'A record',
+      gbl_resourceClass_sm: ['Datasets'],
+      dct_accessRights_s: 'Public',
+      gbl_mdVersion_s: 'Aardvark',
+      ...fields,
+    } as GeoBlacklightSchemaAardvark);
+
+  it('says where one record is', async () => {
+    const location = locationFor(record({ dcat_bbox: 'ENVELOPE(29.57,35.0,4.23,-1.47)' }));
+
+    expect(location).toBeInstanceOf(LocationPreviewer);
+    expect(await location!.getBounds()).toEqual([
+      [29.57, -1.47],
+      [35, 4.23],
+    ]);
+  });
+
+  // Which is not a failure. A record can be ordinary metadata with nothing to place it by, and the
+  // one component that draws a single location answers for having nothing to draw.
+  it('has nothing to say about a record that does not say where it is', () => {
+    expect(locationFor(record({}))).toBeUndefined();
   });
 });
 

--- a/src/lib/previewers/location.ts
+++ b/src/lib/previewers/location.ts
@@ -16,7 +16,7 @@ type AddGeoJsonSourceObject = GeoJSONSourceSpecification & { id: string };
 // extent, not a value an embedding app has a reason to name: setting it to 1 would flatten the frame
 // back into data, which is the one thing this previewer exists to avoid. How faint the extent starts
 // out overall is a separate question, and that one is themed - see --ogm-bounds-opacity.
-const FILL_OPACITY = 0.2;
+export const FILL_OPACITY = 0.2;
 
 /**
  * A record's extent, drawn as a frame rather than as data. What goes on the map when the data itself
@@ -102,9 +102,12 @@ export default class LocationPreviewer extends MapPreviewer {
   }
 }
 
+// Where one record is, or nothing for a record that doesn't say. Not every record has a location,
+// and one that doesn't isn't broken - there is just nothing of it to draw.
+export const locationFor = (record: OgmRecord): LocationPreviewer | undefined => {
+  const geometry = record.getGeometry();
+  return geometry ? new LocationPreviewer(new LocationResource(record.id, geometry as GeoJSON.Geometry)) : undefined;
+};
+
 // Generate a list of LocationPreviewers using the geometry of provided records
-export const locationsFor = (records: OgmRecord[]): (LocationPreviewer | undefined)[] =>
-  records.map(record => {
-    const geometry = record.getGeometry();
-    return geometry ? new LocationPreviewer(new LocationResource(record.id, geometry as GeoJSON.Geometry)) : undefined;
-  });
+export const locationsFor = (records: OgmRecord[]): (LocationPreviewer | undefined)[] => records.map(locationFor);

--- a/src/lib/previewers/previewer.test.ts
+++ b/src/lib/previewers/previewer.test.ts
@@ -15,6 +15,18 @@ describe('Previewer#kind', () => {
   });
 });
 
+describe('Previewer#resourceId', () => {
+  // What <ogm-overview> matches a highlight named by id against, when it was handed previewers rather
+  // than records. previewId can't answer it: it carries the kind and the renderer as well, so a page
+  // holding a record's id has nothing to compare against.
+  it('names the resource this preview draws, and nothing else about the preview', () => {
+    const previewer = new GeoJsonPreviewer(new GeoJsonResource('a-record', 'https://example.com/data.json'));
+
+    expect(previewer.resourceId).toEqual('a-record');
+    expect(previewer.previewId).toEqual('a-record-geojson-map');
+  });
+});
+
 describe('Previewer#requestTransform', () => {
   it("is undefined when the resource wasn't given one", () => {
     const previewer = new GeoJsonPreviewer(new GeoJsonResource('id', 'https://example.com/data.json'));

--- a/src/lib/previewers/previewer.ts
+++ b/src/lib/previewers/previewer.ts
@@ -41,6 +41,14 @@ export default abstract class Previewer {
     return this.resource.kind;
   }
 
+  // What this preview draws, named the way whoever built it named it. For a caller that has to line
+  // previews up against the things they were built from: <ogm-overview> matching a highlight named by
+  // id against the previewers an embedding page handed it. `previewId` below can't answer that - it
+  // carries the kind and the renderer as well, so a page holding a record's id has nothing to compare.
+  get resourceId(): string {
+    return this.resource.id;
+  }
+
   // Identifies the tab and the panel that show this preview. Every resource of one record carries
   // the record's own id, so it takes the kind to tell them apart, and the renderer to tell two
   // previews of one resource apart. Stable under minification, unlike constructor.name. Two

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -2,27 +2,16 @@
 // A DOM, because a marker is now a picture drawn on a canvas rather than a description handed to
 // MapLibre. happy-dom has no canvas behind its <canvas>, which is the case markerImage answers for -
 // what it draws when there is one is checked in a browser, since that is the only place pixels exist.
-import { describe, it, expect } from '@stencil/vitest';
+import { describe, it, expect, vi } from '@stencil/vitest';
 import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
-import {
-  clearResults,
-  drawResults,
-  SELECTED_BOUNDS,
-  MARKER_IMAGE,
-  markerImage,
-  markerImageId,
-  numberedResults,
-  RESULT_MARKERS,
-  RESULT_NUMBERS,
-  resultMarkersLayer,
-  SEARCH_BOUNDS,
-} from './results';
+import { drawResults, SELECTED_BOUNDS, markerImage, markerImageId, numberedResults, RESULT_MARKERS, RESULT_NUMBERS, resultMarkersLayer, SEARCH_BOUNDS } from './results';
 import type { MapLibreStyle } from './themes/maplibre';
 
-// Just enough of a MapLibre map to record what goes on it, in the order it went on. removeSource
-// refuses while a layer is still reading it, the way the real one does: that ordering is the one
-// mistake clearResults can make.
+// Just enough of a MapLibre map to record what goes on it, in the order it went on, and to be changed
+// in place afterwards: a source hands back something with setData on it, an image that is already there
+// is refused a second time the way the real one does, and paint properties are written where the layer
+// stands. Between them those are every way a redraw can avoid taking something off the map.
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
@@ -36,6 +25,9 @@ class FakeMap {
     if (!this.images.has(id)) throw new Error(`No image named "${id}" exists.`);
     this.images.delete(id);
   }
+  hasImage(id: string) {
+    return this.images.has(id);
+  }
   listImages() {
     return [...this.images.keys()];
   }
@@ -44,7 +36,7 @@ class FakeMap {
     return this.sources.get(id);
   }
   addSource(id: string, spec: any) {
-    this.sources.set(id, spec);
+    this.sources.set(id, { ...spec, setData: (data: any) => (this.sources.get(id).data = data) });
   }
   removeSource(id: string) {
     const reader = [...this.layers.values()].find(layer => layer.source === id);
@@ -59,6 +51,9 @@ class FakeMap {
   }
   removeLayer(id: string) {
     this.layers.delete(id);
+  }
+  setPaintProperty(id: string, property: string, value: unknown) {
+    this.layers.get(id).paint[property] = value;
   }
 }
 
@@ -106,13 +101,13 @@ const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.m
 
 describe('numberedResults', () => {
   it('should number the extents from one, in the order it was given them', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND]);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style);
 
     expect(features.map(feature => feature.properties!.label)).toEqual(['1', '2']);
   });
 
   it('should put each number in the middle of its own box', () => {
-    const [california] = numberedResults([CALIFORNIA]).features;
+    const [california] = numberedResults([CALIFORNIA], style).features;
 
     expect(california.geometry.coordinates[0]).toBeCloseTo(-119.27);
     expect(california.geometry.coordinates[1]).toBeCloseTo(37.27);
@@ -121,7 +116,7 @@ describe('numberedResults', () => {
   // The middle of 170..190 is the date line, not Greenwich. MapLibre reads a longitude from outside
   // -180..180 everywhere it takes one, so there is nothing here that has to wrap it back.
   it('should keep a number on the same side of the world as the box it belongs to', () => {
-    const [aleutians] = numberedResults([ALEUTIANS]).features;
+    const [aleutians] = numberedResults([ALEUTIANS], style).features;
 
     expect(aleutians.geometry.coordinates[0]).toEqual(180);
   });
@@ -129,18 +124,18 @@ describe('numberedResults', () => {
   // The number is where the record sits in the list beside the map, so a record nobody could place
   // has to spend its number rather than pass it on to the next one.
   it('should spend a number on a record it has nowhere to put', () => {
-    const { features } = numberedResults([CALIFORNIA, undefined, ICELAND]);
+    const { features } = numberedResults([CALIFORNIA, undefined, ICELAND], style);
 
     expect(features).toHaveLength(2);
     expect(features.map(feature => feature.properties!.label)).toEqual(['1', '3']);
   });
 
   it('should have nothing to draw when no record says where it is', () => {
-    expect(numberedResults([undefined]).features).toEqual([]);
+    expect(numberedResults([undefined], style).features).toEqual([]);
   });
 
   it('should mark the result at the place it was pointed at', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND], 2);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style, 2);
 
     expect(features.map(feature => feature.properties!.selected)).toEqual([false, true]);
   });
@@ -148,21 +143,21 @@ describe('numberedResults', () => {
   // The picture each marker is drawn as. Named on the feature rather than worked out in an expression,
   // so one place decides which marker wears which.
   it('should name the picture each marker is drawn as', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND], 2);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style, 2);
 
-    expect(features.map(feature => feature.properties!.icon)).toEqual([markerImageId('1'), markerImageId('2', true)]);
-    expect(markerImageId('2', true)).not.toEqual(markerImageId('2'));
+    expect(features.map(feature => feature.properties!.icon)).toEqual([markerImageId('1', style), markerImageId('2', style, true)]);
+    expect(markerImageId('2', style, true)).not.toEqual(markerImageId('2', style));
   });
 
   it('should mark nothing when nothing was pointed at', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND]);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style);
 
     expect(features.map(feature => feature.properties!.selected)).toEqual([false, false]);
   });
 
   // The places are counted over every result, so a highlight can land on one that was never drawn
   it('should mark nothing for a place it has nowhere to put', () => {
-    const { features } = numberedResults([CALIFORNIA, undefined], 2);
+    const { features } = numberedResults([CALIFORNIA, undefined], style, 2);
 
     expect(features.map(feature => feature.properties!.selected)).toEqual([false]);
   });
@@ -215,46 +210,113 @@ describe('drawResults', () => {
 
     expect(map.sources.get(RESULT_NUMBERS).type).toEqual('geojson');
     expect(map.sources.get(RESULT_NUMBERS).data.features).toHaveLength(2);
-    expect([...map.layers.keys()]).toEqual(MARKER_LAYERS);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
   });
 
-  // Nothing is reused between draws: a theme swap changes what a marker looks like, and a picture kept
-  // from the last palette would put a marker from the last theme on the map. Asserted through the fake,
-  // which refuses a second image under a name it already holds the way MapLibre does.
-  it('should draw its pictures again rather than reuse them', () => {
-    const map = draw([CALIFORNIA, ICELAND]);
-    map.addImage(`${MARKER_IMAGE}-1`, {}, {});
+  // A page of boxes says less than a page of numbers a reader can find in the list beside the map. The
+  // two boxes are on the map either way, holding nothing until there is something for them to say:
+  // that is what lets them stay under the numbers without being put back there on every draw.
+  it('should draw nothing of a result but its number', () => {
+    const map = draw([CALIFORNIA]);
 
-    expect(() => drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] })).not.toThrow();
-    expect(map.listImages().filter(id => id.startsWith(MARKER_IMAGE))).toEqual([]);
+    expect(marked(map)).toHaveLength(1);
+    expect(map.sources.get(SEARCH_BOUNDS).data.features).toEqual([]);
+    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
+  });
+
+  // The whole of why a highlight doesn't flash. Both are asserted through the fake, which refuses a
+  // second image under a name it already holds the way MapLibre does, and which is holding the pictures
+  // a canvas would have drawn - there is none in this DOM; see markerImage.
+  it('should change no pictures at all when the highlight moves', () => {
+    const map = draw([CALIFORNIA, ICELAND]);
+    for (const label of ['1', '2']) for (const id of [markerImageId(label, style), markerImageId(label, style, true)]) map.addImage(id, {}, {});
+    const addImage = vi.spyOn(map, 'addImage');
+    const removeImage = vi.spyOn(map, 'removeImage');
+
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: 2 });
+
+    expect(addImage).not.toHaveBeenCalled();
+    expect(removeImage).not.toHaveBeenCalled();
+  });
+
+  // Both pictures of every number, so that which one a marker wears is a property rather than a swap
+  it('should draw each number both ways, pointed at or not', () => {
+    const map = draw([CALIFORNIA]);
+    map.addImage(markerImageId('1', style), {}, {});
+    const addImage = vi.spyOn(map, 'addImage');
+
+    // A canvas would have drawn the other one here; this DOM has none, so what is asserted is the ask
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA] });
+
+    expect(addImage).not.toHaveBeenCalledWith(markerImageId('1', style), expect.anything(), expect.anything());
+    expect(markerImage(markerImageId('1', style), style.markerColor, style, 1)).toBeUndefined();
+  });
+
+  // MapLibre carries images across setStyle - it diffs the new style document against the old one, and
+  // the diff has nothing to say about images - so a picture kept under a name that said only which
+  // marker it was would leave the map wearing the palette it was drawn in. See markerImageId.
+  it('should draw its pictures again for a palette that changed under it', () => {
+    const map = draw([CALIFORNIA]);
+    map.addImage(markerImageId('1', style), {}, {});
+    const dusk = { ...style, markerColor: '#004ac3' };
+
+    expect(markerImageId('1', dusk)).not.toEqual(markerImageId('1', style));
+
+    drawResults(map as unknown as maplibregl.Map, dusk, { extents: [CALIFORNIA] });
+
+    // The picture drawn in the old palette is gone; a canvas would have drawn the new one in its place
+    expect(map.listImages()).toEqual([]);
   });
 
   // Left behind, they would outlive every marker that ever used them
-  it('should take its pictures off with everything else', () => {
-    const map = draw([CALIFORNIA]);
-    map.addImage(`${MARKER_IMAGE}-1`, {}, {});
+  it('should take away the pictures no marker needs any more', () => {
+    const map = draw([CALIFORNIA, ICELAND]);
+    map.addImage(markerImageId('2', style), {}, {});
+    map.addImage(markerImageId('2', style, true), {}, {});
     map.addImage('someone-elses-image', {}, {});
 
-    clearResults(map as unknown as maplibregl.Map);
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA] });
 
     expect(map.listImages()).toEqual(['someone-elses-image']);
   });
 
-  // A page of boxes says less than a page of numbers a reader can find in the list beside the map
-  it('should draw nothing of a result but its number', () => {
+  // addLayer appends, so a layer put back on would come back over whatever had been added above it -
+  // and dropping a source drops its tiles, which is the frame a reader sees as a flash
+  it('should take nothing off the map to draw again', () => {
     const map = draw([CALIFORNIA]);
+    const removeLayer = vi.spyOn(map, 'removeLayer');
+    const removeSource = vi.spyOn(map, 'removeSource');
+    const order = [...map.layers.keys()];
 
-    expect([...map.sources.keys()]).toEqual([RESULT_NUMBERS]);
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: 2, searchBounds: LngLatBounds.convert(ICELAND) });
+
+    expect([...map.layers.keys()]).toEqual(order);
+    expect(removeLayer).not.toHaveBeenCalled();
+    expect(removeSource).not.toHaveBeenCalled();
   });
 
-  // addLayer appends, so the numbers only stay over the boxes if they go back on after the boxes
-  // are redrawn. Adding them again rather than updating the source in place is what does that.
-  it('should put the numbers back on top of boxes drawn after them', () => {
+  it('should hand its sources new data rather than replacing them', () => {
     const map = draw([CALIFORNIA]);
-    map.addLayer({ id: 'a-box', type: 'fill' });
+    const numbers = map.sources.get(RESULT_NUMBERS);
+
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect([...map.layers.keys()]).toEqual(['a-box', ...MARKER_LAYERS]);
+    expect(map.sources.get(RESULT_NUMBERS)).toBe(numbers);
+    expect(numbers.data.features).toHaveLength(2);
+  });
+
+  // A theme swap empties the style document without asking, so a draw that follows one is a first draw
+  // again: everything back, in the order that keeps the numbers over the boxes.
+  it('should build itself again into a style document a theme swap emptied', () => {
+    const map = draw([CALIFORNIA], { highlighted: 1 });
+    map.sources.clear();
+    map.layers.clear();
+    map.images.clear();
+
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA], highlighted: 1 });
+
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect(marked(map)).toHaveLength(1);
   });
 
   it('should draw the searched area, then the highlight, then the numbers', () => {
@@ -276,7 +338,18 @@ describe('drawResults', () => {
   it('should draw nothing for a search area it was not given', () => {
     const map = draw([CALIFORNIA]);
 
-    expect(map.sources.has(SEARCH_BOUNDS)).toBe(false);
+    expect(map.sources.get(SEARCH_BOUNDS).data.features).toEqual([]);
+  });
+
+  // Nothing takes these layers off again, so the colors have to be able to change where they stand:
+  // a theme can swap under a map that is already drawn.
+  it('should follow the colors of a theme that changed under it', () => {
+    const map = draw([CALIFORNIA], { highlighted: 1 });
+
+    drawResults(map as unknown as maplibregl.Map, { ...style, selectedColor: '#7a4600', strokeSelectedColor: '#4a0a0a' }, { extents: [CALIFORNIA], highlighted: 1 });
+
+    expect(map.layers.get(`${SELECTED_BOUNDS}-fill`).paint['fill-color']).toEqual('#7a4600');
+    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual('#4a0a0a');
   });
 
   // The colors a selected feature gets, not a hovered one: a hover is what points at it, but what it
@@ -289,8 +362,8 @@ describe('drawResults', () => {
     expect(map.layers.get(`${SELECTED_BOUNDS}-fill`).paint['fill-color']).toEqual(style.selectedColor);
     expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
     expect(marked(map)).toEqual([
-      { label: '1', selected: false, icon: markerImageId('1') },
-      { label: '2', selected: true, icon: markerImageId('2', true) },
+      { label: '1', selected: false, icon: markerImageId('1', style) },
+      { label: '2', selected: true, icon: markerImageId('2', style, true) },
     ]);
   });
 
@@ -298,28 +371,15 @@ describe('drawResults', () => {
   it('should draw no extent for a selection it cannot place', () => {
     const map = draw([CALIFORNIA, undefined], { highlighted: 2 });
 
-    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
-    expect(marked(map)).toEqual([{ label: '1', selected: false, icon: markerImageId('1') }]);
+    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
+    expect(marked(map)).toEqual([{ label: '1', selected: false, icon: markerImageId('1', style) }]);
   });
 
-  it('should take everything off the map when cleared', () => {
-    const map = draw([CALIFORNIA], { highlighted: 1, searchBounds: LngLatBounds.convert(ICELAND) });
-    clearResults(map as unknown as maplibregl.Map);
+  it('should take the extent away again when the highlight is withdrawn', () => {
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2 });
 
-    expect(map.sources.size).toEqual(0);
-    expect(map.layers.size).toEqual(0);
-  });
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-  // Which is what the fake above refuses, the way MapLibre does
-  it('should take every layer off before the source it reads', () => {
-    const map = draw([CALIFORNIA], { highlighted: 1, searchBounds: LngLatBounds.convert(ICELAND) });
-
-    expect(() => clearResults(map as unknown as maplibregl.Map)).not.toThrow();
-  });
-
-  // A theme swap empties the style document without asking, so what this last drew may be gone by
-  // the time anyone thinks to take it off
-  it('should have nothing to say about layers a style swap already took away', () => {
-    expect(() => clearResults(new FakeMap() as unknown as maplibregl.Map)).not.toThrow();
+    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
   });
 });

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi } from '@stencil/vitest';
 import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
-import { drawResults, SELECTED_BOUNDS, markerImage, markerImageId, numberedResults, RESULT_MARKERS, RESULT_NUMBERS, resultMarkersLayer, SEARCH_BOUNDS } from './results';
+import { drawResults, HIGHLIGHT_BOUNDS, markerImage, markerImageId, numberedResults, RESULT_MARKERS, RESULT_NUMBERS, resultMarkersLayer, SEARCH_BOUNDS } from './results';
 import type { MapLibreStyle } from './themes/maplibre';
 
 // Just enough of a MapLibre map to record what goes on it, in the order it went on, and to be changed
@@ -65,7 +65,7 @@ const style = {
   selectedColor: '#93da98',
   strokeSelectedColor: '#1e662a',
   markerColor: '#2d5883',
-  markerSelectedColor: '#1e662a',
+  markerHighlightColor: '#268499',
   textColor: '#000',
   textHaloColor: '#fff',
   textFont: 'Noto Sans Regular',
@@ -91,7 +91,7 @@ const ALEUTIANS: LngLatBoundsLike = [
 const MARKER_LAYERS = [RESULT_MARKERS];
 const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 
-const draw = (extents: (LngLatBoundsLike | undefined)[], rest: { highlighted?: number; searchBounds?: LngLatBounds } = {}) => {
+const draw = (extents: (LngLatBoundsLike | undefined)[], rest: { highlighted?: number[]; searchBounds?: LngLatBounds } = {}) => {
   const map = new FakeMap();
   drawResults(map as unknown as maplibregl.Map, style, { extents, ...rest });
   return map;
@@ -135,15 +135,15 @@ describe('numberedResults', () => {
   });
 
   it('should mark the result at the place it was pointed at', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND], style, 2);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style, [2]);
 
-    expect(features.map(feature => feature.properties!.selected)).toEqual([false, true]);
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, true]);
   });
 
   // The picture each marker is drawn as. Named on the feature rather than worked out in an expression,
   // so one place decides which marker wears which.
   it('should name the picture each marker is drawn as', () => {
-    const { features } = numberedResults([CALIFORNIA, ICELAND], style, 2);
+    const { features } = numberedResults([CALIFORNIA, ICELAND], style, [2]);
 
     expect(features.map(feature => feature.properties!.icon)).toEqual([markerImageId('1', style), markerImageId('2', style, true)]);
     expect(markerImageId('2', style, true)).not.toEqual(markerImageId('2', style));
@@ -152,14 +152,14 @@ describe('numberedResults', () => {
   it('should mark nothing when nothing was pointed at', () => {
     const { features } = numberedResults([CALIFORNIA, ICELAND], style);
 
-    expect(features.map(feature => feature.properties!.selected)).toEqual([false, false]);
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, false]);
   });
 
   // The places are counted over every result, so a highlight can land on one that was never drawn
   it('should mark nothing for a place it has nowhere to put', () => {
-    const { features } = numberedResults([CALIFORNIA, undefined], style, 2);
+    const { features } = numberedResults([CALIFORNIA, undefined], style, [2]);
 
-    expect(features.map(feature => feature.properties!.selected)).toEqual([false]);
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false]);
   });
 });
 
@@ -191,7 +191,7 @@ describe('resultMarkersLayer', () => {
   // the reader pans - which reads as the numbers rearranging themselves. A higher key draws over a
   // lower one, so the key is the number negated, and the highlighted one sorts above all of them.
   it('should keep the earlier results on top of the later ones, and the highlight above both', () => {
-    expect(resultMarkersLayer().layout!['symbol-sort-key']).toEqual(['case', ['get', 'selected'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
+    expect(resultMarkersLayer().layout!['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 });
 
@@ -210,7 +210,7 @@ describe('drawResults', () => {
 
     expect(map.sources.get(RESULT_NUMBERS).type).toEqual('geojson');
     expect(map.sources.get(RESULT_NUMBERS).data.features).toHaveLength(2);
-    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
   });
 
   // A page of boxes says less than a page of numbers a reader can find in the list beside the map. The
@@ -221,7 +221,7 @@ describe('drawResults', () => {
 
     expect(marked(map)).toHaveLength(1);
     expect(map.sources.get(SEARCH_BOUNDS).data.features).toEqual([]);
-    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
   });
 
   // The whole of why a highlight doesn't flash. Both are asserted through the fake, which refuses a
@@ -233,7 +233,7 @@ describe('drawResults', () => {
     const addImage = vi.spyOn(map, 'addImage');
     const removeImage = vi.spyOn(map, 'removeImage');
 
-    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: 2 });
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: [2] });
 
     expect(addImage).not.toHaveBeenCalled();
     expect(removeImage).not.toHaveBeenCalled();
@@ -288,7 +288,7 @@ describe('drawResults', () => {
     const removeSource = vi.spyOn(map, 'removeSource');
     const order = [...map.layers.keys()];
 
-    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: 2, searchBounds: LngLatBounds.convert(ICELAND) });
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND], highlighted: [2], searchBounds: LngLatBounds.convert(ICELAND) });
 
     expect([...map.layers.keys()]).toEqual(order);
     expect(removeLayer).not.toHaveBeenCalled();
@@ -308,21 +308,21 @@ describe('drawResults', () => {
   // A theme swap empties the style document without asking, so a draw that follows one is a first draw
   // again: everything back, in the order that keeps the numbers over the boxes.
   it('should build itself again into a style document a theme swap emptied', () => {
-    const map = draw([CALIFORNIA], { highlighted: 1 });
+    const map = draw([CALIFORNIA], { highlighted: [1] });
     map.sources.clear();
     map.layers.clear();
     map.images.clear();
 
-    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA], highlighted: 1 });
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA], highlighted: [1] });
 
-    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
     expect(marked(map)).toHaveLength(1);
   });
 
   it('should draw the searched area, then the highlight, then the numbers', () => {
-    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2, searchBounds: LngLatBounds.convert(CALIFORNIA) });
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: [2], searchBounds: LngLatBounds.convert(CALIFORNIA) });
 
-    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
   });
 
   it('should draw the area being searched in the colors a bounding box gets', () => {
@@ -344,42 +344,52 @@ describe('drawResults', () => {
   // Nothing takes these layers off again, so the colors have to be able to change where they stand:
   // a theme can swap under a map that is already drawn.
   it('should follow the colors of a theme that changed under it', () => {
-    const map = draw([CALIFORNIA], { highlighted: 1 });
+    const map = draw([CALIFORNIA], { highlighted: [1] });
 
-    drawResults(map as unknown as maplibregl.Map, { ...style, selectedColor: '#7a4600', strokeSelectedColor: '#4a0a0a' }, { extents: [CALIFORNIA], highlighted: 1 });
+    drawResults(map as unknown as maplibregl.Map, { ...style, highlightColor: '#7a4600', strokeHighlightColor: '#4a0a0a' }, { extents: [CALIFORNIA], highlighted: [1] });
 
-    expect(map.layers.get(`${SELECTED_BOUNDS}-fill`).paint['fill-color']).toEqual('#7a4600');
-    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual('#4a0a0a');
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-fill`).paint['fill-color']).toEqual('#7a4600');
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual('#4a0a0a');
   });
 
-  // The colors a selected feature gets, not a hovered one: a hover is what points at it, but what it
-  // means is that this is the result being read
-  it('should draw the pointed-at result’s own extent, in the colors of a selection', () => {
-    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2 });
+  // The colors a hovered feature gets, whichever of the two ways of pointing at a result is what asked
+  // for it: a pointer over the number, or something outside naming the row
+  it('should draw a highlighted result’s own extent, in the colors of a hover', () => {
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: [2] });
 
-    expect(map.sources.get(SELECTED_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
-    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeSelectedColor);
-    expect(map.layers.get(`${SELECTED_BOUNDS}-fill`).paint['fill-color']).toEqual(style.selectedColor);
-    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features[0].geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeHighlightColor);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-fill`).paint['fill-color']).toEqual(style.highlightColor);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
     expect(marked(map)).toEqual([
-      { label: '1', selected: false, icon: markerImageId('1', style) },
-      { label: '2', selected: true, icon: markerImageId('2', style, true) },
+      { label: '1', highlighted: false, icon: markerImageId('1', style) },
+      { label: '2', highlighted: true, icon: markerImageId('2', style, true) },
     ]);
   });
 
   // There is no number on the map to bring forward and no extent to draw around, which is the truth
-  it('should draw no extent for a selection it cannot place', () => {
-    const map = draw([CALIFORNIA, undefined], { highlighted: 2 });
+  it('should draw no extent for a highlight it cannot place', () => {
+    const map = draw([CALIFORNIA, undefined], { highlighted: [2] });
 
-    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
-    expect(marked(map)).toEqual([{ label: '1', selected: false, icon: markerImageId('1', style) }]);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
+    expect(marked(map)).toEqual([{ label: '1', highlighted: false, icon: markerImageId('1', style) }]);
+  });
+
+  // A pointer over one number while something outside names a different row. Neither is a correction
+  // of the other, so both are drawn.
+  it('should draw every result being highlighted, and a box for each', () => {
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: [1, 2] });
+
+    expect(marked(map).map((properties: { highlighted: boolean }) => properties.highlighted)).toEqual([true, true]);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toHaveLength(2);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features.map((feature: GeoJSON.Feature) => feature.geometry.type)).toEqual(['Polygon', 'Polygon']);
   });
 
   it('should take the extent away again when the highlight is withdrawn', () => {
-    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2 });
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: [2] });
 
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect(map.sources.get(SELECTED_BOUNDS).data.features).toEqual([]);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
   });
 });

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -5,7 +5,18 @@
 import { describe, it, expect, vi } from '@stencil/vitest';
 import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
-import { drawResults, HIGHLIGHT_BOUNDS, markerImage, markerImageId, numberedResults, RESULT_MARKERS, RESULT_NUMBERS, resultMarkersLayer, SEARCH_BOUNDS } from './results';
+import {
+  drawResults,
+  HIGHLIGHT_BOUNDS,
+  markerImage,
+  markerImageId,
+  markerMetrics,
+  numberedResults,
+  RESULT_MARKERS,
+  RESULT_NUMBERS,
+  resultMarkersLayer,
+  SEARCH_BOUNDS,
+} from './results';
 import type { MapLibreStyle } from './themes/maplibre';
 
 // Just enough of a MapLibre map to record what goes on it, in the order it went on, and to be changed
@@ -195,12 +206,38 @@ describe('resultMarkersLayer', () => {
   });
 });
 
+describe('markerMetrics', () => {
+  // Enough to read as coming forward, without saying that something happened
+  it('should draw a highlighted marker bigger than the rest', () => {
+    expect(markerMetrics(style, true).box).toBeGreaterThan(markerMetrics(style, false).box);
+    expect(markerMetrics(style, true).box / markerMetrics(style, false).box).toBeLessThan(1.3);
+  });
+
+  // A disc that grew without its numeral would leave the number looking lost on it
+  it('should grow the numeral with the disc', () => {
+    const plain = markerMetrics(style, false);
+    const grown = markerMetrics(style, true);
+
+    expect(grown.size / plain.size).toBeCloseTo(grown.radius / plain.radius);
+  });
+
+  // What holds a disc off the basemap and off its neighbours, which is the same job at either size
+  it('should leave the ring the same width on a marker that has come forward', () => {
+    expect(markerMetrics(style, true).box - markerMetrics(style, true).radius * 2).toBeCloseTo(markerMetrics(style, false).box - markerMetrics(style, false).radius * 2, 0);
+  });
+
+  // The one value an embedding app sets to move every marker together
+  it('should follow the text size the theme was given', () => {
+    expect(markerMetrics({ ...style, textSize: 24 }, false).box).toBeGreaterThan(markerMetrics({ ...style, textSize: 12 }, false).box);
+  });
+});
+
 describe('markerImage', () => {
   // There is no canvas in this DOM, which is the case the caller has to survive: a map missing its
   // numbers rather than a map that failed to open. What it draws when there is one is checked in a
   // browser, since that is the only place pixels exist.
   it('should draw nothing where there is nothing to draw on', () => {
-    expect(markerImage('1', '#2d5883', style, 2)).toBeUndefined();
+    expect(markerImage('1', style, false, 2)).toBeUndefined();
   });
 });
 
@@ -249,7 +286,7 @@ describe('drawResults', () => {
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA] });
 
     expect(addImage).not.toHaveBeenCalledWith(markerImageId('1', style), expect.anything(), expect.anything());
-    expect(markerImage(markerImageId('1', style), style.markerColor, style, 1)).toBeUndefined();
+    expect(addImage).toHaveBeenCalledTimes(0);
   });
 
   // MapLibre carries images across setStyle - it diffs the new style document against the old one, and

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -1,8 +1,23 @@
+/** @vitest-environment happy-dom */
+// A DOM, because a marker is now a picture drawn on a canvas rather than a description handed to
+// MapLibre. happy-dom has no canvas behind its <canvas>, which is the case markerImage answers for -
+// what it draws when there is one is checked in a browser, since that is the only place pixels exist.
 import { describe, it, expect } from '@stencil/vitest';
 import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
-import { clearResults, drawResults, HIGHLIGHT_BOUNDS, numberedResults, RESULT_HIGHLIGHT, RESULT_NUMBERS, resultNumbersLayers, SEARCH_BOUNDS } from './results';
-import { contrastColor } from './themes/color';
+import {
+  clearResults,
+  drawResults,
+  HIGHLIGHT_BOUNDS,
+  MARKER_IMAGE,
+  markerImage,
+  markerImageId,
+  numberedResults,
+  RESULT_MARKERS,
+  RESULT_NUMBERS,
+  resultMarkersLayer,
+  SEARCH_BOUNDS,
+} from './results';
 import type { MapLibreStyle } from './themes/maplibre';
 
 // Just enough of a MapLibre map to record what goes on it, in the order it went on. removeSource
@@ -11,6 +26,19 @@ import type { MapLibreStyle } from './themes/maplibre';
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
+  images = new Map<string, any>();
+
+  addImage(id: string, image: any, options: any) {
+    if (this.images.has(id)) throw new Error(`An image named "${id}" already exists.`);
+    this.images.set(id, { image, options });
+  }
+  removeImage(id: string) {
+    if (!this.images.has(id)) throw new Error(`No image named "${id}" exists.`);
+    this.images.delete(id);
+  }
+  listImages() {
+    return [...this.images.keys()];
+  }
 
   getSource(id: string) {
     return this.sources.get(id);
@@ -63,7 +91,7 @@ const ALEUTIANS: LngLatBoundsLike = [
   [190, 54],
 ];
 
-const NUMBER_LAYERS = [`${RESULT_NUMBERS}-circle`, `${RESULT_NUMBERS}-label`, `${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`];
+const MARKER_LAYERS = [RESULT_MARKERS];
 const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
 
 const draw = (extents: (LngLatBoundsLike | undefined)[], rest: { highlighted?: number; searchBounds?: LngLatBounds } = {}) => {
@@ -115,6 +143,15 @@ describe('numberedResults', () => {
     expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, true]);
   });
 
+  // The picture each marker is drawn as. Named on the feature rather than worked out in an expression,
+  // so one place decides which marker wears which.
+  it('should name the picture each marker is drawn as', () => {
+    const { features } = numberedResults([CALIFORNIA, ICELAND], 2);
+
+    expect(features.map(feature => feature.properties!.icon)).toEqual([markerImageId('1'), markerImageId('2', true)]);
+    expect(markerImageId('2', true)).not.toEqual(markerImageId('2'));
+  });
+
   it('should mark nothing when nothing is highlighted', () => {
     const { features } = numberedResults([CALIFORNIA, ICELAND]);
 
@@ -129,80 +166,44 @@ describe('numberedResults', () => {
   });
 });
 
-describe('resultNumbersLayers', () => {
-  // A number that isn't there is worse than one that overlaps: the list beside the map is counting
-  // on every one of them being findable, so nothing may cull one. What the numbers do get is room
-  // around them, which pushes the basemap's own labels out from under them instead.
-  it('should draw every number, and clear a little space around each', () => {
-    const [, label] = resultNumbersLayers(style);
+describe('resultMarkersLayer', () => {
+  // The whole reason a marker is one picture: two layers cannot be made to interleave. A symbol layer
+  // draws all of its text after all of its icons, and a circle layer draws every circle before any
+  // layer above it, so numbers in a layer of their own land over every disc including their
+  // neighbours'. One image apiece means whichever marker is on top covers the one under it whole.
+  it('should draw every marker from one layer, as an image apiece', () => {
+    const layer = resultMarkersLayer();
 
-    expect(label.layout!['text-allow-overlap']).toBe(true);
-    expect(label.layout!['text-padding']).toBeGreaterThan(2);
+    expect(layer.type).toEqual('symbol');
+    expect(layer.source).toEqual(RESULT_NUMBERS);
+    expect(layer.layout!['icon-image']).toEqual(['get', 'icon']);
+    // Nothing draws text: there is no second pass for a number to be left in
+    expect(layer.layout!['text-field']).toBeUndefined();
+  });
+
+  // A number that isn't there is worse than one that overlaps: the list beside the map is counting on
+  // every one of them being findable
+  it('should draw every marker, whatever it lands on', () => {
+    expect(resultMarkersLayer().layout!['icon-allow-overlap']).toBe(true);
     // Deliberately absent: MapLibre's own default of false is what puts these in the collision grid,
     // so a basemap label that wants the same space is the one that gets dropped
-    expect(label.layout!['text-ignore-placement']).toBeUndefined();
-  });
-
-  it('should draw the numbers the way the theme draws text', () => {
-    const [, label] = resultNumbersLayers(style);
-
-    expect(label.layout!['text-font']).toEqual([style.textFont]);
-    expect(label.paint!['text-color']).toEqual(contrastColor(style.markerColor));
-    // The disc's own color, so a numeral doesn't touch the ring around it
-    expect(label.paint!['text-halo-color']).toEqual(style.markerColor);
-  });
-
-  // Read against a whole globe rather than sitting beside a feature, so bigger than a feature label
-  it('should ask for a number bigger than a label on a feature', () => {
-    const [, label] = resultNumbersLayers(style);
-
-    expect(label.layout!['text-size']).toBeGreaterThan(style.textSize);
-  });
-
-  it('should take its numbers from the label each point carries', () => {
-    expect(resultNumbersLayers(style)[1].layout!['text-field']).toEqual(['get', 'label']);
-  });
-
-  it('should draw a disc behind each number', () => {
-    const [disc, label] = resultNumbersLayers(style);
-
-    expect(disc.type).toEqual('circle');
-    expect(disc.source).toEqual(label.source);
-    expect(disc.paint!['circle-color']).toEqual(style.markerColor);
-    expect(disc.paint!['circle-stroke-width']).toBeGreaterThan(0);
-  });
-
-  // Stepped rather than grown smoothly, so eight results don't wear eight slightly different discs
-  it('should widen the disc for a longer number', () => {
-    const [disc] = resultNumbersLayers(style);
-    const [, , one, , two, , three] = disc.paint!['circle-radius'] as [string, unknown, number, number, number, number, number];
-
-    expect(one).toBeLessThan(two);
-    expect(two).toBeLessThan(three);
-  });
-
-  // Which is the only arrangement that lifts a whole marker: a symbol layer draws all of its text
-  // after all of its icons, so one pair can never put one feature's disc and number above another's.
-  it('should draw the highlighted number in its own color, from a layer of its own', () => {
-    const [disc, label] = resultNumbersLayers(style, true);
-
-    expect([disc.id, label.id]).toEqual([`${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`]);
-    expect(disc.paint!['circle-color']).toEqual(style.markerHighlightColor);
-    expect(label.paint!['text-halo-color']).toEqual(style.markerHighlightColor);
-    // Both pairs read the one source, from opposite sides of the same mark
-    expect(disc.source).toEqual(RESULT_NUMBERS);
-    expect(disc.filter).toEqual(['==', ['get', 'highlighted'], true]);
-    expect(resultNumbersLayers(style)[0].filter).toEqual(['!=', ['get', 'highlighted'], true]);
+    expect(resultMarkersLayer().layout!['icon-ignore-placement']).toBeUndefined();
   });
 
   // Without a key of its own MapLibre orders symbols by where they land on screen, so they restack as
-  // the reader pans - which reads as the numbers rearranging themselves. Both properties draw a higher
-  // key over a lower one, so the key is the number negated: result 1 sorts above result 20.
-  it('should keep the earlier results on top of the later ones', () => {
-    const [disc, label] = resultNumbersLayers(style);
+  // the reader pans - which reads as the numbers rearranging themselves. A higher key draws over a
+  // lower one, so the key is the number negated, and the highlighted one sorts above all of them.
+  it('should keep the earlier results on top of the later ones, and the highlight above both', () => {
+    expect(resultMarkersLayer().layout!['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
+  });
+});
 
-    expect(disc.layout!['circle-sort-key']).toEqual(['-', 0, ['to-number', ['get', 'label']]]);
-    expect(label.layout!['symbol-sort-key']).toEqual(disc.layout!['circle-sort-key']);
+describe('markerImage', () => {
+  // There is no canvas in this DOM, which is the case the caller has to survive: a map missing its
+  // numbers rather than a map that failed to open. What it draws when there is one is checked in a
+  // browser, since that is the only place pixels exist.
+  it('should draw nothing where there is nothing to draw on', () => {
+    expect(markerImage('1', '#2d5883', style, 2)).toBeUndefined();
   });
 });
 
@@ -212,7 +213,29 @@ describe('drawResults', () => {
 
     expect(map.sources.get(RESULT_NUMBERS).type).toEqual('geojson');
     expect(map.sources.get(RESULT_NUMBERS).data.features).toHaveLength(2);
-    expect([...map.layers.keys()]).toEqual(NUMBER_LAYERS);
+    expect([...map.layers.keys()]).toEqual(MARKER_LAYERS);
+  });
+
+  // Nothing is reused between draws: a theme swap changes what a marker looks like, and a picture kept
+  // from the last palette would put a marker from the last theme on the map. Asserted through the fake,
+  // which refuses a second image under a name it already holds the way MapLibre does.
+  it('should draw its pictures again rather than reuse them', () => {
+    const map = draw([CALIFORNIA, ICELAND]);
+    map.addImage(`${MARKER_IMAGE}-1`, {}, {});
+
+    expect(() => drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] })).not.toThrow();
+    expect(map.listImages().filter(id => id.startsWith(MARKER_IMAGE))).toEqual([]);
+  });
+
+  // Left behind, they would outlive every marker that ever used them
+  it('should take its pictures off with everything else', () => {
+    const map = draw([CALIFORNIA]);
+    map.addImage(`${MARKER_IMAGE}-1`, {}, {});
+    map.addImage('someone-elses-image', {}, {});
+
+    clearResults(map as unknown as maplibregl.Map);
+
+    expect(map.listImages()).toEqual(['someone-elses-image']);
   });
 
   // A page of boxes says less than a page of numbers a reader can find in the list beside the map
@@ -229,13 +252,13 @@ describe('drawResults', () => {
     map.addLayer({ id: 'a-box', type: 'fill' });
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect([...map.layers.keys()]).toEqual(['a-box', ...NUMBER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual(['a-box', ...MARKER_LAYERS]);
   });
 
   it('should draw the searched area, then the highlight, then the numbers', () => {
     const map = draw([CALIFORNIA, ICELAND], { highlighted: 2, searchBounds: LngLatBounds.convert(CALIFORNIA) });
 
-    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...NUMBER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
   });
 
   it('should draw the area being searched in the colors a bounding box gets', () => {
@@ -261,8 +284,8 @@ describe('drawResults', () => {
     expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeHighlightColor);
     expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
     expect(marked(map)).toEqual([
-      { label: '1', highlighted: false },
-      { label: '2', highlighted: true },
+      { label: '1', highlighted: false, icon: markerImageId('1') },
+      { label: '2', highlighted: true, icon: markerImageId('2', true) },
     ]);
   });
 
@@ -271,7 +294,7 @@ describe('drawResults', () => {
     const map = draw([CALIFORNIA, undefined], { highlighted: 2 });
 
     expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
-    expect(marked(map)).toEqual([{ label: '1', highlighted: false }]);
+    expect(marked(map)).toEqual([{ label: '1', highlighted: false, icon: markerImageId('1') }]);
   });
 
   it('should take everything off the map when cleared', () => {

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -8,7 +8,7 @@ import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 import {
   clearResults,
   drawResults,
-  HIGHLIGHT_BOUNDS,
+  SELECTED_BOUNDS,
   MARKER_IMAGE,
   markerImage,
   markerImageId,
@@ -67,8 +67,10 @@ const style = {
   strokeColor: '#517daa',
   highlightColor: '#7fd6ec',
   strokeHighlightColor: '#268499',
+  selectedColor: '#93da98',
+  strokeSelectedColor: '#1e662a',
   markerColor: '#2d5883',
-  markerHighlightColor: '#006175',
+  markerSelectedColor: '#1e662a',
   textColor: '#000',
   textHaloColor: '#fff',
   textFont: 'Noto Sans Regular',
@@ -137,10 +139,10 @@ describe('numberedResults', () => {
     expect(numberedResults([undefined]).features).toEqual([]);
   });
 
-  it('should mark the result at the highlighted place', () => {
+  it('should mark the result at the place it was pointed at', () => {
     const { features } = numberedResults([CALIFORNIA, ICELAND], 2);
 
-    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, true]);
+    expect(features.map(feature => feature.properties!.selected)).toEqual([false, true]);
   });
 
   // The picture each marker is drawn as. Named on the feature rather than worked out in an expression,
@@ -152,17 +154,17 @@ describe('numberedResults', () => {
     expect(markerImageId('2', true)).not.toEqual(markerImageId('2'));
   });
 
-  it('should mark nothing when nothing is highlighted', () => {
+  it('should mark nothing when nothing was pointed at', () => {
     const { features } = numberedResults([CALIFORNIA, ICELAND]);
 
-    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, false]);
+    expect(features.map(feature => feature.properties!.selected)).toEqual([false, false]);
   });
 
   // The places are counted over every result, so a highlight can land on one that was never drawn
   it('should mark nothing for a place it has nowhere to put', () => {
     const { features } = numberedResults([CALIFORNIA, undefined], 2);
 
-    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false]);
+    expect(features.map(feature => feature.properties!.selected)).toEqual([false]);
   });
 });
 
@@ -194,7 +196,7 @@ describe('resultMarkersLayer', () => {
   // the reader pans - which reads as the numbers rearranging themselves. A higher key draws over a
   // lower one, so the key is the number negated, and the highlighted one sorts above all of them.
   it('should keep the earlier results on top of the later ones, and the highlight above both', () => {
-    expect(resultMarkersLayer().layout!['symbol-sort-key']).toEqual(['case', ['get', 'highlighted'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
+    expect(resultMarkersLayer().layout!['symbol-sort-key']).toEqual(['case', ['get', 'selected'], 1, ['-', 0, ['to-number', ['get', 'label']]]]);
   });
 });
 
@@ -258,7 +260,7 @@ describe('drawResults', () => {
   it('should draw the searched area, then the highlight, then the numbers', () => {
     const map = draw([CALIFORNIA, ICELAND], { highlighted: 2, searchBounds: LngLatBounds.convert(CALIFORNIA) });
 
-    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...MARKER_LAYERS]);
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(SELECTED_BOUNDS), ...MARKER_LAYERS]);
   });
 
   it('should draw the area being searched in the colors a bounding box gets', () => {
@@ -277,24 +279,27 @@ describe('drawResults', () => {
     expect(map.sources.has(SEARCH_BOUNDS)).toBe(false);
   });
 
-  it('should draw the highlighted result’s own extent, in the highlight colors', () => {
+  // The colors a selected feature gets, not a hovered one: a hover is what points at it, but what it
+  // means is that this is the result being read
+  it('should draw the pointed-at result’s own extent, in the colors of a selection', () => {
     const map = draw([CALIFORNIA, ICELAND], { highlighted: 2 });
 
-    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeHighlightColor);
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
+    expect(map.sources.get(SELECTED_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeSelectedColor);
+    expect(map.layers.get(`${SELECTED_BOUNDS}-fill`).paint['fill-color']).toEqual(style.selectedColor);
+    expect(map.layers.get(`${SELECTED_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
     expect(marked(map)).toEqual([
-      { label: '1', highlighted: false, icon: markerImageId('1') },
-      { label: '2', highlighted: true, icon: markerImageId('2', true) },
+      { label: '1', selected: false, icon: markerImageId('1') },
+      { label: '2', selected: true, icon: markerImageId('2', true) },
     ]);
   });
 
   // There is no number on the map to bring forward and no extent to draw around, which is the truth
-  it('should draw no extent for a highlight it cannot place', () => {
+  it('should draw no extent for a selection it cannot place', () => {
     const map = draw([CALIFORNIA, undefined], { highlighted: 2 });
 
-    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
-    expect(marked(map)).toEqual([{ label: '1', highlighted: false, icon: markerImageId('1') }]);
+    expect(map.sources.has(SELECTED_BOUNDS)).toBe(false);
+    expect(marked(map)).toEqual([{ label: '1', selected: false, icon: markerImageId('1') }]);
   });
 
   it('should take everything off the map when cleared', () => {

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from '@stencil/vitest';
-import type { LngLatBoundsLike } from 'maplibre-gl';
+import { LngLatBounds, type LngLatBoundsLike } from 'maplibre-gl';
 
-import { clearResultNumbers, drawResultNumbers, RESULT_NUMBERS, numberedResults, resultNumbersLayer } from './results';
+import { clearResults, drawResults, HIGHLIGHT_BOUNDS, numberedResults, RESULT_HIGHLIGHT, RESULT_NUMBERS, resultNumbersLayers, SEARCH_BOUNDS } from './results';
+import { contrastColor } from './themes/color';
 import type { MapLibreStyle } from './themes/maplibre';
 
-// Just enough of a MapLibre map to record what goes on it, in the order it went on
+// Just enough of a MapLibre map to record what goes on it, in the order it went on. removeSource
+// refuses while a layer is still reading it, the way the real one does: that ordering is the one
+// mistake clearResults can make.
 class FakeMap {
   sources = new Map<string, any>();
   layers = new Map<string, any>();
@@ -16,6 +19,8 @@ class FakeMap {
     this.sources.set(id, spec);
   }
   removeSource(id: string) {
+    const reader = [...this.layers.values()].find(layer => layer.source === id);
+    if (reader) throw new Error(`Source "${id}" cannot be removed while layer "${reader.id}" is using it.`);
     this.sources.delete(id);
   }
   getLayer(id: string) {
@@ -30,10 +35,18 @@ class FakeMap {
 }
 
 const style = {
+  dataColor: '#9fceff',
+  strokeColor: '#517daa',
+  highlightColor: '#7fd6ec',
+  strokeHighlightColor: '#268499',
+  markerColor: '#2d5883',
+  markerHighlightColor: '#006175',
   textColor: '#000',
   textHaloColor: '#fff',
   textFont: 'Noto Sans Regular',
   textSize: 12,
+  boundsOpacity: 0.6,
+  highlightOpacity: 0.8,
 } as MapLibreStyle;
 
 const CALIFORNIA: LngLatBoundsLike = [
@@ -50,11 +63,16 @@ const ALEUTIANS: LngLatBoundsLike = [
   [190, 54],
 ];
 
-const draw = (extents: (LngLatBoundsLike | undefined)[]) => {
+const NUMBER_LAYERS = [`${RESULT_NUMBERS}-circle`, `${RESULT_NUMBERS}-label`, `${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`];
+const BOX_LAYERS = (id: string) => [`${id}-fill`, `${id}-outline`];
+
+const draw = (extents: (LngLatBoundsLike | undefined)[], rest: { highlighted?: number; searchBounds?: LngLatBounds } = {}) => {
   const map = new FakeMap();
-  drawResultNumbers(map as unknown as maplibregl.Map, style, extents);
+  drawResults(map as unknown as maplibregl.Map, style, { extents, ...rest });
   return map;
 };
+
+const marked = (map: FakeMap) => map.sources.get(RESULT_NUMBERS).data.features.map((feature: GeoJSON.Feature) => feature.properties);
 
 describe('numberedResults', () => {
   it('should number the extents from one, in the order it was given them', () => {
@@ -90,48 +108,118 @@ describe('numberedResults', () => {
   it('should have nothing to draw when no record says where it is', () => {
     expect(numberedResults([undefined]).features).toEqual([]);
   });
+
+  it('should mark the result at the highlighted place', () => {
+    const { features } = numberedResults([CALIFORNIA, ICELAND], 2);
+
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, true]);
+  });
+
+  it('should mark nothing when nothing is highlighted', () => {
+    const { features } = numberedResults([CALIFORNIA, ICELAND]);
+
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false, false]);
+  });
+
+  // The places are counted over every result, so a highlight can land on one that was never drawn
+  it('should mark nothing for a place it has nowhere to put', () => {
+    const { features } = numberedResults([CALIFORNIA, undefined], 2);
+
+    expect(features.map(feature => feature.properties!.highlighted)).toEqual([false]);
+  });
 });
 
-describe('resultNumbersLayer', () => {
+describe('resultNumbersLayers', () => {
   // A number that isn't there is worse than one that overlaps: the list beside the map is counting
-  // on every one of them being findable, so neither the boxes already placed nor the other numbers
-  // are allowed to cull one.
-  it('should draw every number, whatever it lands on', () => {
-    const { layout } = resultNumbersLayer(style);
+  // on every one of them being findable, so nothing may cull one. What the numbers do get is room
+  // around them, which pushes the basemap's own labels out from under them instead.
+  it('should draw every number, and clear a little space around each', () => {
+    const [, label] = resultNumbersLayers(style);
 
-    expect(layout!['text-allow-overlap']).toBe(true);
-    expect(layout!['text-ignore-placement']).toBe(true);
+    expect(label.layout!['text-allow-overlap']).toBe(true);
+    expect(label.layout!['text-padding']).toBeGreaterThan(2);
+    // Deliberately absent: MapLibre's own default of false is what puts these in the collision grid,
+    // so a basemap label that wants the same space is the one that gets dropped
+    expect(label.layout!['text-ignore-placement']).toBeUndefined();
   });
 
   it('should draw the numbers the way the theme draws text', () => {
-    const layer = resultNumbersLayer(style);
+    const [, label] = resultNumbersLayers(style);
 
-    expect(layer.layout!['text-font']).toEqual([style.textFont]);
-    expect(layer.paint!['text-color']).toEqual(style.textColor);
-    expect(layer.paint!['text-halo-color']).toEqual(style.textHaloColor);
+    expect(label.layout!['text-font']).toEqual([style.textFont]);
+    expect(label.paint!['text-color']).toEqual(contrastColor(style.markerColor));
+    // The disc's own color, so a numeral doesn't touch the ring around it
+    expect(label.paint!['text-halo-color']).toEqual(style.markerColor);
   });
 
   // Read against a whole globe rather than sitting beside a feature, so bigger than a feature label
-  // and haloed harder - at this size a single pixel of outline disappears into the basemap.
   it('should ask for a number bigger than a label on a feature', () => {
-    const layer = resultNumbersLayer(style);
+    const [, label] = resultNumbersLayers(style);
 
-    expect(layer.layout!['text-size']).toBeGreaterThan(style.textSize);
-    expect(layer.paint!['text-halo-width']).toBeGreaterThan(1);
+    expect(label.layout!['text-size']).toBeGreaterThan(style.textSize);
   });
 
   it('should take its numbers from the label each point carries', () => {
-    expect(resultNumbersLayer(style).layout!['text-field']).toEqual(['get', 'label']);
+    expect(resultNumbersLayers(style)[1].layout!['text-field']).toEqual(['get', 'label']);
+  });
+
+  it('should draw a disc behind each number', () => {
+    const [disc, label] = resultNumbersLayers(style);
+
+    expect(disc.type).toEqual('circle');
+    expect(disc.source).toEqual(label.source);
+    expect(disc.paint!['circle-color']).toEqual(style.markerColor);
+    expect(disc.paint!['circle-stroke-width']).toBeGreaterThan(0);
+  });
+
+  // Stepped rather than grown smoothly, so eight results don't wear eight slightly different discs
+  it('should widen the disc for a longer number', () => {
+    const [disc] = resultNumbersLayers(style);
+    const [, , one, , two, , three] = disc.paint!['circle-radius'] as [string, unknown, number, number, number, number, number];
+
+    expect(one).toBeLessThan(two);
+    expect(two).toBeLessThan(three);
+  });
+
+  // Which is the only arrangement that lifts a whole marker: a symbol layer draws all of its text
+  // after all of its icons, so one pair can never put one feature's disc and number above another's.
+  it('should draw the highlighted number in its own color, from a layer of its own', () => {
+    const [disc, label] = resultNumbersLayers(style, true);
+
+    expect([disc.id, label.id]).toEqual([`${RESULT_HIGHLIGHT}-circle`, `${RESULT_HIGHLIGHT}-label`]);
+    expect(disc.paint!['circle-color']).toEqual(style.markerHighlightColor);
+    expect(label.paint!['text-halo-color']).toEqual(style.markerHighlightColor);
+    // Both pairs read the one source, from opposite sides of the same mark
+    expect(disc.source).toEqual(RESULT_NUMBERS);
+    expect(disc.filter).toEqual(['==', ['get', 'highlighted'], true]);
+    expect(resultNumbersLayers(style)[0].filter).toEqual(['!=', ['get', 'highlighted'], true]);
+  });
+
+  // Without a key of its own MapLibre orders symbols by where they land on screen, so they restack as
+  // the reader pans - which reads as the numbers rearranging themselves. Both properties draw a higher
+  // key over a lower one, so the key is the number negated: result 1 sorts above result 20.
+  it('should keep the earlier results on top of the later ones', () => {
+    const [disc, label] = resultNumbersLayers(style);
+
+    expect(disc.layout!['circle-sort-key']).toEqual(['-', 0, ['to-number', ['get', 'label']]]);
+    expect(label.layout!['symbol-sort-key']).toEqual(disc.layout!['circle-sort-key']);
   });
 });
 
-describe('drawResultNumbers', () => {
-  it('should put a source and a layer on the map', () => {
+describe('drawResults', () => {
+  it('should put the numbers and their discs on the map', () => {
     const map = draw([CALIFORNIA, ICELAND]);
 
     expect(map.sources.get(RESULT_NUMBERS).type).toEqual('geojson');
     expect(map.sources.get(RESULT_NUMBERS).data.features).toHaveLength(2);
-    expect(map.layers.get(RESULT_NUMBERS).type).toEqual('symbol');
+    expect([...map.layers.keys()]).toEqual(NUMBER_LAYERS);
+  });
+
+  // A page of boxes says less than a page of numbers a reader can find in the list beside the map
+  it('should draw nothing of a result but its number', () => {
+    const map = draw([CALIFORNIA]);
+
+    expect([...map.sources.keys()]).toEqual([RESULT_NUMBERS]);
   });
 
   // addLayer appends, so the numbers only stay over the boxes if they go back on after the boxes
@@ -139,22 +227,71 @@ describe('drawResultNumbers', () => {
   it('should put the numbers back on top of boxes drawn after them', () => {
     const map = draw([CALIFORNIA]);
     map.addLayer({ id: 'a-box', type: 'fill' });
-    drawResultNumbers(map as unknown as maplibregl.Map, style, [CALIFORNIA, ICELAND]);
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect([...map.layers.keys()]).toEqual(['a-box', RESULT_NUMBERS]);
+    expect([...map.layers.keys()]).toEqual(['a-box', ...NUMBER_LAYERS]);
   });
 
-  it('should take the numbers off the map when cleared', () => {
+  it('should draw the searched area, then the highlight, then the numbers', () => {
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2, searchBounds: LngLatBounds.convert(CALIFORNIA) });
+
+    expect([...map.layers.keys()]).toEqual([...BOX_LAYERS(SEARCH_BOUNDS), ...BOX_LAYERS(HIGHLIGHT_BOUNDS), ...NUMBER_LAYERS]);
+  });
+
+  it('should draw the area being searched in the colors a bounding box gets', () => {
+    const map = draw([], { searchBounds: LngLatBounds.convert(CALIFORNIA) });
+
+    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeColor);
+    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.boundsOpacity);
+    expect(map.layers.get(`${SEARCH_BOUNDS}-fill`).paint['fill-color']).toEqual(style.dataColor);
+    // The wash is held below the outline, the way a location's is
+    expect(map.layers.get(`${SEARCH_BOUNDS}-fill`).paint['fill-opacity']).toBeLessThan(style.boundsOpacity);
+  });
+
+  it('should draw nothing for a search area it was not given', () => {
     const map = draw([CALIFORNIA]);
-    clearResultNumbers(map as unknown as maplibregl.Map);
+
+    expect(map.sources.has(SEARCH_BOUNDS)).toBe(false);
+  });
+
+  it('should draw the highlighted result’s own extent, in the highlight colors', () => {
+    const map = draw([CALIFORNIA, ICELAND], { highlighted: 2 });
+
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.geometry.coordinates[0][0]).toEqual([-24.55, 63.39]);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-color']).toEqual(style.strokeHighlightColor);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(style.highlightOpacity);
+    expect(marked(map)).toEqual([
+      { label: '1', highlighted: false },
+      { label: '2', highlighted: true },
+    ]);
+  });
+
+  // There is no number on the map to bring forward and no extent to draw around, which is the truth
+  it('should draw no extent for a highlight it cannot place', () => {
+    const map = draw([CALIFORNIA, undefined], { highlighted: 2 });
+
+    expect(map.sources.has(HIGHLIGHT_BOUNDS)).toBe(false);
+    expect(marked(map)).toEqual([{ label: '1', highlighted: false }]);
+  });
+
+  it('should take everything off the map when cleared', () => {
+    const map = draw([CALIFORNIA], { highlighted: 1, searchBounds: LngLatBounds.convert(ICELAND) });
+    clearResults(map as unknown as maplibregl.Map);
 
     expect(map.sources.size).toEqual(0);
     expect(map.layers.size).toEqual(0);
   });
 
-  // A theme swap empties the style document without asking, so the layer this last drew may be
-  // gone by the time anyone thinks to take it off
-  it('should have nothing to say about numbers a style swap already took away', () => {
-    expect(() => clearResultNumbers(new FakeMap() as unknown as maplibregl.Map)).not.toThrow();
+  // Which is what the fake above refuses, the way MapLibre does
+  it('should take every layer off before the source it reads', () => {
+    const map = draw([CALIFORNIA], { highlighted: 1, searchBounds: LngLatBounds.convert(ICELAND) });
+
+    expect(() => clearResults(map as unknown as maplibregl.Map)).not.toThrow();
+  });
+
+  // A theme swap empties the style document without asking, so what this last drew may be gone by
+  // the time anyone thinks to take it off
+  it('should have nothing to say about layers a style swap already took away', () => {
+    expect(() => clearResults(new FakeMap() as unknown as maplibregl.Map)).not.toThrow();
   });
 });

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -376,6 +376,7 @@ describe('drawResults', () => {
     const map = draw([CALIFORNIA]);
 
     expect(map.sources.get(SEARCH_BOUNDS).data.features).toEqual([]);
+    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
   });
 
   // Nothing takes these layers off again, so the colors have to be able to change where they stand:
@@ -408,7 +409,7 @@ describe('drawResults', () => {
   it('should draw no extent for a highlight it cannot place', () => {
     const map = draw([CALIFORNIA, undefined], { highlighted: [2] });
 
-    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
     expect(marked(map)).toEqual([{ label: '1', highlighted: false, icon: markerImageId('1', style) }]);
   });
 
@@ -422,11 +423,36 @@ describe('drawResults', () => {
     expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features.map((feature: GeoJSON.Feature) => feature.geometry.type)).toEqual(['Polygon', 'Polygon']);
   });
 
-  it('should take the extent away again when the highlight is withdrawn', () => {
+  // Faded out rather than taken off, which is why what it was drawn from stays where it is: a box whose
+  // geometry had been taken out of the source would have nothing left to fade.
+  it('should fade the extent out when the highlight is withdrawn', () => {
     const map = draw([CALIFORNIA, ICELAND], { highlighted: [2] });
 
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
+    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-fill`).paint['fill-opacity']).toEqual(0);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toHaveLength(1);
+  });
+
+  // MapLibre interpolates a paint property that changes, so a box arrives and leaves over this rather
+  // than appearing. Named on our own layers because getTransition() takes the style document's word for
+  // it first, and the basemaps are CARTO's to change.
+  it('should give both boxes an opacity that fades', () => {
+    const map = draw([CALIFORNIA], { highlighted: [1], searchBounds: LngLatBounds.convert(ICELAND) });
+
+    for (const id of [SEARCH_BOUNDS, HIGHLIGHT_BOUNDS]) {
+      expect(map.layers.get(`${id}-fill`).paint['fill-opacity-transition'].duration).toBeGreaterThan(0);
+      expect(map.layers.get(`${id}-outline`).paint['line-opacity-transition'].duration).toBeGreaterThan(0);
+    }
+  });
+
+  it('should fade the searched area out when the filter is withdrawn', () => {
+    const map = draw([CALIFORNIA], { searchBounds: LngLatBounds.convert(ICELAND) });
+
+    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA] });
+
+    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
+    expect(map.sources.get(SEARCH_BOUNDS).data.features).toHaveLength(1);
   });
 });

--- a/src/lib/results.test.ts
+++ b/src/lib/results.test.ts
@@ -376,7 +376,6 @@ describe('drawResults', () => {
     const map = draw([CALIFORNIA]);
 
     expect(map.sources.get(SEARCH_BOUNDS).data.features).toEqual([]);
-    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
   });
 
   // Nothing takes these layers off again, so the colors have to be able to change where they stand:
@@ -409,7 +408,7 @@ describe('drawResults', () => {
   it('should draw no extent for a highlight it cannot place', () => {
     const map = draw([CALIFORNIA, undefined], { highlighted: [2] });
 
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
     expect(marked(map)).toEqual([{ label: '1', highlighted: false, icon: markerImageId('1', style) }]);
   });
 
@@ -423,36 +422,11 @@ describe('drawResults', () => {
     expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features.map((feature: GeoJSON.Feature) => feature.geometry.type)).toEqual(['Polygon', 'Polygon']);
   });
 
-  // Faded out rather than taken off, which is why what it was drawn from stays where it is: a box whose
-  // geometry had been taken out of the source would have nothing left to fade.
-  it('should fade the extent out when the highlight is withdrawn', () => {
+  it('should take the extent away again when the highlight is withdrawn', () => {
     const map = draw([CALIFORNIA, ICELAND], { highlighted: [2] });
 
     drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA, ICELAND] });
 
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
-    expect(map.layers.get(`${HIGHLIGHT_BOUNDS}-fill`).paint['fill-opacity']).toEqual(0);
-    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toHaveLength(1);
-  });
-
-  // MapLibre interpolates a paint property that changes, so a box arrives and leaves over this rather
-  // than appearing. Named on our own layers because getTransition() takes the style document's word for
-  // it first, and the basemaps are CARTO's to change.
-  it('should give both boxes an opacity that fades', () => {
-    const map = draw([CALIFORNIA], { highlighted: [1], searchBounds: LngLatBounds.convert(ICELAND) });
-
-    for (const id of [SEARCH_BOUNDS, HIGHLIGHT_BOUNDS]) {
-      expect(map.layers.get(`${id}-fill`).paint['fill-opacity-transition'].duration).toBeGreaterThan(0);
-      expect(map.layers.get(`${id}-outline`).paint['line-opacity-transition'].duration).toBeGreaterThan(0);
-    }
-  });
-
-  it('should fade the searched area out when the filter is withdrawn', () => {
-    const map = draw([CALIFORNIA], { searchBounds: LngLatBounds.convert(ICELAND) });
-
-    drawResults(map as unknown as maplibregl.Map, style, { extents: [CALIFORNIA] });
-
-    expect(map.layers.get(`${SEARCH_BOUNDS}-outline`).paint['line-opacity']).toEqual(0);
-    expect(map.sources.get(SEARCH_BOUNDS).data.features).toHaveLength(1);
+    expect(map.sources.get(HIGHLIGHT_BOUNDS).data.features).toEqual([]);
   });
 });

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -19,9 +19,10 @@ import type { MapLibreStyle } from './themes/maplibre';
 export const RESULT_NUMBERS = 'ogm-result-numbers';
 export const RESULT_MARKERS = `${RESULT_NUMBERS}-markers`;
 
-// What an image of one marker is called. Two per number on the map: the picture of that number, and
-// the picture of it highlighted. Both are drawn whether anything is highlighting it or not, so that a
-// highlight arriving changes no pictures at all; see syncMarkerImages.
+// What an image of one marker is called. Two per number on the map: the picture of that number, and the
+// picture of it highlighted, which is drawn bigger and in another color. Both are drawn whether
+// anything is highlighting it or not, so that a highlight arriving changes no pictures at all; see
+// syncMarkerImages.
 const MARKER_IMAGE = 'ogm-result-marker';
 
 // The two boxes drawn under the numbers: the area a search is filtered to, and the extent of every
@@ -56,6 +57,12 @@ const NUMERAL_WIDTH = 0.72;
 // The most a disc is drawn at, however many pixels the display has. Two is every screen worth
 // drawing for; past it the image is memory spent on detail nothing can show.
 const MAX_PIXEL_RATIO = 2;
+
+// How much bigger a highlighted marker is drawn than the rest. Enough to read as coming forward, and
+// no more: it is the same marker, and one that jumped in size would say something happened rather than
+// that this is the one being pointed at. The ring around it doesn't grow with it - see MARKER_RING -
+// so a marker that has come forward still sits the same distance off the basemap.
+const HIGHLIGHT_GROWTH = 1.15;
 
 // Where a highlighted marker sorts. Above every other, which are sorted at minus their own number:
 // see resultMarkersLayer.
@@ -129,9 +136,31 @@ export const markerImageId = (label: string, style: MapLibreStyle, highlighted: 
 
 // What a marker's picture depends on, in a form a name can carry: the color of the disc, the size of
 // the numeral, and the font it is set in. Word characters only, since this ends up in an id - and it is
-// only ever compared with itself, so what it drops costs nothing.
-const markerLook = (style: MapLibreStyle, highlighted: boolean): string =>
-  [highlighted ? style.markerHighlightColor : style.markerColor, style.textSize, style.markerFont].join('-').replace(/[^\w-]+/g, '');
+// only ever compared with itself, so what it drops costs nothing. Nothing here says how big a
+// highlighted marker is drawn, because the name already says which of the two it is.
+const markerLook = (style: MapLibreStyle, highlighted: boolean): string => [discColor(style, highlighted), style.textSize, style.markerFont].join('-').replace(/[^\w-]+/g, '');
+
+// What a marker's disc is drawn in, which is the whole of what being highlighted does to its color
+const discColor = (style: MapLibreStyle, highlighted: boolean): string => (highlighted ? style.markerHighlightColor : style.markerColor);
+
+/**
+ * How big a marker is drawn, in CSS pixels: the numeral, the disc under it, and the square the two are
+ * drawn in.
+ *
+ * All three off one number, so that a marker grows as one thing - a disc that grew without its numeral
+ * would leave the number looking lost on it. That one number is what makes a highlighted marker bigger
+ * than the rest, and --ogm-text-size is what moves every marker together.
+ *
+ * The ring is added rather than scaled, so it is the same width on a marker that has come forward as on
+ * one that hasn't: what it does is hold a disc off the basemap and off its neighbours, and that job
+ * doesn't change with the size of the disc.
+ */
+export const markerMetrics = (style: MapLibreStyle, highlighted: boolean): { size: number; radius: number; box: number } => {
+  const size = style.textSize * NUMBER_SIZE * (highlighted ? HIGHLIGHT_GROWTH : 1);
+  const radius = size * MARKER_RADIUS;
+
+  return { size, radius, box: Math.ceil((radius + MARKER_RING) * 2) };
+};
 
 /**
  * The one layer every marker is drawn from: an image apiece, and nothing else.
@@ -185,13 +214,19 @@ const markerSortKey: ExpressionSpecification = ['case', ['get', 'highlighted'], 
  * what is centered has to be the ink rather than the line it sits on.
  *
  * Drawn at the display's own pixel ratio and handed over with it, so a marker is as crisp as the map
- * under it. Nothing comes back where there is nothing to draw on - a DOM without a canvas behind it,
- * or no DOM at all - and the caller carries on without the picture rather than without the map.
+ * under it - which is also why a highlighted marker is drawn bigger rather than the same picture scaled
+ * up by the layer that draws it. Nothing comes back where there is nothing to draw on - a DOM without a
+ * canvas behind it, or no DOM at all - and the caller carries on without the picture rather than
+ * without the map.
  */
-export const markerImage = (label: string, color: string, style: MapLibreStyle, pixelRatio: number): { width: number; height: number; data: Uint8ClampedArray } | undefined => {
-  const size = style.textSize * NUMBER_SIZE;
-  const radius = size * MARKER_RADIUS;
-  const box = Math.ceil((radius + MARKER_RING) * 2);
+export const markerImage = (
+  label: string,
+  style: MapLibreStyle,
+  highlighted: boolean,
+  pixelRatio: number,
+): { width: number; height: number; data: Uint8ClampedArray } | undefined => {
+  const { size, radius, box } = markerMetrics(style, highlighted);
+  const color = discColor(style, highlighted);
   const scale = Math.min(pixelRatio, MAX_PIXEL_RATIO);
 
   if (typeof document === 'undefined') return undefined;
@@ -366,18 +401,15 @@ const syncMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.Featu
 
   const wanted = numbers.features.flatMap(({ properties }) => {
     const label = String(properties?.label);
-    return [
-      { id: markerImageId(label, style), label, color: style.markerColor },
-      { id: markerImageId(label, style, true), label, color: style.markerHighlightColor },
-    ];
+    return [false, true].map(highlighted => ({ id: markerImageId(label, style, highlighted), label, highlighted }));
   });
 
   const keep = new Set(wanted.map(({ id }) => id));
   for (const id of map.listImages()) if (id.startsWith(MARKER_IMAGE) && !keep.has(id)) map.removeImage(id);
 
-  for (const { id, label, color } of wanted) {
+  for (const { id, label, highlighted } of wanted) {
     if (map.hasImage(id)) continue;
-    const image = markerImage(label, color, style, ratio);
+    const image = markerImage(label, style, highlighted, ratio);
     if (image) map.addImage(id, image, { pixelRatio: Math.min(ratio, MAX_PIXEL_RATIO) });
   }
 };

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -20,16 +20,16 @@ export const RESULT_NUMBERS = 'ogm-result-numbers';
 export const RESULT_MARKERS = `${RESULT_NUMBERS}-markers`;
 
 // What an image of one marker is called. Two per number on the map: the picture of that number, and
-// the picture of it selected. Both are drawn whether anything has pointed at it or not, so that a
+// the picture of it highlighted. Both are drawn whether anything is highlighting it or not, so that a
 // highlight arriving changes no pictures at all; see syncMarkerImages.
 const MARKER_IMAGE = 'ogm-result-marker';
 
-// The two boxes drawn under the numbers: the area a search is filtered to, and the extent of the
-// result something outside has pointed at. A source each rather than two features of one, because they
-// are two different statements about the map, drawn in different colors, arriving at different times.
-// Both stay on the map once drawn, holding nothing when there is nothing to say; see drawInto.
+// The two boxes drawn under the numbers: the area a search is filtered to, and the extent of every
+// result being highlighted. A source each rather than features of one, because they are two different
+// statements about the map, drawn in different colors, arriving at different times. Both stay on the
+// map once drawn, holding nothing when there is nothing to say; see drawInto.
 export const SEARCH_BOUNDS = 'ogm-search-bounds';
-export const SELECTED_BOUNDS = 'ogm-selected-bounds';
+export const HIGHLIGHT_BOUNDS = 'ogm-highlight-bounds';
 
 // How big a result's number is drawn, against the size of a label on a feature. A little larger, and
 // no more: a marker is read at a glance rather than studied, and a page of twenty of them covers more
@@ -57,24 +57,25 @@ const NUMERAL_WIDTH = 0.72;
 // drawing for; past it the image is memory spent on detail nothing can show.
 const MAX_PIXEL_RATIO = 2;
 
-// Where the selected marker sorts. Above every other, which are sorted at minus their own number:
+// Where a highlighted marker sorts. Above every other, which are sorted at minus their own number:
 // see resultMarkersLayer.
-const SELECTED_SORT_KEY = 1;
+const HIGHLIGHT_SORT_KEY = 1;
 
 // Everything an overview draws, gathered in one place because the order it goes onto the map in is
 // most of what keeps it readable.
 export type DrawnResults = {
   // Where every result is, in the order they were given, including the ones nobody could place
   extents: (LngLatBoundsLike | undefined)[];
-  // Which of those results something outside has pointed at, as its place in that list counted from
-  // one. It is drawn as a selection rather than as a hover: see drawResults.
-  highlighted?: number;
+  // Which of those results are highlighted, as their places in that list counted from one. More than
+  // one can be: a pointer over a number highlights it, and so does something outside pointing at a
+  // result, and the two are separate ways of saying the same thing about different rows.
+  highlighted?: number[];
   // The area a search is currently filtered to, if one is
   searchBounds?: LngLatBounds;
 };
 
 // What a box is drawn in. The two of them differ in nothing else, so this is the whole of the
-// difference between the area being searched and the extent of the result being pointed at.
+// difference between the area being searched and the extent of a result being highlighted.
 type BoxColors = { color: string; strokeColor: string; opacity: number };
 
 /**
@@ -89,7 +90,7 @@ type BoxColors = { color: string; strokeColor: string; opacity: number };
  * touches, and with collision turned off below there is nothing left to suppress the copies. A
  * country-sized box would wear its number three or four times.
  */
-export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], style: MapLibreStyle, highlighted?: number): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
+export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], style: MapLibreStyle, highlighted: number[] = []): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
   type: 'FeatureCollection',
   features: extents.flatMap((extent, index) => {
     if (!extent) return [];
@@ -98,14 +99,14 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], style
     // longitude from outside -180..180 everywhere it takes one, so there is nothing to wrap back.
     const { lng, lat } = LngLatBounds.convert(extent).getCenter();
     const label = String(index + 1);
-    const selected = index + 1 === highlighted;
+    const marked = highlighted.includes(index + 1);
 
     return [
       {
         type: 'Feature' as const,
         // The image each one is drawn as, named on the feature rather than worked out in an
         // expression, so there is one place that decides which marker wears which picture.
-        properties: { label, selected, icon: markerImageId(label, style, selected) },
+        properties: { label, highlighted: marked, icon: markerImageId(label, style, marked) },
         geometry: { type: 'Point' as const, coordinates: [lng, lat] },
       },
     ];
@@ -123,14 +124,14 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], style
  * for names that aren't there, gets fresh pictures, and leaves the old names to be taken away - and
  * everything else, which is most redraws, asks for the names already on the map. See syncMarkerImages.
  */
-export const markerImageId = (label: string, style: MapLibreStyle, selected: boolean = false): string =>
-  [MARKER_IMAGE, selected ? 'selected' : 'plain', markerLook(style, selected), label].join('-');
+export const markerImageId = (label: string, style: MapLibreStyle, highlighted: boolean = false): string =>
+  [MARKER_IMAGE, highlighted ? 'highlight' : 'plain', markerLook(style, highlighted), label].join('-');
 
 // What a marker's picture depends on, in a form a name can carry: the color of the disc, the size of
 // the numeral, and the font it is set in. Word characters only, since this ends up in an id - and it is
 // only ever compared with itself, so what it drops costs nothing.
-const markerLook = (style: MapLibreStyle, selected: boolean): string =>
-  [selected ? style.markerSelectedColor : style.markerColor, style.textSize, style.markerFont].join('-').replace(/[^\w-]+/g, '');
+const markerLook = (style: MapLibreStyle, highlighted: boolean): string =>
+  [highlighted ? style.markerHighlightColor : style.markerColor, style.textSize, style.markerFont].join('-').replace(/[^\w-]+/g, '');
 
 /**
  * The one layer every marker is drawn from: an image apiece, and nothing else.
@@ -166,14 +167,14 @@ export const resultMarkersLayer = (): SymbolLayerSpecification => ({
     // Earlier results on top, so counting down the list beside the map is counting away from the
     // reader: the first result is the one a page put first, and it stays over the twentieth however the
     // map is panned. A higher key draws over a lower one, so the key is the number negated - and the
-    // selected one, which something outside has pointed at, sorts above all of them. Without a key at
-    // all MapLibre orders these by where they land on screen, and they restack as the map moves, which
-    // reads as the numbers rearranging themselves.
+    // ones being highlighted sort above all of them. Without a key at all MapLibre orders these by
+    // where they land on screen, and they restack as the map moves, which reads as the numbers
+    // rearranging themselves.
     'symbol-sort-key': markerSortKey,
   },
 });
 
-const markerSortKey: ExpressionSpecification = ['case', ['get', 'selected'], SELECTED_SORT_KEY, ['-', 0, ['to-number', ['get', 'label']]]];
+const markerSortKey: ExpressionSpecification = ['case', ['get', 'highlighted'], HIGHLIGHT_SORT_KEY, ['-', 0, ['to-number', ['get', 'label']]]];
 
 /**
  * A disc with a numeral centered on it, as pixels MapLibre can draw as an icon.
@@ -261,13 +262,14 @@ const boundsLayers = (id: string, { color, strokeColor, opacity }: BoxColors): [
   },
 ];
 
-// Nothing to say, in the form MapLibre takes it in. A box that isn't there stays on the map as a
-// source with no features in it rather than coming off, which is what lets the two layers that read it
-// stay on as well; see drawInto.
-const NOTHING: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
-
-const boundsData = (bounds: LngLatBounds | undefined): GeoJSON.GeoJSON =>
-  bounds ? { type: 'Feature', properties: {}, geometry: boundsToGeoJSON(bounds) as GeoJSON.Geometry } : NOTHING;
+// However many boxes there are to draw, which for the area being searched is one or none and for the
+// results being highlighted is one per result. A collection either way, so that a box nobody asked for
+// is an empty one rather than a source coming off the map - which is what lets the two layers that read
+// it stay on as well; see drawInto.
+const boundsData = (bounds: (LngLatBounds | undefined)[]): GeoJSON.FeatureCollection => ({
+  type: 'FeatureCollection',
+  features: bounds.filter((box): box is LngLatBounds => !!box).map(box => ({ type: 'Feature', properties: {}, geometry: boundsToGeoJSON(box) as GeoJSON.Geometry })),
+});
 
 // Anything this draws with, which is three kinds of layer over the same kind of source
 type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerSpecification;
@@ -309,7 +311,7 @@ const repaint = (map: Map, layer: DrawnLayer) => {
 /**
  * Put everything an overview draws on the map, and from then on change it where it stands.
  *
- * Bottom to top: the area being searched, the extent of the selected result, and the markers. That
+ * Bottom to top: the area being searched, the extents of the highlighted results, and the markers. That
  * order is settled the first time this runs and kept by never taking any of it off again - addLayer
  * appends, so a layer put back on would come back above whatever had been added over it.
  *
@@ -326,17 +328,16 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
   // Before the layer that names them, so that no frame asks for a picture that isn't there yet
   syncMarkerImages(map, style, numbers);
 
-  drawInto(map, SEARCH_BOUNDS, boundsData(searchBounds), boundsLayers(SEARCH_BOUNDS, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity }));
+  drawInto(map, SEARCH_BOUNDS, boundsData([searchBounds]), boundsLayers(SEARCH_BOUNDS, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity }));
 
-  // Nothing for a selection that landed on a result nobody could place. That is the truth rather than
+  // Nothing for a highlight that landed on a result nobody could place. That is the truth rather than
   // a gap: there is no number on the map to bring forward and no extent to draw around.
-  const extent = highlighted === undefined ? undefined : extents[highlighted - 1];
+  const marked = (highlighted ?? []).map(place => extents[place - 1]).map(extent => (extent ? LngLatBounds.convert(extent) : undefined));
 
-  // The colors a selected feature is drawn in rather than a hovered one. A hover is what points at
-  // it, but what it says is that this is the result being read - and it is drawn at the opacity any
-  // called-out feature gets, which is what InspectableRasterPreviewer draws a selection at too.
-  const selected = { color: style.selectedColor, strokeColor: style.strokeSelectedColor, opacity: style.highlightOpacity };
-  drawInto(map, SELECTED_BOUNDS, boundsData(extent ? LngLatBounds.convert(extent) : undefined), boundsLayers(SELECTED_BOUNDS, selected));
+  // The colors a hovered feature is drawn in, since being pointed at is what is being said - whether
+  // the pointer is over the number itself or over something outside that names the result
+  const highlight = { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity };
+  drawInto(map, HIGHLIGHT_BOUNDS, boundsData(marked), boundsLayers(HIGHLIGHT_BOUNDS, highlight));
 
   drawInto(map, RESULT_NUMBERS, numbers, [resultMarkersLayer()]);
 };
@@ -367,7 +368,7 @@ const syncMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.Featu
     const label = String(properties?.label);
     return [
       { id: markerImageId(label, style), label, color: style.markerColor },
-      { id: markerImageId(label, style, true), label, color: style.markerSelectedColor },
+      { id: markerImageId(label, style, true), label, color: style.markerHighlightColor },
     ];
   });
 

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -2,6 +2,7 @@ import {
   LngLatBounds,
   type ExpressionSpecification,
   type FillLayerSpecification,
+  type GeoJSONSource,
   type LineLayerSpecification,
   type LngLatBoundsLike,
   type Map,
@@ -18,13 +19,15 @@ import type { MapLibreStyle } from './themes/maplibre';
 export const RESULT_NUMBERS = 'ogm-result-numbers';
 export const RESULT_MARKERS = `${RESULT_NUMBERS}-markers`;
 
-// What an image of one marker is called. One per number on the map, plus one more for the number
-// something outside has pointed at, which is drawn as a selection; see markerImage.
-export const MARKER_IMAGE = 'ogm-result-marker';
+// What an image of one marker is called. Two per number on the map: the picture of that number, and
+// the picture of it selected. Both are drawn whether anything has pointed at it or not, so that a
+// highlight arriving changes no pictures at all; see syncMarkerImages.
+const MARKER_IMAGE = 'ogm-result-marker';
 
 // The two boxes drawn under the numbers: the area a search is filtered to, and the extent of the
 // result something outside has pointed at. A source each rather than two features of one, because they
 // are two different statements about the map, drawn in different colors, arriving at different times.
+// Both stay on the map once drawn, holding nothing when there is nothing to say; see drawInto.
 export const SEARCH_BOUNDS = 'ogm-search-bounds';
 export const SELECTED_BOUNDS = 'ogm-selected-bounds';
 
@@ -86,7 +89,7 @@ type BoxColors = { color: string; strokeColor: string; opacity: number };
  * touches, and with collision turned off below there is nothing left to suppress the copies. A
  * country-sized box would wear its number three or four times.
  */
-export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highlighted?: number): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
+export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], style: MapLibreStyle, highlighted?: number): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
   type: 'FeatureCollection',
   features: extents.flatMap((extent, index) => {
     if (!extent) return [];
@@ -102,15 +105,32 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highl
         type: 'Feature' as const,
         // The image each one is drawn as, named on the feature rather than worked out in an
         // expression, so there is one place that decides which marker wears which picture.
-        properties: { label, selected, icon: markerImageId(label, selected) },
+        properties: { label, selected, icon: markerImageId(label, style, selected) },
         geometry: { type: 'Point' as const, coordinates: [lng, lat] },
       },
     ];
   }),
 });
 
-// What the image for one marker is called
-export const markerImageId = (label: string, selected: boolean = false): string => `${MARKER_IMAGE}${selected ? '-selected' : ''}-${label}`;
+/**
+ * What the image for one marker is called: the number it shows, and everything that decides how it
+ * looks.
+ *
+ * The whole look is in the name because that is what makes a picture safe to keep. A name that said
+ * only which marker it was would be reused after a theme swap and the map would go on wearing the last
+ * palette's discs: MapLibre carries images across setStyle, since it diffs the new style document
+ * against the old one and the diff has nothing to say about images. Named this way, a new palette asks
+ * for names that aren't there, gets fresh pictures, and leaves the old names to be taken away - and
+ * everything else, which is most redraws, asks for the names already on the map. See syncMarkerImages.
+ */
+export const markerImageId = (label: string, style: MapLibreStyle, selected: boolean = false): string =>
+  [MARKER_IMAGE, selected ? 'selected' : 'plain', markerLook(style, selected), label].join('-');
+
+// What a marker's picture depends on, in a form a name can carry: the color of the disc, the size of
+// the numeral, and the font it is set in. Word characters only, since this ends up in an id - and it is
+// only ever compared with itself, so what it drops costs nothing.
+const markerLook = (style: MapLibreStyle, selected: boolean): string =>
+  [selected ? style.markerSelectedColor : style.markerColor, style.textSize, style.markerFont].join('-').replace(/[^\w-]+/g, '');
 
 /**
  * The one layer every marker is drawn from: an image apiece, and nothing else.
@@ -241,73 +261,122 @@ const boundsLayers = (id: string, { color, strokeColor, opacity }: BoxColors): [
   },
 ];
 
-const addBounds = (map: Map, id: string, bounds: LngLatBounds, colors: BoxColors) => {
-  map.addSource(id, { type: 'geojson', data: { type: 'Feature', properties: {}, geometry: boundsToGeoJSON(bounds) as GeoJSON.Geometry } });
-  for (const layer of boundsLayers(id, colors)) map.addLayer(layer);
+// Nothing to say, in the form MapLibre takes it in. A box that isn't there stays on the map as a
+// source with no features in it rather than coming off, which is what lets the two layers that read it
+// stay on as well; see drawInto.
+const NOTHING: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+const boundsData = (bounds: LngLatBounds | undefined): GeoJSON.GeoJSON =>
+  bounds ? { type: 'Feature', properties: {}, geometry: boundsToGeoJSON(bounds) as GeoJSON.Geometry } : NOTHING;
+
+// Anything this draws with, which is three kinds of layer over the same kind of source
+type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerSpecification;
+
+/**
+ * New data into a source already on the map - or the source, and the layers that read it, if this is
+ * the first thing drawn into this style document.
+ *
+ * Which is the whole of what keeps a redraw from flashing. removeSource drops a source's tiles the
+ * moment it is called, so a redraw that begins by taking everything off has nothing to draw until a
+ * worker has parsed the new data and placed it again: several frames, every one of them missing
+ * whatever was there. setData marks the tiles for reloading and leaves them up, so what is on screen
+ * stays on screen until there is something to put in its place.
+ *
+ * The paint goes on again for a source that was already there, so a layer says the same thing however
+ * this was reached: these colors come out of the theme, and a theme can change under a map that has
+ * already been drawn. What can't be said twice is the order - addLayer appends, so the order these
+ * first went on in is the order they keep, and it is fixed by drawResults below.
+ */
+const drawInto = (map: Map, id: string, data: GeoJSON.GeoJSON, layers: DrawnLayer[]) => {
+  const source = map.getSource(id) as GeoJSONSource | undefined;
+
+  if (!source) {
+    map.addSource(id, { type: 'geojson', data });
+    for (const layer of layers) map.addLayer(layer);
+    return;
+  }
+
+  source.setData(data);
+  for (const layer of layers) repaint(map, layer);
+};
+
+// A layer's colors again. A no-op for the markers, which carry no paint at all: what a marker is drawn
+// in is in the picture.
+const repaint = (map: Map, layer: DrawnLayer) => {
+  for (const [property, value] of Object.entries(layer.paint ?? {})) map.setPaintProperty(layer.id, property, value);
 };
 
 /**
- * Put everything an overview draws on the map, in the order it has to be drawn in.
+ * Put everything an overview draws on the map, and from then on change it where it stands.
  *
- * Bottom to top: the area being searched, the extent of the selected result, and the markers. All
- * of it comes off and goes back on rather than being changed in place, because addLayer appends and
- * there is no other way to say which of these sits over which. Nothing here reaches the network - the
- * markers are drawn on a canvas and the boxes are two shapes - so moving the selection costs a handful
- * of style layers and as many small pictures as there are results.
+ * Bottom to top: the area being searched, the extent of the selected result, and the markers. That
+ * order is settled the first time this runs and kept by never taking any of it off again - addLayer
+ * appends, so a layer put back on would come back above whatever had been added over it.
+ *
+ * Changed rather than rebuilt, because rebuilding flashes, and the reader sees it: a highlight moves
+ * with the pointer down a list of results, so a set of markers that blinks once per redraw blinks the
+ * whole way down the page. Two things did it. Taking the sources off dropped their tiles on the spot -
+ * see drawInto - and taking the markers' pictures off had MapLibre place every symbol on the map over
+ * again, ours and the basemap's labels with them. So nothing comes off: a highlight arriving is two
+ * calls to setData, and it touches no layer and no picture at all.
  */
 export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlighted, searchBounds }: DrawnResults) => {
-  clearResults(map);
+  const numbers = numberedResults(extents, style, highlighted);
 
-  if (searchBounds) {
-    addBounds(map, SEARCH_BOUNDS, searchBounds, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity });
-  }
+  // Before the layer that names them, so that no frame asks for a picture that isn't there yet
+  syncMarkerImages(map, style, numbers);
+
+  drawInto(map, SEARCH_BOUNDS, boundsData(searchBounds), boundsLayers(SEARCH_BOUNDS, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity }));
 
   // Nothing for a selection that landed on a result nobody could place. That is the truth rather than
   // a gap: there is no number on the map to bring forward and no extent to draw around.
   const extent = highlighted === undefined ? undefined : extents[highlighted - 1];
-  if (extent) {
-    // The colors a selected feature is drawn in rather than a hovered one. A hover is what points at
-    // it, but what it says is that this is the result being read - and it is drawn at the opacity any
-    // called-out feature gets, which is what InspectableRasterPreviewer draws a selection at too.
-    addBounds(map, SELECTED_BOUNDS, LngLatBounds.convert(extent), { color: style.selectedColor, strokeColor: style.strokeSelectedColor, opacity: style.highlightOpacity });
-  }
 
-  const numbers = numberedResults(extents, highlighted);
-  addMarkerImages(map, style, numbers);
-  map.addSource(RESULT_NUMBERS, { type: 'geojson', data: numbers });
-  map.addLayer(resultMarkersLayer());
+  // The colors a selected feature is drawn in rather than a hovered one. A hover is what points at
+  // it, but what it says is that this is the result being read - and it is drawn at the opacity any
+  // called-out feature gets, which is what InspectableRasterPreviewer draws a selection at too.
+  const selected = { color: style.selectedColor, strokeColor: style.strokeSelectedColor, opacity: style.highlightOpacity };
+  drawInto(map, SELECTED_BOUNDS, boundsData(extent ? LngLatBounds.convert(extent) : undefined), boundsLayers(SELECTED_BOUNDS, selected));
+
+  drawInto(map, RESULT_NUMBERS, numbers, [resultMarkersLayer()]);
 };
-
-// A picture for every marker about to be drawn, in the colors the theme is currently in. Added rather
-// than reused, because clearResults has just taken the last set away: a theme swap changes what these
-// look like, and holding onto one drawn in the old palette would put a marker from the last theme on
-// the map. A DOM with no canvas in it draws none of them and the markers come out empty, which is a
-// map missing its numbers rather than a map that failed to open; see markerImage.
-const addMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.FeatureCollection<GeoJSON.Point>) => {
-  const ratio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
-
-  for (const { properties } of numbers.features) {
-    const { label, selected, icon } = properties as { label: string; selected: boolean; icon: string };
-    const image = markerImage(label, selected ? style.markerSelectedColor : style.markerColor, style, ratio);
-    if (image) map.addImage(icon, image, { pixelRatio: Math.min(ratio, MAX_PIXEL_RATIO) });
-  }
-};
-
-// Every layer this draws, and every source under them. The layers go first: a source can't be taken
-// off the map while a layer is still reading it.
-const RESULT_LAYERS = [...[SEARCH_BOUNDS, SELECTED_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]), RESULT_MARKERS];
-const RESULT_SOURCES = [SEARCH_BOUNDS, SELECTED_BOUNDS, RESULT_NUMBERS];
 
 /**
- * Take all of it back off, pictures included.
+ * Both pictures of every marker that could be drawn, in the colors the theme is currently in.
  *
- * Guarded every way: a theme swap empties the style document without asking, so what this last drew
- * may already be gone - and the images go with it, since they live on the style rather than on the map.
- * The pictures are found by name rather than remembered, so a set left behind by a draw nobody
- * finished is taken away too.
+ * Both, whether or not anything has pointed at that number, so that which one a marker wears is a
+ * property of the feature rather than a picture that has to be swapped for it. That is why a highlight
+ * costs nothing: addImage and removeImage each invalidate the icon atlas, which has MapLibre place
+ * every symbol on the map over again, so changing one marker's picture would cost a frame of every
+ * marker on it. Two canvases per result instead, once.
+ *
+ * Which pictures are already there is read off the map rather than remembered, and the names carry the
+ * whole look - see markerImageId - so a picture is reused exactly when it would have been drawn the
+ * same. Both ways a set of pictures goes stale end up here: a theme swap asks for names that aren't on
+ * the map yet, and what it leaves behind is unwanted; so is the tail of a set of results that has been
+ * replaced by a shorter one. Unwanted pictures are found by our own prefix, so a set left by a draw
+ * nobody finished goes with them and nobody else's images are touched.
+ *
+ * A DOM with no canvas in it draws none of them and the markers come out empty, which is a map missing
+ * its numbers rather than a map that failed to open; see markerImage.
  */
-export const clearResults = (map: Map) => {
-  for (const id of RESULT_LAYERS) if (map.getLayer(id)) map.removeLayer(id);
-  for (const id of RESULT_SOURCES) if (map.getSource(id)) map.removeSource(id);
-  for (const id of map.listImages()) if (id.startsWith(MARKER_IMAGE)) map.removeImage(id);
+const syncMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.FeatureCollection<GeoJSON.Point>) => {
+  const ratio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+
+  const wanted = numbers.features.flatMap(({ properties }) => {
+    const label = String(properties?.label);
+    return [
+      { id: markerImageId(label, style), label, color: style.markerColor },
+      { id: markerImageId(label, style, true), label, color: style.markerSelectedColor },
+    ];
+  });
+
+  const keep = new Set(wanted.map(({ id }) => id));
+  for (const id of map.listImages()) if (id.startsWith(MARKER_IMAGE) && !keep.has(id)) map.removeImage(id);
+
+  for (const { id, label, color } of wanted) {
+    if (map.hasImage(id)) continue;
+    const image = markerImage(label, color, style, ratio);
+    if (image) map.addImage(id, image, { pixelRatio: Math.min(ratio, MAX_PIXEL_RATIO) });
+  }
 };

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -55,7 +55,12 @@ const NUMBER_HALO = 1;
 // How much room each number clears around itself, in pixels; MapLibre's own default is 2. Nothing
 // culls one of ours - see resultNumbersLayers - so this only ever pushes the basemap's own labels out
 // from under them, which is the one kind of overlap here worth spending anything on.
-const NUMBER_PADDING = 4;
+//
+// Roughly the difference between the numeral and the disc it sits on, because the box this pads is the
+// numeral's: the disc is a circle layer, and circles take no part in the collision grid at all. At
+// MapLibre's default of 2 a basemap label could sit under the disc's own rim while clearing the digits
+// inside it, which reads as a label with a marker dropped on it.
+const NUMBER_PADDING = 8;
 
 // Everything an overview draws, gathered in one place because the order it goes onto the map in is
 // most of what keeps it readable.

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -19,20 +19,22 @@ export const RESULT_NUMBERS = 'ogm-result-numbers';
 export const RESULT_MARKERS = `${RESULT_NUMBERS}-markers`;
 
 // What an image of one marker is called. One per number on the map, plus one more for the number
-// something outside has asked to highlight; see markerImage.
+// something outside has pointed at, which is drawn as a selection; see markerImage.
 export const MARKER_IMAGE = 'ogm-result-marker';
 
 // The two boxes drawn under the numbers: the area a search is filtered to, and the extent of the
-// highlighted result. A source each rather than two features of one, because they are two different
-// statements about the map, drawn in different colors, arriving at different times.
+// result something outside has pointed at. A source each rather than two features of one, because they
+// are two different statements about the map, drawn in different colors, arriving at different times.
 export const SEARCH_BOUNDS = 'ogm-search-bounds';
-export const HIGHLIGHT_BOUNDS = 'ogm-highlight-bounds';
+export const SELECTED_BOUNDS = 'ogm-selected-bounds';
 
-// How much bigger a result's number is drawn than a label on a feature. Deliberately not themed,
-// for the reason LocationPreviewer's FILL_OPACITY isn't: this is the relationship between a number
-// read against a whole globe and the text drawn beside a feature, not a value an embedding app has
-// a reason to name. Setting --ogm-text-size still moves both together.
-const NUMBER_SIZE = 1.5;
+// How big a result's number is drawn, against the size of a label on a feature. A little larger, and
+// no more: a marker is read at a glance rather than studied, and a page of twenty of them covers more
+// of the map than it says anything about. Deliberately not themed, for the reason LocationPreviewer's
+// FILL_OPACITY isn't - this is the relationship between a number and the text drawn beside a feature,
+// not a value an embedding app has a reason to name. Setting --ogm-text-size still moves both
+// together, and the disc follows the number.
+const NUMBER_SIZE = 1.05;
 
 // How wide the disc behind a number is, as a multiple of the number's own size. One size for every
 // marker, whatever it says and however far the map is zoomed: these are read as a set, and a set of
@@ -52,23 +54,24 @@ const NUMERAL_WIDTH = 0.72;
 // drawing for; past it the image is memory spent on detail nothing can show.
 const MAX_PIXEL_RATIO = 2;
 
-// Where the highlighted marker sorts. Above every other, which are sorted at minus their own number:
+// Where the selected marker sorts. Above every other, which are sorted at minus their own number:
 // see resultMarkersLayer.
-const HIGHLIGHT_SORT_KEY = 1;
+const SELECTED_SORT_KEY = 1;
 
 // Everything an overview draws, gathered in one place because the order it goes onto the map in is
 // most of what keeps it readable.
 export type DrawnResults = {
   // Where every result is, in the order they were given, including the ones nobody could place
   extents: (LngLatBoundsLike | undefined)[];
-  // Which of those results is highlighted, as its place in that list counted from one
+  // Which of those results something outside has pointed at, as its place in that list counted from
+  // one. It is drawn as a selection rather than as a hover: see drawResults.
   highlighted?: number;
   // The area a search is currently filtered to, if one is
   searchBounds?: LngLatBounds;
 };
 
 // What a box is drawn in. The two of them differ in nothing else, so this is the whole of the
-// difference between the area being searched and the extent of the highlighted result.
+// difference between the area being searched and the extent of the result being pointed at.
 type BoxColors = { color: string; strokeColor: string; opacity: number };
 
 /**
@@ -92,14 +95,14 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highl
     // longitude from outside -180..180 everywhere it takes one, so there is nothing to wrap back.
     const { lng, lat } = LngLatBounds.convert(extent).getCenter();
     const label = String(index + 1);
-    const marked = index + 1 === highlighted;
+    const selected = index + 1 === highlighted;
 
     return [
       {
         type: 'Feature' as const,
         // The image each one is drawn as, named on the feature rather than worked out in an
         // expression, so there is one place that decides which marker wears which picture.
-        properties: { label, highlighted: marked, icon: markerImageId(label, marked) },
+        properties: { label, selected, icon: markerImageId(label, selected) },
         geometry: { type: 'Point' as const, coordinates: [lng, lat] },
       },
     ];
@@ -107,7 +110,7 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highl
 });
 
 // What the image for one marker is called
-export const markerImageId = (label: string, highlighted: boolean = false): string => `${MARKER_IMAGE}${highlighted ? '-highlight' : ''}-${label}`;
+export const markerImageId = (label: string, selected: boolean = false): string => `${MARKER_IMAGE}${selected ? '-selected' : ''}-${label}`;
 
 /**
  * The one layer every marker is drawn from: an image apiece, and nothing else.
@@ -143,14 +146,14 @@ export const resultMarkersLayer = (): SymbolLayerSpecification => ({
     // Earlier results on top, so counting down the list beside the map is counting away from the
     // reader: the first result is the one a page put first, and it stays over the twentieth however the
     // map is panned. A higher key draws over a lower one, so the key is the number negated - and the
-    // highlighted one, which something outside has pointed at, sorts above all of them. Without a key
-    // at all MapLibre orders these by where they land on screen, and they restack as the map moves,
-    // which reads as the numbers rearranging themselves.
+    // selected one, which something outside has pointed at, sorts above all of them. Without a key at
+    // all MapLibre orders these by where they land on screen, and they restack as the map moves, which
+    // reads as the numbers rearranging themselves.
     'symbol-sort-key': markerSortKey,
   },
 });
 
-const markerSortKey: ExpressionSpecification = ['case', ['get', 'highlighted'], HIGHLIGHT_SORT_KEY, ['-', 0, ['to-number', ['get', 'label']]]];
+const markerSortKey: ExpressionSpecification = ['case', ['get', 'selected'], SELECTED_SORT_KEY, ['-', 0, ['to-number', ['get', 'label']]]];
 
 /**
  * A disc with a numeral centered on it, as pixels MapLibre can draw as an icon.
@@ -246,10 +249,10 @@ const addBounds = (map: Map, id: string, bounds: LngLatBounds, colors: BoxColors
 /**
  * Put everything an overview draws on the map, in the order it has to be drawn in.
  *
- * Bottom to top: the area being searched, the extent of the highlighted result, and the markers. All
+ * Bottom to top: the area being searched, the extent of the selected result, and the markers. All
  * of it comes off and goes back on rather than being changed in place, because addLayer appends and
  * there is no other way to say which of these sits over which. Nothing here reaches the network - the
- * markers are drawn on a canvas and the boxes are two shapes - so moving one highlight costs a handful
+ * markers are drawn on a canvas and the boxes are two shapes - so moving the selection costs a handful
  * of style layers and as many small pictures as there are results.
  */
 export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlighted, searchBounds }: DrawnResults) => {
@@ -259,11 +262,14 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
     addBounds(map, SEARCH_BOUNDS, searchBounds, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity });
   }
 
-  // Nothing for a highlight that landed on a result nobody could place. That is the truth rather than
+  // Nothing for a selection that landed on a result nobody could place. That is the truth rather than
   // a gap: there is no number on the map to bring forward and no extent to draw around.
   const extent = highlighted === undefined ? undefined : extents[highlighted - 1];
   if (extent) {
-    addBounds(map, HIGHLIGHT_BOUNDS, LngLatBounds.convert(extent), { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity });
+    // The colors a selected feature is drawn in rather than a hovered one. A hover is what points at
+    // it, but what it says is that this is the result being read - and it is drawn at the opacity any
+    // called-out feature gets, which is what InspectableRasterPreviewer draws a selection at too.
+    addBounds(map, SELECTED_BOUNDS, LngLatBounds.convert(extent), { color: style.selectedColor, strokeColor: style.strokeSelectedColor, opacity: style.highlightOpacity });
   }
 
   const numbers = numberedResults(extents, highlighted);
@@ -281,16 +287,16 @@ const addMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.Featur
   const ratio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
 
   for (const { properties } of numbers.features) {
-    const { label, highlighted, icon } = properties as { label: string; highlighted: boolean; icon: string };
-    const image = markerImage(label, highlighted ? style.markerHighlightColor : style.markerColor, style, ratio);
+    const { label, selected, icon } = properties as { label: string; selected: boolean; icon: string };
+    const image = markerImage(label, selected ? style.markerSelectedColor : style.markerColor, style, ratio);
     if (image) map.addImage(icon, image, { pixelRatio: Math.min(ratio, MAX_PIXEL_RATIO) });
   }
 };
 
 // Every layer this draws, and every source under them. The layers go first: a source can't be taken
 // off the map while a layer is still reading it.
-const RESULT_LAYERS = [...[SEARCH_BOUNDS, HIGHLIGHT_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]), RESULT_MARKERS];
-const RESULT_SOURCES = [SEARCH_BOUNDS, HIGHLIGHT_BOUNDS, RESULT_NUMBERS];
+const RESULT_LAYERS = [...[SEARCH_BOUNDS, SELECTED_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]), RESULT_MARKERS];
+const RESULT_SOURCES = [SEARCH_BOUNDS, SELECTED_BOUNDS, RESULT_NUMBERS];
 
 /**
  * Take all of it back off, pictures included.

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -1,10 +1,7 @@
 import {
   LngLatBounds,
-  type CircleLayerSpecification,
-  type DataDrivenPropertyValueSpecification,
   type ExpressionSpecification,
   type FillLayerSpecification,
-  type FilterSpecification,
   type LineLayerSpecification,
   type LngLatBoundsLike,
   type Map,
@@ -16,11 +13,14 @@ import { FILL_OPACITY } from './previewers/location';
 import { contrastColor } from './themes/color';
 import type { MapLibreStyle } from './themes/maplibre';
 
-// The one source that carries the result numbers, and the two pairs of layers that draw them: the
-// results as they were given, and the one something outside has asked to highlight. Not derived from
+// The source that carries the result numbers and the one layer that draws them. Not derived from
 // anything - there is exactly one set of these on a map, however many results are drawn on it.
 export const RESULT_NUMBERS = 'ogm-result-numbers';
-export const RESULT_HIGHLIGHT = `${RESULT_NUMBERS}-highlight`;
+export const RESULT_MARKERS = `${RESULT_NUMBERS}-markers`;
+
+// What an image of one marker is called. One per number on the map, plus one more for the number
+// something outside has asked to highlight; see markerImage.
+export const MARKER_IMAGE = 'ogm-result-marker';
 
 // The two boxes drawn under the numbers: the area a search is filtered to, and the extent of the
 // highlighted result. A source each rather than two features of one, because they are two different
@@ -32,35 +32,29 @@ export const HIGHLIGHT_BOUNDS = 'ogm-highlight-bounds';
 // for the reason LocationPreviewer's FILL_OPACITY isn't: this is the relationship between a number
 // read against a whole globe and the text drawn beside a feature, not a value an embedding app has
 // a reason to name. Setting --ogm-text-size still moves both together.
-//
-// It is also all the weight a number gets. `text-font` names a fontstack the basemap's own glyph
-// endpoint has to serve rather than a CSS font stack, so there is no Bold to ask for: a stack CARTO
-// doesn't serve draws nothing at all. The size, the disc under it and the halo are what make these
-// read as bold.
 const NUMBER_SIZE = 1.5;
 
-// How wide the disc behind a number is, as a multiple of the number's own size: room for one digit,
-// then for two, then for anything longer. Stepped rather than grown smoothly with the label, because
-// a page of eight results would otherwise wear eight slightly different discs and read as eight
-// different kinds of thing. Not themed, for the same reason NUMBER_SIZE isn't.
-const NUMBER_RADIUS = [0.7, 0.9, 1.15];
+// How wide the disc behind a number is, as a multiple of the number's own size. One size for every
+// marker, whatever it says and however far the map is zoomed: these are read as a set, and a set of
+// discs that are not the same size reads as a set of different things. A number too long for the disc
+// is drawn smaller rather than given a bigger one - see markerImage.
+const MARKER_RADIUS = 1.05;
 
-// The ring around a disc and the edge on the numeral inside it, in pixels. The same two the rest of
-// the library draws with: a location's outline is 2 and a feature label's halo is 1. The ring is what
-// holds a disc apart from the basemap and from the disc beside it, which is the halo's job done for
-// a shape.
-const NUMBER_STROKE = 2;
-const NUMBER_HALO = 1;
+// The ring around a disc, in CSS pixels. The same width a location's outline is drawn at. It is what
+// holds a disc apart from the basemap, and from the disc beside it when two results overlap.
+const MARKER_RING = 2;
 
-// How much room each number clears around itself, in pixels; MapLibre's own default is 2. Nothing
-// culls one of ours - see resultNumbersLayers - so this only ever pushes the basemap's own labels out
-// from under them, which is the one kind of overlap here worth spending anything on.
-//
-// Roughly the difference between the numeral and the disc it sits on, because the box this pads is the
-// numeral's: the disc is a circle layer, and circles take no part in the collision grid at all. At
-// MapLibre's default of 2 a basemap label could sit under the disc's own rim while clearing the digits
-// inside it, which reads as a label with a marker dropped on it.
-const NUMBER_PADDING = 8;
+// How much of the disc a numeral is allowed to fill across. Past this the numeral is drawn smaller,
+// which is what keeps a four-digit result inside the same disc as a one-digit one.
+const NUMERAL_WIDTH = 0.72;
+
+// The most a disc is drawn at, however many pixels the display has. Two is every screen worth
+// drawing for; past it the image is memory spent on detail nothing can show.
+const MAX_PIXEL_RATIO = 2;
+
+// Where the highlighted marker sorts. Above every other, which are sorted at minus their own number:
+// see resultMarkersLayer.
+const HIGHLIGHT_SORT_KEY = 1;
 
 // Everything an overview draws, gathered in one place because the order it goes onto the map in is
 // most of what keeps it readable.
@@ -97,112 +91,129 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highl
     // 180 - see unwrapEast - is centered on the Pacific rather than on Greenwich. MapLibre reads a
     // longitude from outside -180..180 everywhere it takes one, so there is nothing to wrap back.
     const { lng, lat } = LngLatBounds.convert(extent).getCenter();
+    const label = String(index + 1);
+    const marked = index + 1 === highlighted;
+
     return [
       {
         type: 'Feature' as const,
-        // Marked on every point rather than only on the one that has it. Two pairs of layers select
-        // on this from opposite sides, and a filter that reads as a plain comparison against
-        // something every feature carries is worth the two bytes it costs.
-        properties: { label: String(index + 1), highlighted: index + 1 === highlighted },
+        // The image each one is drawn as, named on the feature rather than worked out in an
+        // expression, so there is one place that decides which marker wears which picture.
+        properties: { label, highlighted: marked, icon: markerImageId(label, marked) },
         geometry: { type: 'Point' as const, coordinates: [lng, lat] },
       },
     ];
   }),
 });
 
+// What the image for one marker is called
+export const markerImageId = (label: string, highlighted: boolean = false): string => `${MARKER_IMAGE}${highlighted ? '-highlight' : ''}-${label}`;
+
 /**
- * A disc with a numeral on it, in the two style layers it takes to draw one.
+ * The one layer every marker is drawn from: an image apiece, and nothing else.
  *
- * A symbol layer has no background to put behind its text, so the disc is a circle layer of its own
- * underneath, reading the same source. Two of these pairs go on a map, selecting on the same property
- * from opposite sides, and the highlighted one goes on last. A `case` expression in each paint
- * property would color the highlighted marker in place, but it could not lift it: a symbol layer
- * draws all of its text after all of its icons, and layers draw in the order they were added, so
- * within one pair there is no arrangement that puts one feature's disc and its number together above
- * its neighbours'. Only a later pair does that.
+ * A disc with a numeral on it, drawn as one picture rather than as a circle with text over it. Two
+ * layers would be the obvious way and it cannot be made to work: a symbol layer draws all of its text
+ * after all of its icons, and a circle layer draws every circle before any layer above it, so with the
+ * numbers in a layer of their own *every* number lands over *every* disc - including its neighbour's.
+ * One image per marker is what makes overlapping markers read as markers: whichever is on top covers
+ * the one under it whole, disc and number together, which is the only arrangement in which a number is
+ * always the one thing you can see of the marker it belongs to.
  *
- * Neither pair is ever culled. A number that isn't there is worse than one that overlaps, because the
- * list beside the map is counting on every one of them being findable. What is deliberately not asked
- * for is `text-ignore-placement`: keeping our numbers out of the collision grid would leave the
- * basemap's own labels free to draw underneath them, which is the most cluttered thing they could sit
- * on. In the grid, a basemap label that collides with a number is dropped instead - and ours still
- * can't be dropped, because allowing overlap skips the hit test for them entirely and placement runs
- * from the top layer down, so these are placed before anything the basemap wanted that space for.
+ * It is also what makes the size of a disc ours rather than MapLibre's, and what lets a numeral be
+ * bold: `text-font` names a fontstack the basemap's glyph endpoint has to serve, and a stack CARTO
+ * doesn't serve draws nothing at all, so nothing asked of MapLibre could be.
+ *
+ * Nothing is ever culled. A number that isn't there is worse than one that overlaps, because the list
+ * beside the map is counting on every one of them being findable. What is deliberately not asked for
+ * is `icon-ignore-placement`: keeping our markers out of the collision grid would leave the basemap's
+ * own labels free to draw underneath them, which is the most cluttered thing they could sit on. In the
+ * grid a basemap label that collides with a marker is dropped instead - and ours still can't be,
+ * because allowing overlap skips the hit test for them entirely and placement runs from the top layer
+ * down, so these are placed before anything the basemap wanted that space for.
  */
-export const resultNumbersLayers = (style: MapLibreStyle, highlighted: boolean = false): [CircleLayerSpecification, SymbolLayerSpecification] => {
-  const id = highlighted ? RESULT_HIGHLIGHT : RESULT_NUMBERS;
-  const color = highlighted ? style.markerHighlightColor : style.markerColor;
-  const filter: FilterSpecification = highlighted ? ['==', ['get', 'highlighted'], true] : ['!=', ['get', 'highlighted'], true];
+export const resultMarkersLayer = (): SymbolLayerSpecification => ({
+  id: RESULT_MARKERS,
+  type: 'symbol' as const,
+  source: RESULT_NUMBERS,
+  layout: {
+    'visibility': 'visible' as const,
+    'icon-image': ['get', 'icon'] as const,
+    'icon-allow-overlap': true,
+    // Earlier results on top, so counting down the list beside the map is counting away from the
+    // reader: the first result is the one a page put first, and it stays over the twentieth however the
+    // map is panned. A higher key draws over a lower one, so the key is the number negated - and the
+    // highlighted one, which something outside has pointed at, sorts above all of them. Without a key
+    // at all MapLibre orders these by where they land on screen, and they restack as the map moves,
+    // which reads as the numbers rearranging themselves.
+    'symbol-sort-key': markerSortKey,
+  },
+});
+
+const markerSortKey: ExpressionSpecification = ['case', ['get', 'highlighted'], HIGHLIGHT_SORT_KEY, ['-', 0, ['to-number', ['get', 'label']]]];
+
+/**
+ * A disc with a numeral centered on it, as pixels MapLibre can draw as an icon.
+ *
+ * Drawn here rather than described to MapLibre because a marker has to be one picture; see
+ * resultMarkersLayer. Which also means the numeral is placed by measuring it: canvas centers text on
+ * the font's own box, and a digit - which has no descender to speak of - sits high in that box, so
+ * what is centered has to be the ink rather than the line it sits on.
+ *
+ * Drawn at the display's own pixel ratio and handed over with it, so a marker is as crisp as the map
+ * under it. Nothing comes back where there is nothing to draw on - a DOM without a canvas behind it,
+ * or no DOM at all - and the caller carries on without the picture rather than without the map.
+ */
+export const markerImage = (label: string, color: string, style: MapLibreStyle, pixelRatio: number): { width: number; height: number; data: Uint8ClampedArray } | undefined => {
   const size = style.textSize * NUMBER_SIZE;
+  const radius = size * MARKER_RADIUS;
+  const box = Math.ceil((radius + MARKER_RING) * 2);
+  const scale = Math.min(pixelRatio, MAX_PIXEL_RATIO);
 
-  // Earlier results on top, so counting down the list beside the map is counting away from the
-  // reader: the first result is the one a page put first, and it stays over the twentieth however the
-  // map is panned. Both properties draw a higher key over a lower one, so the key is the number
-  // negated. Without one at all, MapLibre orders symbols by where they land on screen, and they
-  // restack as the map moves - which reads as the numbers rearranging themselves.
-  const sortKey: ExpressionSpecification = ['-', 0, ['to-number', ['get', 'label']]];
+  if (typeof document === 'undefined') return undefined;
 
-  // Room for the digits, in the three sizes a page of results can need
-  const radius: DataDrivenPropertyValueSpecification<number> = [
-    'step',
-    ['length', ['get', 'label']],
-    size * NUMBER_RADIUS[0],
-    2,
-    size * NUMBER_RADIUS[1],
-    3,
-    size * NUMBER_RADIUS[2],
-  ];
+  const canvas = document.createElement('canvas');
+  canvas.width = box * scale;
+  canvas.height = box * scale;
 
-  return [
-    {
-      id: `${id}-circle`,
-      type: 'circle' as const,
-      source: RESULT_NUMBERS,
-      filter,
-      layout: {
-        'visibility': 'visible' as const,
-        'circle-sort-key': sortKey,
-      },
-      paint: {
-        'circle-color': color,
-        'circle-radius': radius,
-        // The ink the numeral is drawn in, so a disc reads as one shape with a rim rather than as a
-        // disc with a halo of its own. One color that holds up on either basemap, and the thing that
-        // keeps two overlapping discs from reading as one.
-        'circle-stroke-color': contrastColor(color) || style.textHaloColor,
-        'circle-stroke-width': NUMBER_STROKE,
-        // No opacity asked for, here or on the numbers. Everything else this map draws is a note
-        // about where to look and starts faint so the basemap can be read through it; a number is
-        // the thing being read, and there is nothing under it worth seeing.
-      },
-    },
-    {
-      id: `${id}-label`,
-      type: 'symbol' as const,
-      source: RESULT_NUMBERS,
-      filter,
-      layout: {
-        'visibility': 'visible' as const,
-        'text-field': ['get', 'label'] as const,
-        'text-font': [style.textFont],
-        'text-size': size,
-        'text-allow-overlap': true,
-        'text-padding': NUMBER_PADDING,
-        'symbol-sort-key': sortKey,
-      },
-      paint: {
-        // Whichever of black and white can be read on the disc, rather than the theme's own text
-        // color, which is near-black in light mode and would disappear into it. The disc is derived
-        // to a depth that makes this white; see MapLibreTheme.markerColor.
-        'text-color': contrastColor(color) || style.textHaloColor,
-        // The disc's own color, not the theme's halo: on a disc there is nothing left for white to
-        // hold the numeral apart from, and an edge in the disc's color is what keeps a numeral from
-        // touching the ring around it.
-        'text-halo-color': color,
-        'text-halo-width': NUMBER_HALO,
-      },
-    },
-  ];
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+
+  context.scale(scale, scale);
+  const center = box / 2;
+
+  context.beginPath();
+  context.arc(center, center, radius, 0, Math.PI * 2);
+  context.fillStyle = color;
+  context.fill();
+  context.lineWidth = MARKER_RING;
+  // The same ink as the numeral, so a marker reads as one shape with a rim rather than as a disc with
+  // something drawn on it
+  context.strokeStyle = contrastColor(color) || style.textHaloColor;
+  context.stroke();
+
+  context.fillStyle = contrastColor(color) || style.textHaloColor;
+  context.textAlign = 'center';
+  context.textBaseline = 'alphabetic';
+  context.font = numeralFont(context, label, size, radius, style.markerFont);
+
+  // The middle of the ink, rather than the middle of the line box it was measured in
+  const metrics = context.measureText(label);
+  const ink = (metrics.actualBoundingBoxAscent ?? size * 0.7) - (metrics.actualBoundingBoxDescent ?? 0);
+  context.fillText(label, center, center + ink / 2);
+
+  return { width: canvas.width, height: canvas.height, data: context.getImageData(0, 0, canvas.width, canvas.height).data };
+};
+
+// The numeral at a size that fits the disc it sits on. Every disc is the same size, so a number long
+// enough to reach the rim is the thing that gives way: three digits still fill the disc, and a page
+// with a thousand results in it gets smaller numbers rather than bigger markers.
+const numeralFont = (context: CanvasRenderingContext2D, label: string, size: number, radius: number, family: string): string => {
+  const room = radius * 2 * NUMERAL_WIDTH;
+  context.font = `bold ${size}px ${family}`;
+  const width = context.measureText(label).width;
+
+  return width <= room ? context.font : `bold ${Math.floor((size * room) / width)}px ${family}`;
 };
 
 // A box, drawn the way LocationPreviewer draws a record's extent: a thin outline with a wash inside
@@ -235,11 +246,11 @@ const addBounds = (map: Map, id: string, bounds: LngLatBounds, colors: BoxColors
 /**
  * Put everything an overview draws on the map, in the order it has to be drawn in.
  *
- * Bottom to top: the area being searched, the extent of the highlighted result, the numbers, and the
- * highlighted number last of all. All of it comes off and goes back on rather than being changed in
- * place, because addLayer appends and there is no other way to say which of these sits over which.
- * Nothing here reaches the network, so moving one highlight costs a rebuild of eight style layers
- * and nothing else.
+ * Bottom to top: the area being searched, the extent of the highlighted result, and the markers. All
+ * of it comes off and goes back on rather than being changed in place, because addLayer appends and
+ * there is no other way to say which of these sits over which. Nothing here reaches the network - the
+ * markers are drawn on a canvas and the boxes are two shapes - so moving one highlight costs a handful
+ * of style layers and as many small pictures as there are results.
  */
 export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlighted, searchBounds }: DrawnResults) => {
   clearResults(map);
@@ -255,21 +266,42 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
     addBounds(map, HIGHLIGHT_BOUNDS, LngLatBounds.convert(extent), { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity });
   }
 
-  map.addSource(RESULT_NUMBERS, { type: 'geojson', data: numberedResults(extents, highlighted) });
-  for (const layer of [...resultNumbersLayers(style), ...resultNumbersLayers(style, true)]) map.addLayer(layer);
+  const numbers = numberedResults(extents, highlighted);
+  addMarkerImages(map, style, numbers);
+  map.addSource(RESULT_NUMBERS, { type: 'geojson', data: numbers });
+  map.addLayer(resultMarkersLayer());
+};
+
+// A picture for every marker about to be drawn, in the colors the theme is currently in. Added rather
+// than reused, because clearResults has just taken the last set away: a theme swap changes what these
+// look like, and holding onto one drawn in the old palette would put a marker from the last theme on
+// the map. A DOM with no canvas in it draws none of them and the markers come out empty, which is a
+// map missing its numbers rather than a map that failed to open; see markerImage.
+const addMarkerImages = (map: Map, style: MapLibreStyle, numbers: GeoJSON.FeatureCollection<GeoJSON.Point>) => {
+  const ratio = typeof window === 'undefined' ? 1 : window.devicePixelRatio || 1;
+
+  for (const { properties } of numbers.features) {
+    const { label, highlighted, icon } = properties as { label: string; highlighted: boolean; icon: string };
+    const image = markerImage(label, highlighted ? style.markerHighlightColor : style.markerColor, style, ratio);
+    if (image) map.addImage(icon, image, { pixelRatio: Math.min(ratio, MAX_PIXEL_RATIO) });
+  }
 };
 
 // Every layer this draws, and every source under them. The layers go first: a source can't be taken
 // off the map while a layer is still reading it.
-const RESULT_LAYERS = [
-  ...[SEARCH_BOUNDS, HIGHLIGHT_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]),
-  ...[RESULT_NUMBERS, RESULT_HIGHLIGHT].flatMap(id => [`${id}-circle`, `${id}-label`]),
-];
+const RESULT_LAYERS = [...[SEARCH_BOUNDS, HIGHLIGHT_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]), RESULT_MARKERS];
 const RESULT_SOURCES = [SEARCH_BOUNDS, HIGHLIGHT_BOUNDS, RESULT_NUMBERS];
 
-// Take all of it back off. Guarded both ways: a theme swap empties the style document without asking,
-// so what this last drew may already be gone.
+/**
+ * Take all of it back off, pictures included.
+ *
+ * Guarded every way: a theme swap empties the style document without asking, so what this last drew
+ * may already be gone - and the images go with it, since they live on the style rather than on the map.
+ * The pictures are found by name rather than remembered, so a set left behind by a draw nobody
+ * finished is taken away too.
+ */
 export const clearResults = (map: Map) => {
   for (const id of RESULT_LAYERS) if (map.getLayer(id)) map.removeLayer(id);
   for (const id of RESULT_SOURCES) if (map.getSource(id)) map.removeSource(id);
+  for (const id of map.listImages()) if (id.startsWith(MARKER_IMAGE)) map.removeImage(id);
 };

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -1,16 +1,76 @@
-import { LngLatBounds, type LngLatBoundsLike, type Map, type SymbolLayerSpecification } from 'maplibre-gl';
+import {
+  LngLatBounds,
+  type CircleLayerSpecification,
+  type DataDrivenPropertyValueSpecification,
+  type ExpressionSpecification,
+  type FillLayerSpecification,
+  type FilterSpecification,
+  type LineLayerSpecification,
+  type LngLatBoundsLike,
+  type Map,
+  type SymbolLayerSpecification,
+} from 'maplibre-gl';
 
+import { boundsToGeoJSON } from './geometry';
+import { FILL_OPACITY } from './previewers/location';
+import { contrastColor } from './themes/color';
 import type { MapLibreStyle } from './themes/maplibre';
 
-// The one source and the one layer that carry the result numbers. Not derived from anything: there
-// is exactly one set of them on a map, however many records are drawn on it.
+// The one source that carries the result numbers, and the two pairs of layers that draw them: the
+// results as they were given, and the one something outside has asked to highlight. Not derived from
+// anything - there is exactly one set of these on a map, however many results are drawn on it.
 export const RESULT_NUMBERS = 'ogm-result-numbers';
+export const RESULT_HIGHLIGHT = `${RESULT_NUMBERS}-highlight`;
+
+// The two boxes drawn under the numbers: the area a search is filtered to, and the extent of the
+// highlighted result. A source each rather than two features of one, because they are two different
+// statements about the map, drawn in different colors, arriving at different times.
+export const SEARCH_BOUNDS = 'ogm-search-bounds';
+export const HIGHLIGHT_BOUNDS = 'ogm-highlight-bounds';
 
 // How much bigger a result's number is drawn than a label on a feature. Deliberately not themed,
 // for the reason LocationPreviewer's FILL_OPACITY isn't: this is the relationship between a number
 // read against a whole globe and the text drawn beside a feature, not a value an embedding app has
 // a reason to name. Setting --ogm-text-size still moves both together.
+//
+// It is also all the weight a number gets. `text-font` names a fontstack the basemap's own glyph
+// endpoint has to serve rather than a CSS font stack, so there is no Bold to ask for: a stack CARTO
+// doesn't serve draws nothing at all. The size, the disc under it and the halo are what make these
+// read as bold.
 const NUMBER_SIZE = 1.5;
+
+// How wide the disc behind a number is, as a multiple of the number's own size: room for one digit,
+// then for two, then for anything longer. Stepped rather than grown smoothly with the label, because
+// a page of eight results would otherwise wear eight slightly different discs and read as eight
+// different kinds of thing. Not themed, for the same reason NUMBER_SIZE isn't.
+const NUMBER_RADIUS = [0.7, 0.9, 1.15];
+
+// The ring around a disc and the edge on the numeral inside it, in pixels. The same two the rest of
+// the library draws with: a location's outline is 2 and a feature label's halo is 1. The ring is what
+// holds a disc apart from the basemap and from the disc beside it, which is the halo's job done for
+// a shape.
+const NUMBER_STROKE = 2;
+const NUMBER_HALO = 1;
+
+// How much room each number clears around itself, in pixels; MapLibre's own default is 2. Nothing
+// culls one of ours - see resultNumbersLayers - so this only ever pushes the basemap's own labels out
+// from under them, which is the one kind of overlap here worth spending anything on.
+const NUMBER_PADDING = 4;
+
+// Everything an overview draws, gathered in one place because the order it goes onto the map in is
+// most of what keeps it readable.
+export type DrawnResults = {
+  // Where every result is, in the order they were given, including the ones nobody could place
+  extents: (LngLatBoundsLike | undefined)[];
+  // Which of those results is highlighted, as its place in that list counted from one
+  highlighted?: number;
+  // The area a search is currently filtered to, if one is
+  searchBounds?: LngLatBounds;
+};
+
+// What a box is drawn in. The two of them differ in nothing else, so this is the whole of the
+// difference between the area being searched and the extent of the highlighted result.
+type BoxColors = { color: string; strokeColor: string; opacity: number };
 
 /**
  * One numbered point per extent, in the order the extents were given.
@@ -24,7 +84,7 @@ const NUMBER_SIZE = 1.5;
  * touches, and with collision turned off below there is nothing left to suppress the copies. A
  * country-sized box would wear its number three or four times.
  */
-export const numberedResults = (extents: (LngLatBoundsLike | undefined)[]): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
+export const numberedResults = (extents: (LngLatBoundsLike | undefined)[], highlighted?: number): GeoJSON.FeatureCollection<GeoJSON.Point> => ({
   type: 'FeatureCollection',
   features: extents.flatMap((extent, index) => {
     if (!extent) return [];
@@ -32,47 +92,179 @@ export const numberedResults = (extents: (LngLatBoundsLike | undefined)[]): GeoJ
     // 180 - see unwrapEast - is centered on the Pacific rather than on Greenwich. MapLibre reads a
     // longitude from outside -180..180 everywhere it takes one, so there is nothing to wrap back.
     const { lng, lat } = LngLatBounds.convert(extent).getCenter();
-    return [{ type: 'Feature' as const, properties: { label: String(index + 1) }, geometry: { type: 'Point' as const, coordinates: [lng, lat] } }];
+    return [
+      {
+        type: 'Feature' as const,
+        // Marked on every point rather than only on the one that has it. Two pairs of layers select
+        // on this from opposite sides, and a filter that reads as a plain comparison against
+        // something every feature carries is worth the two bytes it costs.
+        properties: { label: String(index + 1), highlighted: index + 1 === highlighted },
+        geometry: { type: 'Point' as const, coordinates: [lng, lat] },
+      },
+    ];
   }),
 });
 
-// Drawn in the theme's text, and never dropped. A number that isn't there is worse than one that
-// overlaps: the list beside the map is counting on every one of them being findable. Allowing
-// overlap keeps this layer's numbers from being culled by the ones already placed; ignoring
-// placement keeps them from culling each other.
-export const resultNumbersLayer = (style: MapLibreStyle): SymbolLayerSpecification => ({
-  id: RESULT_NUMBERS,
-  type: 'symbol' as const,
-  source: RESULT_NUMBERS,
-  layout: {
-    'visibility': 'visible' as const,
-    'text-field': ['get', 'label'] as const,
-    'text-font': [style.textFont],
-    'text-size': style.textSize * NUMBER_SIZE,
-    'text-allow-overlap': true,
-    'text-ignore-placement': true,
-  },
-  paint: {
-    'text-color': style.textColor,
-    'text-halo-color': style.textHaloColor,
-    // Twice the halo a feature label gets. These are read against whatever box, wash and basemap
-    // happen to be underneath, at a size where a single pixel of outline disappears.
-    'text-halo-width': 2,
-  },
-});
+/**
+ * A disc with a numeral on it, in the two style layers it takes to draw one.
+ *
+ * A symbol layer has no background to put behind its text, so the disc is a circle layer of its own
+ * underneath, reading the same source. Two of these pairs go on a map, selecting on the same property
+ * from opposite sides, and the highlighted one goes on last. A `case` expression in each paint
+ * property would color the highlighted marker in place, but it could not lift it: a symbol layer
+ * draws all of its text after all of its icons, and layers draw in the order they were added, so
+ * within one pair there is no arrangement that puts one feature's disc and its number together above
+ * its neighbours'. Only a later pair does that.
+ *
+ * Neither pair is ever culled. A number that isn't there is worse than one that overlaps, because the
+ * list beside the map is counting on every one of them being findable. What is deliberately not asked
+ * for is `text-ignore-placement`: keeping our numbers out of the collision grid would leave the
+ * basemap's own labels free to draw underneath them, which is the most cluttered thing they could sit
+ * on. In the grid, a basemap label that collides with a number is dropped instead - and ours still
+ * can't be dropped, because allowing overlap skips the hit test for them entirely and placement runs
+ * from the top layer down, so these are placed before anything the basemap wanted that space for.
+ */
+export const resultNumbersLayers = (style: MapLibreStyle, highlighted: boolean = false): [CircleLayerSpecification, SymbolLayerSpecification] => {
+  const id = highlighted ? RESULT_HIGHLIGHT : RESULT_NUMBERS;
+  const color = highlighted ? style.markerHighlightColor : style.markerColor;
+  const filter: FilterSpecification = highlighted ? ['==', ['get', 'highlighted'], true] : ['!=', ['get', 'highlighted'], true];
+  const size = style.textSize * NUMBER_SIZE;
 
-// Put the numbers on the map, above everything already drawn there. Taken off and put back rather
-// than updated in place, because addLayer appends: adding the layer again after the boxes have been
-// redrawn is what keeps every number over every box, whatever order the boxes arrived in.
-export const drawResultNumbers = (map: Map, style: MapLibreStyle, extents: (LngLatBoundsLike | undefined)[]) => {
-  clearResultNumbers(map);
-  map.addSource(RESULT_NUMBERS, { type: 'geojson', data: numberedResults(extents) });
-  map.addLayer(resultNumbersLayer(style));
+  // Earlier results on top, so counting down the list beside the map is counting away from the
+  // reader: the first result is the one a page put first, and it stays over the twentieth however the
+  // map is panned. Both properties draw a higher key over a lower one, so the key is the number
+  // negated. Without one at all, MapLibre orders symbols by where they land on screen, and they
+  // restack as the map moves - which reads as the numbers rearranging themselves.
+  const sortKey: ExpressionSpecification = ['-', 0, ['to-number', ['get', 'label']]];
+
+  // Room for the digits, in the three sizes a page of results can need
+  const radius: DataDrivenPropertyValueSpecification<number> = [
+    'step',
+    ['length', ['get', 'label']],
+    size * NUMBER_RADIUS[0],
+    2,
+    size * NUMBER_RADIUS[1],
+    3,
+    size * NUMBER_RADIUS[2],
+  ];
+
+  return [
+    {
+      id: `${id}-circle`,
+      type: 'circle' as const,
+      source: RESULT_NUMBERS,
+      filter,
+      layout: {
+        'visibility': 'visible' as const,
+        'circle-sort-key': sortKey,
+      },
+      paint: {
+        'circle-color': color,
+        'circle-radius': radius,
+        // The ink the numeral is drawn in, so a disc reads as one shape with a rim rather than as a
+        // disc with a halo of its own. One color that holds up on either basemap, and the thing that
+        // keeps two overlapping discs from reading as one.
+        'circle-stroke-color': contrastColor(color) || style.textHaloColor,
+        'circle-stroke-width': NUMBER_STROKE,
+        // No opacity asked for, here or on the numbers. Everything else this map draws is a note
+        // about where to look and starts faint so the basemap can be read through it; a number is
+        // the thing being read, and there is nothing under it worth seeing.
+      },
+    },
+    {
+      id: `${id}-label`,
+      type: 'symbol' as const,
+      source: RESULT_NUMBERS,
+      filter,
+      layout: {
+        'visibility': 'visible' as const,
+        'text-field': ['get', 'label'] as const,
+        'text-font': [style.textFont],
+        'text-size': size,
+        'text-allow-overlap': true,
+        'text-padding': NUMBER_PADDING,
+        'symbol-sort-key': sortKey,
+      },
+      paint: {
+        // Whichever of black and white can be read on the disc, rather than the theme's own text
+        // color, which is near-black in light mode and would disappear into it. The disc is derived
+        // to a depth that makes this white; see MapLibreTheme.markerColor.
+        'text-color': contrastColor(color) || style.textHaloColor,
+        // The disc's own color, not the theme's halo: on a disc there is nothing left for white to
+        // hold the numeral apart from, and an edge in the disc's color is what keeps a numeral from
+        // touching the ring around it.
+        'text-halo-color': color,
+        'text-halo-width': NUMBER_HALO,
+      },
+    },
+  ];
 };
 
-// Take the numbers back off. Guarded both ways: a theme swap empties the style document without
-// asking, so the layer this last drew may already be gone.
-export const clearResultNumbers = (map: Map) => {
-  if (map.getLayer(RESULT_NUMBERS)) map.removeLayer(RESULT_NUMBERS);
-  if (map.getSource(RESULT_NUMBERS)) map.removeSource(RESULT_NUMBERS);
+// A box, drawn the way LocationPreviewer draws a record's extent: a thin outline with a wash inside
+// it, the wash held below the outline at every setting. Drawn from here rather than by that previewer
+// because neither of these is a preview - there is no tab to name, no row for the layer panel, no
+// opacity for a reader to drag and nothing to inspect - and because what keeps all of this readable
+// is the order it goes on in, which is easier to see written out once.
+const boundsLayers = (id: string, { color, strokeColor, opacity }: BoxColors): [FillLayerSpecification, LineLayerSpecification] => [
+  {
+    id: `${id}-fill`,
+    type: 'fill' as const,
+    source: id,
+    layout: { visibility: 'visible' as const },
+    paint: { 'fill-color': color, 'fill-opacity': opacity * FILL_OPACITY },
+  },
+  {
+    id: `${id}-outline`,
+    type: 'line' as const,
+    source: id,
+    layout: { visibility: 'visible' as const },
+    paint: { 'line-color': strokeColor, 'line-width': 2, 'line-opacity': opacity },
+  },
+];
+
+const addBounds = (map: Map, id: string, bounds: LngLatBounds, colors: BoxColors) => {
+  map.addSource(id, { type: 'geojson', data: { type: 'Feature', properties: {}, geometry: boundsToGeoJSON(bounds) as GeoJSON.Geometry } });
+  for (const layer of boundsLayers(id, colors)) map.addLayer(layer);
+};
+
+/**
+ * Put everything an overview draws on the map, in the order it has to be drawn in.
+ *
+ * Bottom to top: the area being searched, the extent of the highlighted result, the numbers, and the
+ * highlighted number last of all. All of it comes off and goes back on rather than being changed in
+ * place, because addLayer appends and there is no other way to say which of these sits over which.
+ * Nothing here reaches the network, so moving one highlight costs a rebuild of eight style layers
+ * and nothing else.
+ */
+export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlighted, searchBounds }: DrawnResults) => {
+  clearResults(map);
+
+  if (searchBounds) {
+    addBounds(map, SEARCH_BOUNDS, searchBounds, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity });
+  }
+
+  // Nothing for a highlight that landed on a result nobody could place. That is the truth rather than
+  // a gap: there is no number on the map to bring forward and no extent to draw around.
+  const extent = highlighted === undefined ? undefined : extents[highlighted - 1];
+  if (extent) {
+    addBounds(map, HIGHLIGHT_BOUNDS, LngLatBounds.convert(extent), { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity });
+  }
+
+  map.addSource(RESULT_NUMBERS, { type: 'geojson', data: numberedResults(extents, highlighted) });
+  for (const layer of [...resultNumbersLayers(style), ...resultNumbersLayers(style, true)]) map.addLayer(layer);
+};
+
+// Every layer this draws, and every source under them. The layers go first: a source can't be taken
+// off the map while a layer is still reading it.
+const RESULT_LAYERS = [
+  ...[SEARCH_BOUNDS, HIGHLIGHT_BOUNDS].flatMap(id => [`${id}-fill`, `${id}-outline`]),
+  ...[RESULT_NUMBERS, RESULT_HIGHLIGHT].flatMap(id => [`${id}-circle`, `${id}-label`]),
+];
+const RESULT_SOURCES = [SEARCH_BOUNDS, HIGHLIGHT_BOUNDS, RESULT_NUMBERS];
+
+// Take all of it back off. Guarded both ways: a theme swap empties the style document without asking,
+// so what this last drew may already be gone.
+export const clearResults = (map: Map) => {
+  for (const id of RESULT_LAYERS) if (map.getLayer(id)) map.removeLayer(id);
+  for (const id of RESULT_SOURCES) if (map.getSource(id)) map.removeSource(id);
 };

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -58,6 +58,11 @@ const NUMERAL_WIDTH = 0.72;
 // drawing for; past it the image is memory spent on detail nothing can show.
 const MAX_PIXEL_RATIO = 2;
 
+// How long a box takes to fade in or out, in milliseconds. MapLibre's own default for a paint property,
+// but named on our own layers rather than left to the style document: getTransition() takes whatever the
+// stylesheet says over the default, and the stylesheets are CARTO's to change.
+const BOX_FADE = 300;
+
 // How much bigger a highlighted marker is drawn than the rest. Enough to read as coming forward, and
 // no more: it is the same marker, and one that jumped in size would say something happened rather than
 // that this is the one being pointed at. The ring around it doesn't grow with it - see MARKER_RING -
@@ -286,32 +291,35 @@ const boundsLayers = (id: string, { color, strokeColor, opacity }: BoxColors): [
     type: 'fill' as const,
     source: id,
     layout: { visibility: 'visible' as const },
-    paint: { 'fill-color': color, 'fill-opacity': opacity * FILL_OPACITY },
+    paint: { 'fill-color': color, 'fill-opacity': opacity * FILL_OPACITY, 'fill-opacity-transition': { duration: BOX_FADE, delay: 0 } },
   },
   {
     id: `${id}-outline`,
     type: 'line' as const,
     source: id,
     layout: { visibility: 'visible' as const },
-    paint: { 'line-color': strokeColor, 'line-width': 2, 'line-opacity': opacity },
+    paint: { 'line-color': strokeColor, 'line-width': 2, 'line-opacity': opacity, 'line-opacity-transition': { duration: BOX_FADE, delay: 0 } },
   },
 ];
 
-// However many boxes there are to draw, which for the area being searched is one or none and for the
-// results being highlighted is one per result. A collection either way, so that a box nobody asked for
-// is an empty one rather than a source coming off the map - which is what lets the two layers that read
-// it stay on as well; see drawInto.
-const boundsData = (bounds: (LngLatBounds | undefined)[]): GeoJSON.FeatureCollection => ({
+// However many boxes there are to draw, which for the area being searched is one and for the results
+// being highlighted is one per result
+const boundsData = (bounds: LngLatBounds[]): GeoJSON.FeatureCollection => ({
   type: 'FeatureCollection',
-  features: bounds.filter((box): box is LngLatBounds => !!box).map(box => ({ type: 'Feature', properties: {}, geometry: boundsToGeoJSON(box) as GeoJSON.Geometry })),
+  features: bounds.map(box => ({ type: 'Feature', properties: {}, geometry: boundsToGeoJSON(box) as GeoJSON.Geometry })),
 });
+
+// What a map that has never had a box on it starts from. Everything after that is a change of opacity,
+// and a box on its way out stays in the source it was drawn from; see drawBox.
+const NOTHING: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
 
 // Anything this draws with, which is three kinds of layer over the same kind of source
 type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerSpecification;
 
 /**
  * New data into a source already on the map - or the source, and the layers that read it, if this is
- * the first thing drawn into this style document.
+ * the first thing drawn into this style document. Data of `undefined` leaves whatever the source is
+ * holding, for a box that is fading out and still has to be drawn while it does; see drawBox.
  *
  * Which is the whole of what keeps a redraw from flashing. removeSource drops a source's tiles the
  * moment it is called, so a redraw that begins by taking everything off has nothing to draw until a
@@ -324,17 +332,40 @@ type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerS
  * already been drawn. What can't be said twice is the order - addLayer appends, so the order these
  * first went on in is the order they keep, and it is fixed by drawResults below.
  */
-const drawInto = (map: Map, id: string, data: GeoJSON.GeoJSON, layers: DrawnLayer[]) => {
+const drawInto = (map: Map, id: string, data: GeoJSON.GeoJSON | undefined, layers: DrawnLayer[]) => {
   const source = map.getSource(id) as GeoJSONSource | undefined;
 
   if (!source) {
-    map.addSource(id, { type: 'geojson', data });
+    map.addSource(id, { type: 'geojson', data: data ?? NOTHING });
     for (const layer of layers) map.addLayer(layer);
     return;
   }
 
-  source.setData(data);
+  if (data) source.setData(data);
   for (const layer of layers) repaint(map, layer);
+};
+
+/**
+ * A box, faded in or out rather than put on the map and taken off it.
+ *
+ * An opacity that changes is interpolated by MapLibre over the layer's transition, so a box with
+ * something to say arrives at the theme's opacity over BOX_FADE and one with nothing to say leaves the
+ * same way. What it was drawn from stays where it is while that happens - a box whose geometry had been
+ * taken out of the source would have nothing left to fade - and a box at no opacity is invisible either
+ * way.
+ *
+ * Only a constant fades. MapLibre's DataDrivenProperty.interpolate gives up on anything evaluated per
+ * feature - "we aren't able to interpolate data-driven values" - and holds the old value until the
+ * transition is over, so this is one opacity for the whole layer rather than one for each box on it.
+ * Which also means a highlight moving from one result to another moves the box rather than fading it
+ * across: the geometry changes under an opacity that is already up. That is the right way round for a
+ * reader running down a list of results, where a box lagging behind the pointer would read worse than
+ * one that keeps up with it.
+ */
+const drawBox = (map: Map, id: string, bounds: (LngLatBounds | undefined)[], colors: BoxColors) => {
+  const shown = bounds.filter((box): box is LngLatBounds => !!box);
+
+  drawInto(map, id, shown.length ? boundsData(shown) : undefined, boundsLayers(id, { ...colors, opacity: shown.length ? colors.opacity : 0 }));
 };
 
 // A layer's colors again. A no-op for the markers, which carry no paint at all: what a marker is drawn
@@ -363,7 +394,7 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
   // Before the layer that names them, so that no frame asks for a picture that isn't there yet
   syncMarkerImages(map, style, numbers);
 
-  drawInto(map, SEARCH_BOUNDS, boundsData([searchBounds]), boundsLayers(SEARCH_BOUNDS, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity }));
+  drawBox(map, SEARCH_BOUNDS, [searchBounds], { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity });
 
   // Nothing for a highlight that landed on a result nobody could place. That is the truth rather than
   // a gap: there is no number on the map to bring forward and no extent to draw around.
@@ -372,7 +403,7 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
   // The colors a hovered feature is drawn in, since being pointed at is what is being said - whether
   // the pointer is over the number itself or over something outside that names the result
   const highlight = { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity };
-  drawInto(map, HIGHLIGHT_BOUNDS, boundsData(marked), boundsLayers(HIGHLIGHT_BOUNDS, highlight));
+  drawBox(map, HIGHLIGHT_BOUNDS, marked, highlight);
 
   drawInto(map, RESULT_NUMBERS, numbers, [resultMarkersLayer()]);
 };

--- a/src/lib/results.ts
+++ b/src/lib/results.ts
@@ -58,11 +58,6 @@ const NUMERAL_WIDTH = 0.72;
 // drawing for; past it the image is memory spent on detail nothing can show.
 const MAX_PIXEL_RATIO = 2;
 
-// How long a box takes to fade in or out, in milliseconds. MapLibre's own default for a paint property,
-// but named on our own layers rather than left to the style document: getTransition() takes whatever the
-// stylesheet says over the default, and the stylesheets are CARTO's to change.
-const BOX_FADE = 300;
-
 // How much bigger a highlighted marker is drawn than the rest. Enough to read as coming forward, and
 // no more: it is the same marker, and one that jumped in size would say something happened rather than
 // that this is the one being pointed at. The ring around it doesn't grow with it - see MARKER_RING -
@@ -291,35 +286,32 @@ const boundsLayers = (id: string, { color, strokeColor, opacity }: BoxColors): [
     type: 'fill' as const,
     source: id,
     layout: { visibility: 'visible' as const },
-    paint: { 'fill-color': color, 'fill-opacity': opacity * FILL_OPACITY, 'fill-opacity-transition': { duration: BOX_FADE, delay: 0 } },
+    paint: { 'fill-color': color, 'fill-opacity': opacity * FILL_OPACITY },
   },
   {
     id: `${id}-outline`,
     type: 'line' as const,
     source: id,
     layout: { visibility: 'visible' as const },
-    paint: { 'line-color': strokeColor, 'line-width': 2, 'line-opacity': opacity, 'line-opacity-transition': { duration: BOX_FADE, delay: 0 } },
+    paint: { 'line-color': strokeColor, 'line-width': 2, 'line-opacity': opacity },
   },
 ];
 
-// However many boxes there are to draw, which for the area being searched is one and for the results
-// being highlighted is one per result
-const boundsData = (bounds: LngLatBounds[]): GeoJSON.FeatureCollection => ({
+// However many boxes there are to draw, which for the area being searched is one or none and for the
+// results being highlighted is one per result. A collection either way, so that a box nobody asked for
+// is an empty one rather than a source coming off the map - which is what lets the two layers that read
+// it stay on as well; see drawInto.
+const boundsData = (bounds: (LngLatBounds | undefined)[]): GeoJSON.FeatureCollection => ({
   type: 'FeatureCollection',
-  features: bounds.map(box => ({ type: 'Feature', properties: {}, geometry: boundsToGeoJSON(box) as GeoJSON.Geometry })),
+  features: bounds.filter((box): box is LngLatBounds => !!box).map(box => ({ type: 'Feature', properties: {}, geometry: boundsToGeoJSON(box) as GeoJSON.Geometry })),
 });
-
-// What a map that has never had a box on it starts from. Everything after that is a change of opacity,
-// and a box on its way out stays in the source it was drawn from; see drawBox.
-const NOTHING: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
 
 // Anything this draws with, which is three kinds of layer over the same kind of source
 type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerSpecification;
 
 /**
  * New data into a source already on the map - or the source, and the layers that read it, if this is
- * the first thing drawn into this style document. Data of `undefined` leaves whatever the source is
- * holding, for a box that is fading out and still has to be drawn while it does; see drawBox.
+ * the first thing drawn into this style document.
  *
  * Which is the whole of what keeps a redraw from flashing. removeSource drops a source's tiles the
  * moment it is called, so a redraw that begins by taking everything off has nothing to draw until a
@@ -332,40 +324,17 @@ type DrawnLayer = FillLayerSpecification | LineLayerSpecification | SymbolLayerS
  * already been drawn. What can't be said twice is the order - addLayer appends, so the order these
  * first went on in is the order they keep, and it is fixed by drawResults below.
  */
-const drawInto = (map: Map, id: string, data: GeoJSON.GeoJSON | undefined, layers: DrawnLayer[]) => {
+const drawInto = (map: Map, id: string, data: GeoJSON.GeoJSON, layers: DrawnLayer[]) => {
   const source = map.getSource(id) as GeoJSONSource | undefined;
 
   if (!source) {
-    map.addSource(id, { type: 'geojson', data: data ?? NOTHING });
+    map.addSource(id, { type: 'geojson', data });
     for (const layer of layers) map.addLayer(layer);
     return;
   }
 
-  if (data) source.setData(data);
+  source.setData(data);
   for (const layer of layers) repaint(map, layer);
-};
-
-/**
- * A box, faded in or out rather than put on the map and taken off it.
- *
- * An opacity that changes is interpolated by MapLibre over the layer's transition, so a box with
- * something to say arrives at the theme's opacity over BOX_FADE and one with nothing to say leaves the
- * same way. What it was drawn from stays where it is while that happens - a box whose geometry had been
- * taken out of the source would have nothing left to fade - and a box at no opacity is invisible either
- * way.
- *
- * Only a constant fades. MapLibre's DataDrivenProperty.interpolate gives up on anything evaluated per
- * feature - "we aren't able to interpolate data-driven values" - and holds the old value until the
- * transition is over, so this is one opacity for the whole layer rather than one for each box on it.
- * Which also means a highlight moving from one result to another moves the box rather than fading it
- * across: the geometry changes under an opacity that is already up. That is the right way round for a
- * reader running down a list of results, where a box lagging behind the pointer would read worse than
- * one that keeps up with it.
- */
-const drawBox = (map: Map, id: string, bounds: (LngLatBounds | undefined)[], colors: BoxColors) => {
-  const shown = bounds.filter((box): box is LngLatBounds => !!box);
-
-  drawInto(map, id, shown.length ? boundsData(shown) : undefined, boundsLayers(id, { ...colors, opacity: shown.length ? colors.opacity : 0 }));
 };
 
 // A layer's colors again. A no-op for the markers, which carry no paint at all: what a marker is drawn
@@ -394,7 +363,7 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
   // Before the layer that names them, so that no frame asks for a picture that isn't there yet
   syncMarkerImages(map, style, numbers);
 
-  drawBox(map, SEARCH_BOUNDS, [searchBounds], { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity });
+  drawInto(map, SEARCH_BOUNDS, boundsData([searchBounds]), boundsLayers(SEARCH_BOUNDS, { color: style.dataColor, strokeColor: style.strokeColor, opacity: style.boundsOpacity }));
 
   // Nothing for a highlight that landed on a result nobody could place. That is the truth rather than
   // a gap: there is no number on the map to bring forward and no extent to draw around.
@@ -403,7 +372,7 @@ export const drawResults = (map: Map, style: MapLibreStyle, { extents, highlight
   // The colors a hovered feature is drawn in, since being pointed at is what is being said - whether
   // the pointer is over the number itself or over something outside that names the result
   const highlight = { color: style.highlightColor, strokeColor: style.strokeHighlightColor, opacity: style.highlightOpacity };
-  drawBox(map, HIGHLIGHT_BOUNDS, marked, highlight);
+  drawInto(map, HIGHLIGHT_BOUNDS, boundsData(marked), boundsLayers(HIGHLIGHT_BOUNDS, highlight));
 
   drawInto(map, RESULT_NUMBERS, numbers, [resultMarkersLayer()]);
 };

--- a/src/lib/themes/color.test.ts
+++ b/src/lib/themes/color.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@stencil/vitest';
 
-import { contrastColor, shiftLightness } from './color';
+import { atLightness, contrastColor, shiftLightness } from './color';
 
 // Perceptual lightness of a hex color, on the 0-1 scale shiftLightness works in. Reimplemented here
 // rather than exported from the module under test, so an error in its conversion can't cancel out.
@@ -76,6 +76,52 @@ describe('shiftLightness', () => {
     expect(shiftLightness('oklch(0.5 0.1 20)', -0.26)).toBe('oklch(0.5 0.1 20)');
     expect(shiftLightness('color-mix(in oklab, red, blue)', -0.26)).toBe('color-mix(in oklab, red, blue)');
     expect(shiftLightness('', -0.26)).toBe('');
+  });
+});
+
+describe('atLightness', () => {
+  // To within what eight bits a channel can hold: the answer is a hex color, and reading its
+  // lightness back off three rounded channels is worth about a thousandth either way.
+  it('lands on the lightness it was given, wherever it started', () => {
+    expect(lightness(atLightness('#9fceff', 0.45))).toBeCloseTo(0.45, 2);
+    expect(lightness(atLightness('#7fd6ec', 0.6))).toBeCloseTo(0.6, 2);
+  });
+
+  // Holding a hue and its chroma while moving the lightness can land outside sRGB, and clipping the
+  // channel back into it costs a little of the lightness that was asked for. The same trade
+  // shiftLightness documents, and it only shows on the colors with the most chroma in them.
+  it('gets as close as sRGB allows for a color with no room left', () => {
+    expect(lightness(atLightness('#0071ec', 0.45))).toBeCloseTo(0.45, 1);
+  });
+
+  // Which is the whole point of taking a destination rather than a step: the two tokens behind one of
+  // our colors sit at opposite ends of the scale, and both have to end up somewhere a numeral reads.
+  it('brings a pair of light and dark colors to the same place', () => {
+    const pale = atLightness('#9fceff', 0.45);
+    const deep = atLightness(shiftLightness('#9fceff', 0.3), 0.45);
+
+    expect(lightness(pale)).toBeCloseTo(lightness(deep), 2);
+  });
+
+  it('keeps the hue it was given', () => {
+    // Still a blue, and still nearer blue than the red it isn't
+    const [r, g, b] = [1, 3, 5].map(i => parseInt(atLightness('#9fceff', 0.45).slice(i, i + 2), 16));
+    expect(b).toBeGreaterThan(g);
+    expect(g).toBeGreaterThan(r);
+  });
+
+  // What the disc behind a result's number rests on. Asserted against every color the palette can
+  // hand over, plus what an app is likely to name, because the numeral's own color is chosen by
+  // contrast and a disc that came out pale would put black ink on a map full of white ink.
+  it('lands deep enough for white ink, whatever color it was given', () => {
+    const colors = ['#9fceff', '#0071ec', '#7fd6ec', '#00a3c0', '#93da98', '#00883c', '#f3676c', '#dc3146', '#ffe08a', '#ffff00', '#ffffff', '#000000'];
+
+    colors.forEach(color => expect(contrastColor(atLightness(color, 0.45))).toBe('#ffffff'));
+  });
+
+  it('hands back anything it cannot read, untouched', () => {
+    expect(atLightness('oklch(0.5 0.1 20)', 0.45)).toBe('oklch(0.5 0.1 20)');
+    expect(atLightness('', 0.45)).toBe('');
   });
 });
 

--- a/src/lib/themes/color.ts
+++ b/src/lib/themes/color.ts
@@ -82,6 +82,27 @@ export const shiftLightness = (color: string, delta: number): string => {
 };
 
 /**
+ * The same color at a stated perceptual lightness, rather than a step away from wherever it was.
+ * Hue and chroma are left where they were, as above.
+ *
+ * `shiftLightness` answers a different question and can't answer this one. An outline only has to be
+ * told apart from the color it outlines, so a step in either direction will do, and which direction
+ * depends on the basemap - which is why that one takes a delta and this one takes a destination. A
+ * color that has to carry text has to arrive somewhere in particular whatever it started as, and the
+ * two mode tokens behind one of ours start at opposite ends of the scale: the same step from each
+ * lands them either side of the point where white stops being the more readable ink.
+ *
+ * Anything d3-color can't read comes back untouched, for the reason above.
+ */
+export const atLightness = (color: string, lightness: number): string => {
+  const { r, g, b } = rgb(commaSyntax(color));
+  if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return color;
+
+  const [, a, bb] = toOklab(r, g, b);
+  return toHex(lightness, a, bb);
+};
+
+/**
  * Black or white, whichever contrasts more with the color given - the choice CSS `contrast-color()`
  * makes, made here for the reason at the top of this file, and by the measure that function's
  * definition rests on: WCAG relative luminance, whose crossover sits near 0.18 rather than at the

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@stencil/vitest';
 
-import { shiftLightness } from './color';
+import { atLightness, contrastColor, shiftLightness } from './color';
 import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle } from './maplibre';
 
 // A theme reading from an element carrying the given custom properties.
@@ -82,6 +82,59 @@ describe('MapLibreTheme', () => {
 
       expect(themed('light', named).getStyle().strokeColor).toBe('#4a0a0a');
       expect(themed('dark', named).getStyle().strokeColor).toBe('#4a0a0a');
+    });
+  });
+
+  // The disc a result's number sits on is derived to a lightness rather than by a step, because a
+  // numeral has to be readable on it in either mode. Asserted as that relationship, and as the
+  // guarantee that rests on it, rather than against a hex.
+  describe('derived marker colors', () => {
+    const tokens = { '--ogm-data-color': '#8f1414', '--ogm-highlight-color': '#e98300' };
+
+    it('sinks a color to the depth a number can be read on', () => {
+      const { dataColor, markerColor } = themed('light', tokens).getStyle();
+
+      expect(markerColor).toBe(atLightness(dataColor, 0.45));
+    });
+
+    // Which is what a step could not do: the two tokens behind one color start at opposite ends of
+    // the scale, so one step from each would land them either side of where white stops being legible.
+    it('sinks it to the same depth in both modes', () => {
+      const light = themed('light', tokens).getStyle();
+      const dark = themed('dark', tokens).getStyle();
+
+      expect(dark.markerColor).toBe(light.markerColor);
+    });
+
+    it('derives the highlighted marker from the highlight color', () => {
+      const { highlightColor, markerHighlightColor } = themed('light', tokens).getStyle();
+
+      expect(markerHighlightColor).toBe(atLightness(highlightColor, 0.45));
+      expect(markerHighlightColor).not.toBe(themed('light', tokens).getStyle().markerColor);
+    });
+
+    // What the numeral's own color rests on. It is chosen by contrast at the point of drawing, so a
+    // disc that came out pale would put black ink on a map whose other numbers are white. Checked
+    // against the palette's own values for each mode - the pale pair a light basemap gets and the
+    // saturated pair a dark one does - and against a color pale enough that an app naming it would
+    // otherwise get one.
+    it('leaves both discs deep enough for white ink', () => {
+      const light = themed('light', { '--wa-color-blue-80': '#9fceff', '--wa-color-cyan-80': '#7fd6ec' }).getStyle();
+      const dark = themed('dark', { '--wa-color-blue-50': '#0071ec', '--wa-color-cyan-60': '#00a3c0' }).getStyle();
+      const pale = themed('light', { '--ogm-data-color': '#ffe08a', '--ogm-highlight-color': '#ffff00' }).getStyle();
+
+      [light, dark, pale].forEach(style => {
+        expect(contrastColor(style.markerColor)).toBe('#ffffff');
+        expect(contrastColor(style.markerHighlightColor)).toBe('#ffffff');
+      });
+    });
+
+    it('steps aside for an app that names the disc itself', () => {
+      const named = { ...tokens, '--ogm-marker-color': '#4a0a0a', '--ogm-marker-highlight-color': '#7a4600' };
+      const style = themed('light', named).getStyle();
+
+      expect(style.markerColor).toBe('#4a0a0a');
+      expect(style.markerHighlightColor).toBe('#7a4600');
     });
   });
 

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -138,6 +138,20 @@ describe('MapLibreTheme', () => {
     });
   });
 
+  // The numbers on an overview's markers are drawn by this library rather than by MapLibre, so unlike
+  // every other font here this one is an ordinary CSS stack
+  describe('marker font', () => {
+    it('takes the page’s own body font, and an override before it', () => {
+      expect(themed('light', { '--wa-font-family-body': 'Untitled Sans, sans-serif' }).getStyle().markerFont).toBe('Untitled Sans, sans-serif');
+      expect(themed('light', { '--wa-font-family-body': 'Untitled Sans, sans-serif', '--ogm-marker-font': 'Redaction, serif' }).getStyle().markerFont).toBe('Redaction, serif');
+    });
+
+    // Unlike textFont, which names a glyph set the basemap's own endpoint has to serve
+    it('falls back to something a browser will certainly have', () => {
+      expect(themed('light').getStyle().markerFont).toBe('system-ui, sans-serif');
+    });
+  });
+
   // A label's halo is derived like an outline is, but to the opposite end of the scale: it isn't a
   // step away from the text, it's what holds the text apart from the basemap.
   describe('derived text halo', () => {

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -89,7 +89,7 @@ describe('MapLibreTheme', () => {
   // numeral has to be readable on it in either mode. Asserted as that relationship, and as the
   // guarantee that rests on it, rather than against a hex.
   describe('derived marker colors', () => {
-    const tokens = { '--ogm-data-color': '#8f1414', '--ogm-selected-color': '#e98300' };
+    const tokens = { '--ogm-data-color': '#8f1414', '--ogm-highlight-color': '#e98300' };
 
     it('sinks a color to the depth a number can be read on', () => {
       const { dataColor, markerColor } = themed('light', tokens).getStyle();
@@ -106,13 +106,11 @@ describe('MapLibreTheme', () => {
       expect(dark.markerColor).toBe(light.markerColor);
     });
 
-    // From the selected color rather than the hovered one: a hover is what points a result out, but
-    // what it means is that this is the one being read
-    it('derives the marker of the result being pointed at from the selected color', () => {
-      const { selectedColor, markerSelectedColor } = themed('light', tokens).getStyle();
+    it('derives the highlighted marker from the highlight color', () => {
+      const { highlightColor, markerHighlightColor } = themed('light', tokens).getStyle();
 
-      expect(markerSelectedColor).toBe(atLightness(selectedColor, 0.45));
-      expect(markerSelectedColor).not.toBe(themed('light', tokens).getStyle().markerColor);
+      expect(markerHighlightColor).toBe(atLightness(highlightColor, 0.45));
+      expect(markerHighlightColor).not.toBe(themed('light', tokens).getStyle().markerColor);
     });
 
     // What the numeral's own color rests on. It is chosen by contrast at the point of drawing, so a
@@ -121,22 +119,22 @@ describe('MapLibreTheme', () => {
     // saturated pair a dark one does - and against a color pale enough that an app naming it would
     // otherwise get one.
     it('leaves both discs deep enough for white ink', () => {
-      const light = themed('light', { '--wa-color-blue-80': '#9fceff', '--wa-color-green-80': '#93da98' }).getStyle();
-      const dark = themed('dark', { '--wa-color-blue-50': '#0071ec', '--wa-color-green-50': '#00883c' }).getStyle();
-      const pale = themed('light', { '--ogm-data-color': '#ffe08a', '--ogm-selected-color': '#ffff00' }).getStyle();
+      const light = themed('light', { '--wa-color-blue-80': '#9fceff', '--wa-color-cyan-80': '#7fd6ec' }).getStyle();
+      const dark = themed('dark', { '--wa-color-blue-50': '#0071ec', '--wa-color-cyan-60': '#00a3c0' }).getStyle();
+      const pale = themed('light', { '--ogm-data-color': '#ffe08a', '--ogm-highlight-color': '#ffff00' }).getStyle();
 
       [light, dark, pale].forEach(style => {
         expect(contrastColor(style.markerColor)).toBe('#ffffff');
-        expect(contrastColor(style.markerSelectedColor)).toBe('#ffffff');
+        expect(contrastColor(style.markerHighlightColor)).toBe('#ffffff');
       });
     });
 
     it('steps aside for an app that names the disc itself', () => {
-      const named = { ...tokens, '--ogm-marker-color': '#4a0a0a', '--ogm-marker-selected-color': '#7a4600' };
+      const named = { ...tokens, '--ogm-marker-color': '#4a0a0a', '--ogm-marker-highlight-color': '#7a4600' };
       const style = themed('light', named).getStyle();
 
       expect(style.markerColor).toBe('#4a0a0a');
-      expect(style.markerSelectedColor).toBe('#7a4600');
+      expect(style.markerHighlightColor).toBe('#7a4600');
     });
   });
 

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -89,7 +89,7 @@ describe('MapLibreTheme', () => {
   // numeral has to be readable on it in either mode. Asserted as that relationship, and as the
   // guarantee that rests on it, rather than against a hex.
   describe('derived marker colors', () => {
-    const tokens = { '--ogm-data-color': '#8f1414', '--ogm-highlight-color': '#e98300' };
+    const tokens = { '--ogm-data-color': '#8f1414', '--ogm-selected-color': '#e98300' };
 
     it('sinks a color to the depth a number can be read on', () => {
       const { dataColor, markerColor } = themed('light', tokens).getStyle();
@@ -106,11 +106,13 @@ describe('MapLibreTheme', () => {
       expect(dark.markerColor).toBe(light.markerColor);
     });
 
-    it('derives the highlighted marker from the highlight color', () => {
-      const { highlightColor, markerHighlightColor } = themed('light', tokens).getStyle();
+    // From the selected color rather than the hovered one: a hover is what points a result out, but
+    // what it means is that this is the one being read
+    it('derives the marker of the result being pointed at from the selected color', () => {
+      const { selectedColor, markerSelectedColor } = themed('light', tokens).getStyle();
 
-      expect(markerHighlightColor).toBe(atLightness(highlightColor, 0.45));
-      expect(markerHighlightColor).not.toBe(themed('light', tokens).getStyle().markerColor);
+      expect(markerSelectedColor).toBe(atLightness(selectedColor, 0.45));
+      expect(markerSelectedColor).not.toBe(themed('light', tokens).getStyle().markerColor);
     });
 
     // What the numeral's own color rests on. It is chosen by contrast at the point of drawing, so a
@@ -119,22 +121,22 @@ describe('MapLibreTheme', () => {
     // saturated pair a dark one does - and against a color pale enough that an app naming it would
     // otherwise get one.
     it('leaves both discs deep enough for white ink', () => {
-      const light = themed('light', { '--wa-color-blue-80': '#9fceff', '--wa-color-cyan-80': '#7fd6ec' }).getStyle();
-      const dark = themed('dark', { '--wa-color-blue-50': '#0071ec', '--wa-color-cyan-60': '#00a3c0' }).getStyle();
-      const pale = themed('light', { '--ogm-data-color': '#ffe08a', '--ogm-highlight-color': '#ffff00' }).getStyle();
+      const light = themed('light', { '--wa-color-blue-80': '#9fceff', '--wa-color-green-80': '#93da98' }).getStyle();
+      const dark = themed('dark', { '--wa-color-blue-50': '#0071ec', '--wa-color-green-50': '#00883c' }).getStyle();
+      const pale = themed('light', { '--ogm-data-color': '#ffe08a', '--ogm-selected-color': '#ffff00' }).getStyle();
 
       [light, dark, pale].forEach(style => {
         expect(contrastColor(style.markerColor)).toBe('#ffffff');
-        expect(contrastColor(style.markerHighlightColor)).toBe('#ffffff');
+        expect(contrastColor(style.markerSelectedColor)).toBe('#ffffff');
       });
     });
 
     it('steps aside for an app that names the disc itself', () => {
-      const named = { ...tokens, '--ogm-marker-color': '#4a0a0a', '--ogm-marker-highlight-color': '#7a4600' };
+      const named = { ...tokens, '--ogm-marker-color': '#4a0a0a', '--ogm-marker-selected-color': '#7a4600' };
       const style = themed('light', named).getStyle();
 
       expect(style.markerColor).toBe('#4a0a0a');
-      expect(style.markerHighlightColor).toBe('#7a4600');
+      expect(style.markerSelectedColor).toBe('#7a4600');
     });
   });
 

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -11,8 +11,7 @@ export type MapLibreStyle = {
   highlightColor: string;
   selectedColor: string;
   invalidColor: string;
-  // CSS colors for the disc a result's number is drawn on, and for the disc of a result being
-  // highlighted - by a pointer over its number, or by something outside pointing at it
+  // Circular markers used on the overview map
   markerColor: string;
   markerHighlightColor: string;
   // CSS colors used for polygon outlines & circle borders

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -25,6 +25,9 @@ export type MapLibreStyle = {
   textHaloColor: string;
   textFont: string;
   textSize: number;
+  // A CSS font stack, for text this library draws itself rather than asking MapLibre to draw - see
+  // textFont, which names something else entirely
+  markerFont: string;
   // Opacity for highlighted polygons/circles
   highlightOpacity: number;
   // Initial opacity for a preview that says where a record is rather than showing its data: a
@@ -38,6 +41,12 @@ export type MapLibreStyle = {
 // URLs to MapLibre style documents for basemaps
 export const darkBasemapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 export const lightBasemapStyle = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+// What a result's number is drawn in when neither an app nor the palette has said. A CSS font stack,
+// unlike the glyph name below: the numbers are drawn into an image of our own rather than handed to
+// MapLibre, which is also the only reason they can be bold at all - see markerImage. Web Awesome's own
+// body font comes first, so the numbers match whatever the rest of the page is set in.
+const defaultMarkerFont = 'system-ui, sans-serif';
 
 // Default MapLibre `text-font` glyph name. Unlike the rest of our text styling, this can't fall
 // back to a CSS token: `text-font` names a glyph MapLibre requests from the style's glyphs
@@ -108,6 +117,7 @@ export default class MapLibreTheme extends Theme {
       textHaloColor: this.haloColor(textColor),
       textFont: this.readCssProperty('--ogm-font-family') || defaultGlyphFont,
       textSize: this.readCssNumber('--ogm-text-size', 14),
+      markerFont: this.readCssProperty('--ogm-marker-font') || this.readCssProperty('--wa-font-family-body') || defaultMarkerFont,
       highlightOpacity: this.readCssNumber('--ogm-highlight-opacity', 0.8),
       boundsOpacity: this.readCssNumber('--ogm-bounds-opacity', 0.6),
       overviewPadding: this.getOverviewPadding(),

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -11,11 +11,10 @@ export type MapLibreStyle = {
   highlightColor: string;
   selectedColor: string;
   invalidColor: string;
-  // CSS colors for the disc a result's number is drawn on, and for the disc of the one result
-  // something outside has pointed at. That one is drawn as selected rather than as hovered: what
-  // points at it is a hover, but what it means is that this is the result being read.
+  // CSS colors for the disc a result's number is drawn on, and for the disc of a result being
+  // highlighted - by a pointer over its number, or by something outside pointing at it
   markerColor: string;
-  markerSelectedColor: string;
+  markerHighlightColor: string;
   // CSS colors used for polygon outlines & circle borders
   strokeColor: string;
   strokeHighlightColor: string;
@@ -109,7 +108,7 @@ export default class MapLibreTheme extends Theme {
       selectedColor,
       invalidColor,
       markerColor: this.markerColor('--ogm-marker-color', dataColor),
-      markerSelectedColor: this.markerColor('--ogm-marker-selected-color', selectedColor),
+      markerHighlightColor: this.markerColor('--ogm-marker-highlight-color', highlightColor),
       strokeColor: this.strokeColor('--ogm-stroke-color', dataColor),
       strokeHighlightColor: this.strokeColor('--ogm-stroke-highlight-color', highlightColor),
       strokeSelectedColor: this.strokeColor('--ogm-stroke-selected-color', selectedColor),

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -1,6 +1,6 @@
 import type { SkySpecification } from 'maplibre-gl';
 
-import { contrastColor, shiftLightness } from './color';
+import { atLightness, contrastColor, shiftLightness } from './color';
 import Theme from './theme';
 
 export type MapLibreStyle = {
@@ -11,6 +11,10 @@ export type MapLibreStyle = {
   highlightColor: string;
   selectedColor: string;
   invalidColor: string;
+  // CSS colors for the disc a result's number is drawn on, and for the disc of the one result
+  // something outside has asked to highlight
+  markerColor: string;
+  markerHighlightColor: string;
   // CSS colors used for polygon outlines & circle borders
   strokeColor: string;
   strokeHighlightColor: string;
@@ -48,7 +52,15 @@ const defaultGlyphFont = 'Noto Sans Regular';
 // the way it did, and one that names a color gets an outline that follows it into either mode.
 const strokeLightnessShift = 0.26;
 
-// Larger padding used for overviews (static map, search results)
+// How deep the disc a result's number is drawn on sits, in OKLab lightness. A target rather than a
+// step, unlike the outline above: a number has to be readable on its disc in both modes, and the two
+// tokens behind one color start at opposite ends of the scale, so the same step from each would land
+// one of them either side of the point where white stops being the more readable ink. Every color in
+// the palette clears that point at this value, and so does anything an app is likely to name, which
+// is what lets the numeral be white by construction rather than by luck.
+const markerLightness = 0.45;
+
+// Larger padding used for overviews (search results, locators)
 const defaultOverviewPadding = 64;
 
 // Style properties common to all MapLibre-based previewers
@@ -86,6 +98,8 @@ export default class MapLibreTheme extends Theme {
       highlightColor,
       selectedColor,
       invalidColor,
+      markerColor: this.markerColor('--ogm-marker-color', dataColor),
+      markerHighlightColor: this.markerColor('--ogm-marker-highlight-color', highlightColor),
       strokeColor: this.strokeColor('--ogm-stroke-color', dataColor),
       strokeHighlightColor: this.strokeColor('--ogm-stroke-highlight-color', highlightColor),
       strokeSelectedColor: this.strokeColor('--ogm-stroke-selected-color', selectedColor),
@@ -115,6 +129,16 @@ export default class MapLibreTheme extends Theme {
   // had to name both could only name one pair for both modes. This one follows the mode.
   strokeColor(override: string, dataColor: string): string {
     return this.readCssProperty(override) || shiftLightness(dataColor, this.darkMode() ? strokeLightnessShift : -strokeLightnessShift);
+  }
+
+  // The disc a result's number is read against, unless an app named one. Derived for the reason the
+  // outline above is - an app that named --ogm-data-color has named this too, and one that had to name
+  // both could only name a pair for a single mode - but derived to a lightness rather than by a step,
+  // because this one has to carry a numeral. See markerLightness. Whatever comes out, the numeral is
+  // drawn in whichever of black and white can be read on it, so an app that does name a color of its
+  // own gets ink that follows it.
+  markerColor(override: string, color: string): string {
+    return this.readCssProperty(override) || atLightness(color, markerLightness);
   }
 
   // What a label is read against, derived the same way, but to the opposite end of the scale rather

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -12,9 +12,10 @@ export type MapLibreStyle = {
   selectedColor: string;
   invalidColor: string;
   // CSS colors for the disc a result's number is drawn on, and for the disc of the one result
-  // something outside has asked to highlight
+  // something outside has pointed at. That one is drawn as selected rather than as hovered: what
+  // points at it is a hover, but what it means is that this is the result being read.
   markerColor: string;
-  markerHighlightColor: string;
+  markerSelectedColor: string;
   // CSS colors used for polygon outlines & circle borders
   strokeColor: string;
   strokeHighlightColor: string;
@@ -108,7 +109,7 @@ export default class MapLibreTheme extends Theme {
       selectedColor,
       invalidColor,
       markerColor: this.markerColor('--ogm-marker-color', dataColor),
-      markerHighlightColor: this.markerColor('--ogm-marker-highlight-color', highlightColor),
+      markerSelectedColor: this.markerColor('--ogm-marker-selected-color', selectedColor),
       strokeColor: this.strokeColor('--ogm-stroke-color', dataColor),
       strokeHighlightColor: this.strokeColor('--ogm-stroke-highlight-color', highlightColor),
       strokeSelectedColor: this.strokeColor('--ogm-stroke-selected-color', selectedColor),

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -26,6 +26,7 @@ import './dist/components/ogm-alerts.js';
 import './dist/components/ogm-attributes.js';
 import './dist/components/ogm-image.js';
 import './dist/components/ogm-layers.js';
+import './dist/components/ogm-locator.js';
 import './dist/components/ogm-map.js';
 import './dist/components/ogm-menubar.js';
 import './dist/components/ogm-metadata.js';


### PR DESCRIPTION
This separates overview maps from locator maps and reworks both for easier inclusion in GeoBlacklight.