### PR TITLE
Fix every component failing to construct in the lazy build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "stencil-test",
     "test:unit": "stencil-test --project unit",
     "test:component": "stencil-test --project component",
+    "test:www": "stencil-test --project www",
     "generate": "stencil generate",
     "lint": "tsc --noEmit && prettier --check ."
   },

--- a/src/lib/init.test.ts
+++ b/src/lib/init.test.ts
@@ -39,6 +39,18 @@ describe('initialTheme', () => {
     expect(initialTheme(el)).toEqual('dark');
   });
 
+  // The lazy build asks without an element: a @Prop's default runs as a class field initializer,
+  // ahead of the constructor body that registers the host ref @Element() reads from, so there is
+  // nothing to read an attribute off yet. Answering with the preference is right *and* enough there
+  // - the runtime has the attribute either way, and puts it on the prop before anything renders -
+  // where throwing takes the component's whole construction down with it. That is what it used to
+  // do; src/lib/init.www.test.ts holds the other end of that story.
+  it('falls back to the browser preference when there is no element yet', () => {
+    preferDark(true);
+
+    expect(initialTheme(undefined)).toEqual('dark');
+  });
+
   // An attribute naming neither theme isn't a statement about either one - it's read the same as no
   // attribute at all, rather than, say, coerced to whichever name it happens to resemble.
   it('falls back to the browser preference for an attribute naming neither theme', () => {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -83,8 +83,21 @@ export const themePreference = (): 'light' | 'dark' => (window.matchMedia?.('(pr
 /**
  * What to open a component's `theme` prop with, before anyone has had a chance to set it: the
  * attribute already on the tag, or themePreference() when there isn't one.
+ *
+ * The element is optional because of *when* a @Prop default is evaluated: it compiles to a class
+ * field initializer, and those run ahead of the constructor's own body. That is early enough to
+ * matter in the lazy build, where @Element() becomes a getter over the host ref and the ref is only
+ * registered by the constructor's first statement - so a field reading it gets undefined, and
+ * anything it calls has to survive that. (Under dist-custom-elements the instance *is* the element,
+ * which is why the same field reads fine there, and why nothing but the lazy build ever noticed.)
+ *
+ * Falling back to the preference there costs no accuracy: the lazy runtime has already recorded the
+ * `theme` attribute against the prop by the time it builds the instance - it does that as the element
+ * upgrades - and it keeps that value over one a field initializer writes during construction. So a
+ * tag that named a theme still renders in it, first frame included, which is the whole point of
+ * resolving a theme this early.
  */
-export const initialTheme = (el: Element): 'light' | 'dark' => {
-  const attr = el.getAttribute('theme');
+export const initialTheme = (el?: Element): 'light' | 'dark' => {
+  const attr = el?.getAttribute('theme');
   return attr === 'light' || attr === 'dark' ? attr : themePreference();
 };

--- a/src/lib/init.www.test.ts
+++ b/src/lib/init.www.test.ts
@@ -1,0 +1,84 @@
+/**
+ * What initialTheme() is for, checked against the build that made it necessary: the lazy one, out of
+ * www/, loaded by src/index.html and by the GitHub Pages preview site. A @Prop's default compiles to
+ * a class field initializer, which runs before the constructor body that registers the host ref -
+ * and this is the build where @Element() is a getter over that ref, so a default reading it reads
+ * undefined. Every component below opened by doing exactly that, and every one of them failed to
+ * construct: no `hydrated` class, an empty shadow root, nothing on the page at all.
+ *
+ * So these tests ask each of them for the two things that has to hold however the theme is arrived
+ * at - that it constructs, and that the theme it opens in is the one its own tag named - by driving
+ * the built bundle through its own loader. Nothing else in the suite can: the plugin that compiles a
+ * component for a test emits the custom-elements form, where the instance *is* the element and the
+ * same field reads fine. See src/lib/init.test.ts for initialTheme() on its own.
+ *
+ * Reads the built output, so `npm run build` has to have run first.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+
+// Imported through a variable to keep tsc out of it: this is built JavaScript with no declarations
+// beside it, and the loader defines every component in the library as a side effect of being run.
+const LOADER = '../../www/build/ogm-viewer.esm.js';
+
+// Every component that resolves its own opening theme, which is every one that can be used on its
+// own plus the ones <ogm-viewer> renders - see initialTheme's callers.
+const TAGS = ['ogm-viewer', 'ogm-locator', 'ogm-overview', 'ogm-alerts', 'ogm-preview', 'ogm-previews', 'ogm-map', 'ogm-image'];
+
+// Stands in for the browser's own preference, the way init.test.ts does it, so that each test can
+// name a preference that disagrees with the answer it expects.
+const preferDark = (dark: boolean) => vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: dark }));
+
+// The wa-light/wa-dark classes a host was given over its lifetime, in the order it got them. Both
+// would be present if a component rendered once in one theme and then corrected itself, which is the
+// flash initialTheme() exists to prevent and which asserting on the settled class alone would miss.
+const themesNamed = (classes: string[]): string[] => [...new Set(classes.flatMap(className => className.split(' ')).filter(name => name === 'wa-light' || name === 'wa-dark'))];
+
+// Mount a component the way a page does - attribute first, then into the document - and wait for the
+// class the runtime adds once it has rendered. A component that never constructs never gets it, so
+// the wait is bounded well short of the test timeout to fail as an assertion rather than a timeout.
+const mount = async (tag: string, theme?: 'light' | 'dark') => {
+  const el = document.createElement(tag) as HTMLElement & { theme?: 'light' | 'dark' };
+  const classes: string[] = [];
+  new MutationObserver(records => records.forEach(record => classes.push((record.target as Element).className))).observe(el, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+  if (theme) el.setAttribute('theme', theme);
+
+  document.body.append(el);
+  for (let i = 0; i < 80 && !el.classList.contains('hydrated'); i += 1) await new Promise(resolve => setTimeout(resolve, 25));
+  return { el, classes };
+};
+
+beforeAll(async () => {
+  await import(LOADER);
+
+  // Warm the bundle: the loader fetches the entry chunk the first time a component of ours is asked
+  // for, and that one component would otherwise be waiting on a download the rest of them aren't.
+  await mount('ogm-alerts');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe.each(TAGS)('<%s> in the lazy build', tag => {
+  it('constructs, and opens in the theme its own tag names', async () => {
+    preferDark(false);
+    const { el, classes } = await mount(tag, 'dark');
+
+    expect(el.className).toContain('hydrated');
+    expect(el.theme).toEqual('dark');
+    expect(themesNamed(classes)).not.toContain('wa-light');
+  });
+
+  it('falls back to the browser preference when its tag names no theme', async () => {
+    preferDark(true);
+    const { el, classes } = await mount(tag);
+
+    expect(el.className).toContain('hydrated');
+    expect(el.theme).toEqual('dark');
+    expect(themesNamed(classes)).not.toContain('wa-light');
+  });
+});

--- a/vitest-setup-dom.ts
+++ b/vitest-setup-dom.ts
@@ -1,0 +1,59 @@
+// What any of our components need of the DOM they are tested in, whichever build they came out of:
+// the gaps happy-dom leaves, and a guarantee that nothing under test reaches the network. Shared by
+// the component project (vitest-setup.ts, which drives dist/components) and the www project (which
+// drives the built lazy bundle), since neither concern has anything to do with the output target.
+
+// Enough of ElementInternals for Web Awesome's form controls to upgrade. happy-dom implements none
+// of it (checked in 20.9), and <wa-button> reads validity out of it as it connects, so without this
+// every component that renders one throws before its own markup exists to assert on. Nothing here
+// is exercised by a test - it only has to not be undefined. Form behavior is Web Awesome's to test.
+if (!HTMLElement.prototype.attachInternals) {
+  HTMLElement.prototype.attachInternals = function attachInternals(this: HTMLElement) {
+    return {
+      form: null,
+      labels: [] as unknown as NodeList,
+      states: new Set<string>(),
+      validationMessage: '',
+      validity: { valid: true } as ValidityState,
+      willValidate: false,
+      checkValidity: () => true,
+      reportValidity: () => true,
+      setFormValue: () => {},
+      setValidity: () => {},
+    } as unknown as ElementInternals;
+  };
+}
+
+// Used to intercept requests for fixture data in tests
+const crossOrigin = (url: string | URL): boolean => {
+  try {
+    return new URL(String(url), window.location.href).origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+// Auto-reject cross-origin fetch requests to keep the test DOM off the network
+const realFetch = globalThis.fetch;
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' || input instanceof URL ? input : input.url;
+  return crossOrigin(url) ? Promise.reject(new TypeError('Failed to fetch')) : realFetch(input, init);
+}) as typeof globalThis.fetch;
+
+// Same thing but for XMLHttpRequest; we check at open() and block at send()
+const blocked = new WeakMap<XMLHttpRequest, string>();
+const realOpen = XMLHttpRequest.prototype.open;
+XMLHttpRequest.prototype.open = function (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]) {
+  if (crossOrigin(url)) blocked.set(this, String(url));
+  else blocked.delete(this);
+  return realOpen.call(this, method, url, ...(rest as []));
+};
+
+const realSend = XMLHttpRequest.prototype.send;
+XMLHttpRequest.prototype.send = function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit | null) {
+  const url = blocked.get(this);
+  if (url) throw new DOMException(`Blocked a request to "${url}": the test DOM has no server behind it.`, 'NetworkError');
+  return realSend.call(this, body);
+};
+
+export {};

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,23 +1,5 @@
-// Enough of ElementInternals for Web Awesome's form controls to upgrade. happy-dom implements none
-// of it (checked in 20.9), and <wa-button> reads validity out of it as it connects, so without this
-// every component that renders one throws before its own markup exists to assert on. Nothing here
-// is exercised by a test - it only has to not be undefined. Form behavior is Web Awesome's to test.
-if (!HTMLElement.prototype.attachInternals) {
-  HTMLElement.prototype.attachInternals = function attachInternals(this: HTMLElement) {
-    return {
-      form: null,
-      labels: [] as unknown as NodeList,
-      states: new Set<string>(),
-      validationMessage: '',
-      validity: { valid: true } as ValidityState,
-      willValidate: false,
-      checkValidity: () => true,
-      reportValidity: () => true,
-      setFormValue: () => {},
-      setValidity: () => {},
-    } as unknown as ElementInternals;
-  };
-}
+// The gaps happy-dom leaves, and the network guards - see there for both
+import './vitest-setup-dom';
 
 // Register the components under test as custom elements. The custom-elements build has no loader to
 // call: importing a component entry defines that component and everything it renders - including
@@ -40,38 +22,6 @@ import './dist/components/ogm-previews.js';
 // set". Harmless in itself, but vitest counts unhandled rejections and fails the run over them.
 // Production builds drop the profiling code entirely, so this is a test-only gap.
 performance.mark('st:app:start');
-
-// Used to intercept requests for fixture data in tests
-const crossOrigin = (url: string | URL): boolean => {
-  try {
-    return new URL(String(url), window.location.href).origin !== window.location.origin;
-  } catch {
-    return false;
-  }
-};
-
-// Auto-reject cross-origin fetch requests to keep the test DOM off the network
-const realFetch = globalThis.fetch;
-globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-  const url = typeof input === 'string' || input instanceof URL ? input : input.url;
-  return crossOrigin(url) ? Promise.reject(new TypeError('Failed to fetch')) : realFetch(input, init);
-}) as typeof globalThis.fetch;
-
-// Same thing but for XMLHttpRequest; we check at open() and block at send()
-const blocked = new WeakMap<XMLHttpRequest, string>();
-const realOpen = XMLHttpRequest.prototype.open;
-XMLHttpRequest.prototype.open = function (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]) {
-  if (crossOrigin(url)) blocked.set(this, String(url));
-  else blocked.delete(this);
-  return realOpen.call(this, method, url, ...(rest as []));
-};
-
-const realSend = XMLHttpRequest.prototype.send;
-XMLHttpRequest.prototype.send = function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit | null) {
-  const url = blocked.get(this);
-  if (url) throw new DOMException(`Blocked a request to "${url}": the test DOM has no server behind it.`, 'NetworkError');
-  return realSend.call(this, body);
-};
 
 export {};
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineVitestConfig({
         test: {
           name: 'unit',
           include: ['src/**/*.test.ts'],
+          // The www project's tests end in .test.ts too, but need a DOM and a built bundle
+          exclude: ['src/**/*.www.test.ts'],
           environment: 'node',
         },
       },
@@ -26,6 +28,27 @@ export default defineVitestConfig({
             },
           },
           setupFiles: ['./vitest-setup.ts'],
+        },
+      },
+      // The lazy build - the one src/index.html and the GitHub Pages preview site load - driven
+      // through its own loader, out of www/, rather than compiled here. Nothing else in the suite
+      // can see that build: the plugin that compiles a .tsx for a test emits the custom-elements
+      // form of a component, and the component project imports dist/components on top of that. So
+      // whatever the lazy loader and runtime do differently - and they construct a component
+      // differently enough to have broken every one of them once - only these tests can catch.
+      {
+        test: {
+          name: 'www',
+          include: ['src/**/*.www.test.ts'],
+          environment: 'happy-dom',
+          environmentOptions: {
+            happyDOM: {
+              settings: {
+                fetch: { virtualServers: [{ url: /^https?:\/\/[^/]+\/.*\/assets(?=\/)/, directory: './www/build/assets' }] },
+              },
+            },
+          },
+          setupFiles: ['./vitest-setup-dom.ts'],
         },
       },
     ],


### PR DESCRIPTION
The `www` output target — what `src/index.html` and the GitHub Pages preview site load — rendered nothing at all. `<ogm-viewer>`, `<ogm-locator>` and `<ogm-overview>` never got their `hydrated` class, their shadow roots stayed empty, and the console showed one `TypeError: Cannot read properties of undefined (reading 'getAttribute')` per component, out of `initialTheme`.

## Why

`@Prop() theme: 'light' | 'dark' = initialTheme(this.el)` compiles to a class field initializer, and those run ahead of the constructor body. In the lazy build that is too early: `@Element()` becomes `get el() { return getElement(this); }` over a host ref that `registerInstance(this, hostRef)` — the constructor's own first statement — hasn't set yet, so the field read `undefined` and called `getAttribute` on it. `dist-custom-elements` emits `get el() { return this; }`, so the same field reads fine there, which is why the unit tests and any consumer importing `dist/components` saw nothing wrong.

The second error on that page, `Can't render component <ogm-locator /> with invalid Stencil runtime! ... externalRuntime: true`, was a consequence rather than a separate bug: construction threw before `registerInstance`, so `hostRef.$lazyInstance$` stayed undefined and `dispatchHooks` blamed the runtime. Confirmed by reproducing that same message from a bundle patched back to the old behavior — `./build/index.esm.js` is not pulling a second copy of anything.

## The fix

`initialTheme` takes the element optionally and reads through `el?.getAttribute('theme')`. All eight call sites are unchanged.

This keeps what 66787a5 was for. The fallback is never what a themed tag actually renders: as the element upgrades, `attributeChangedCallback` records `theme` against the prop, and `setValue` keeps that recorded value over one a field initializer writes during construction (`!(flags & isConstructingInstance) || oldVal === undefined`). Reading the attribute at construction is still what resolves the theme under `dist-custom-elements`, where the field can see it.

Verified in real Chromium against a served production `www` build, with a MutationObserver installed before the bundle: for `<ogm-viewer theme="dark">`, `<ogm-locator theme="dark">` and `<ogm-overview theme="dark">` the *first* class each host is ever given is `wa-dark` — `wa-light` never appears — and the console is clean on both that page and `www/index.html`.

## Tests

There is a way to cover the lazy path: the built loader can be imported in happy-dom and hydrates for real. `src/lib/init.www.test.ts` mounts each of the eight themed components attribute-first and asks for three things — that it gets `hydrated` at all, that `el.theme` is the theme its tag named, and that no class it ever carried named the other theme (the flash check, which asserting on the settled class alone would miss). Against a bundle patched back to `el.getAttribute`, all 16 cases fail with `expected '' to contain 'hydrated'`.

It runs under a new `www` vitest project, because nothing else in the suite can see that build: `@stencil/vitest` transpiles each `.tsx` with `componentExport: 'customelement'`, and the component project imports `dist/components` on top of that. `unit` gains an `exclude` for `*.www.test.ts`, which its `src/**/*.test.ts` pattern would otherwise pick up in a node environment.

Reviewer notes:

- The happy-dom `ElementInternals` shim and the cross-origin `fetch`/`XHR` guards move from `vitest-setup.ts` to `vitest-setup-dom.ts` so both DOM projects share one copy, comments intact. `vitest-setup.ts` keeps what only the custom-elements project needs.
- `src/lib/init.www.test.ts` imports the loader through a `const` so `tsc --noEmit` leaves the built JavaScript alone.
- `npm test` builds first, so the new project needs no extra setup in CI; run on its own it wants `npm run build`, same as the component project. `npm run test:www` added alongside the existing per-project scripts.

`npm test` — 972 passed, 58 files. `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
