### PR TITLE
Decode COG tiles off the main thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@vitest/coverage-v8": "^4.1.7",
         "happy-dom": "^20.9.0",
         "prettier": "^3.6.2",
+        "rolldown": "^1.0.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@vitest/coverage-v8": "^4.1.7",
     "happy-dom": "^20.9.0",
     "prettier": "^3.6.2",
+    "rolldown": "^1.0.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
   },

--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,12 @@ Set `bounds` to the area a search is currently filtered to. It's drawn as a box 
 <ogm-overview bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
 ```
 
+### Content Security Policy
+
+The viewer runs work off the main thread in web workers: MapLibre's own, and one pool that decodes Cloud Optimized GeoTIFF tiles. Both are built from source the bundle carries rather than from files of their own, so a page that sets a Content-Security-Policy needs `blob:` in `worker-src` - or in whichever of `child-src`, `script-src` or `default-src` it falls back to. In a document with an opaque origin, such as a sandboxed iframe, the decoder uses a `data:` URL instead, which a policy would have to allow in the same place.
+
+Without either, the map cannot be drawn at all, and COG tiles are decoded on the main thread: slower, but still drawn.
+
 ## Development
 
 After cloning the repository, install dependencies:

--- a/src/lib/decoder-worker-source.ts
+++ b/src/lib/decoder-worker-source.ts
@@ -1,0 +1,7 @@
+// The bundled decoder worker, inlined here at build time by stencil.config.ts.
+//
+// Empty as written, and empty in any build that doesn't run that plugin - which is the case for the
+// unit tests, since they import this module rather than the built output. An empty source is what
+// makes createDecoderPool fall back to decoding on the main thread instead of starting a worker with
+// no decoder in it, so a build without the plugin is slower rather than broken.
+export const DECODER_WORKER_SOURCE = '';

--- a/src/lib/decoder-worker.ts
+++ b/src/lib/decoder-worker.ts
@@ -1,0 +1,10 @@
+// What runs inside a COG decoder worker: upstream's own handler, which answers the message protocol
+// its DecoderPool speaks - so the two can never drift out of step, as a copy of the protocol here
+// would. Its only export is that side effect, which is why the bundle that inlines this file has to
+// be told to keep it: @developmentseed/geotiff declares itself side-effect free, and left to shake
+// what it likes a bundler reduces this whole file to nothing.
+//
+// Nothing imports this module. The build bundles it on its own and inlines the result as a string
+// for the pool to start workers from; see createDecoderWorker in decoder.ts for why they start from
+// a string rather than a file, and stencil.config.ts for how the string gets there.
+import '@developmentseed/geotiff/pool/worker';

--- a/src/lib/decoder.test.ts
+++ b/src/lib/decoder.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, afterEach } from '@stencil/vitest';
+
+import { createDecoderPool, decoderPool } from './decoder';
+
+// Enough of a Worker for DecoderPool, which only ever adds a message listener, posts a job and
+// terminates - and for createDecoderPool, which also listens for the two failures a worker reports as
+// events. Records what it was built with, and lets a test answer or fail a job on its behalf.
+class StubWorker {
+  static built: { url: string; type?: string }[] = [];
+
+  private listeners = new Map<string, ((event: unknown) => void)[]>();
+  posted: unknown[] = [];
+  terminated = false;
+
+  constructor(url: string | URL, options?: WorkerOptions) {
+    StubWorker.built.push({ url: String(url), type: options?.type });
+    StubWorker.last = this;
+  }
+
+  static last: StubWorker | undefined;
+
+  addEventListener(type: string, listener: (event: unknown) => void) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  postMessage(message: unknown) {
+    this.posted.push(message);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  // Answer the job just posted, as the real worker's handler would
+  answer(pixels: unknown) {
+    const { jobId } = this.posted[this.posted.length - 1] as { jobId: number };
+    this.emit('message', { data: { jobId, pixels } });
+  }
+
+  emit(type: string, event: unknown) {
+    (this.listeners.get(type) ?? []).forEach(listener => listener(event));
+  }
+}
+
+// One 2x2 tile of uncompressed 8-bit samples: Compression.None, so the main thread can decode it
+// without a codec, which is what makes the fallback checkable rather than only observable.
+const TILE_METADATA = { width: 2, height: 2, bitsPerSample: 8, samplesPerPixel: 1, planarConfiguration: 1, predictor: 1, sampleFormat: 1 };
+const UNCOMPRESSED = 1;
+const tile = () => new Uint8Array([1, 2, 3, 4]).buffer;
+
+// The bundled worker, as stencil.config.ts inlines it. Never run: every test here stubs Worker.
+const SOURCE = 'self.addEventListener("message", () => {})';
+
+const withWorkers = (size = 2) => {
+  vi.stubGlobal('Worker', StubWorker);
+  return createDecoderPool(SOURCE, size);
+};
+
+afterEach(() => {
+  // console.warn is spied on more than once here, and vitest hands back the same spy when a method
+  // is already mocked - so without this the calls of one test are the calls of the next.
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  StubWorker.built = [];
+  StubWorker.last = undefined;
+});
+
+describe('createDecoderPool', () => {
+  it('decodes in workers, which is the whole point of it', () => {
+    const pool = withWorkers(3);
+
+    expect(pool.hasWorkers).toBe(true);
+    expect(StubWorker.built).toHaveLength(3);
+  });
+
+  // A worker has to be same-origin, and this library is usually loaded from a CDN, so its source
+  // travels in the bundle and the worker is started from a blob of it. See decoder.ts.
+  it('starts each worker from a blob of the inlined source, as a module', () => {
+    withWorkers(1);
+
+    expect(StubWorker.built[0].url).toMatch(/^blob:/);
+    expect(StubWorker.built[0].type).toEqual('module');
+  });
+
+  it('decodes on the main thread when the build inlined no worker', () => {
+    vi.stubGlobal('Worker', StubWorker);
+
+    expect(createDecoderPool('').hasWorkers).toBe(false);
+    expect(StubWorker.built).toEqual([]);
+  });
+
+  // Node, and happy-dom - so the tests that load the built output don't try to start one either
+  it('decodes on the main thread where there is no Worker at all', () => {
+    vi.stubGlobal('Worker', undefined);
+
+    expect(createDecoderPool(SOURCE).hasWorkers).toBe(false);
+  });
+
+  // The likeliest refusal in the wild, and the one that arrives as a thrown error rather than an
+  // event: a Content-Security-Policy with no `worker-src blob:`. Uncaught it would fail the preview
+  // over a decoder that only makes it faster.
+  it('decodes on the main thread when the page refuses to start a worker at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal(
+      'Worker',
+      class {
+        constructor() {
+          throw new DOMException('Refused to create a worker from blob:', 'SecurityError');
+        }
+      },
+    );
+
+    expect(createDecoderPool(SOURCE).hasWorkers).toBe(false);
+    expect(warn.mock.calls[0][0]).toContain('decoded on the main thread');
+  });
+
+  it('hands a tile to a worker and gives back what it answers', async () => {
+    const pool = withWorkers(1);
+    const decoded = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+
+    StubWorker.last!.answer({ layout: 'pixel-interleaved', data: new Uint8Array([9, 9, 9, 9]) });
+
+    expect(((await decoded) as { data: Uint8Array }).data).toEqual(new Uint8Array([9, 9, 9, 9]));
+    expect(pool.hasWorkers).toBe(true);
+  });
+
+  // The failure worth guarding against: a worker that can't start answers nothing at all, so the
+  // job it was given would never settle and the tile would never be drawn. The tile is decoded in
+  // place instead, from the copy taken before the bytes were transferred away.
+  it('draws the tile on the main thread when a worker cannot start', async () => {
+    const pool = withWorkers(1);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const decoded = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+
+    StubWorker.last!.emit('error', { message: 'Refused to create a worker from blob:' });
+
+    expect(((await decoded) as { data: Uint8Array }).data).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(warn.mock.calls[0][0]).toContain('decoding them on the main thread instead');
+  });
+
+  // And every tile after it, rather than each one paying for the same discovery again
+  it('stops using the workers once they have failed once', async () => {
+    const pool = withWorkers(1);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const decoded = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+    StubWorker.last!.emit('error', {});
+    await decoded;
+
+    expect(pool.hasWorkers).toBe(false);
+    expect(StubWorker.last!.terminated).toBe(true);
+
+    const posted = StubWorker.last!.posted.length;
+    const next = await pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+
+    expect((next as { data: Uint8Array }).data).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(StubWorker.last!.posted).toHaveLength(posted);
+  });
+
+  // A worker that dies with a job in flight never answers it, and the pool leaves that job pending
+  // for good: deck.gl throttles tile requests, so six of those and the layer stops asking for tiles
+  // at all. Failing the tile is what keeps the layer loading.
+  it('fails a tile rather than leaving it pending when a worker dies mid-session', async () => {
+    const pool = withWorkers(1);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const first = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+    StubWorker.last!.answer({ layout: 'pixel-interleaved', data: new Uint8Array([9]) });
+    await first;
+
+    const lost = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+    StubWorker.last!.emit('error', { message: 'out of memory' });
+
+    await expect(lost).rejects.toThrow('could not start');
+    expect(pool.hasWorkers).toBe(false);
+
+    // And the next tile is decoded here instead of asking the workers that just died
+    expect(((await pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never)) as { data: Uint8Array }).data).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  // A document with an opaque origin - a sandboxed iframe, which is how sul-embed is embedded - has
+  // no origin for a blob URL to inherit, and Chromium refuses a module worker from one of those.
+  it('starts the worker from a data URL where a blob has no origin to inherit', () => {
+    vi.stubGlobal('Worker', StubWorker);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:null/4a1c-0000');
+    const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    createDecoderPool(SOURCE, 1);
+
+    expect(StubWorker.built[0].url).toEqual(`data:text/javascript;charset=utf-8,${encodeURIComponent(SOURCE)}`);
+    expect(StubWorker.built[0].type).toEqual('module');
+    // The blob that couldn't be used is let go rather than left holding a copy of the source
+    expect(revoke).toHaveBeenCalledWith('blob:null/4a1c-0000');
+  });
+
+  // A worker that starts and then says nothing is the same problem arriving more slowly
+  it('gives up on a worker that never answers', async () => {
+    vi.useFakeTimers();
+    const pool = withWorkers(1);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const decoded = pool.decode(tile(), UNCOMPRESSED, TILE_METADATA as never);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(((await decoded) as { data: Uint8Array }).data).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(pool.hasWorkers).toBe(false);
+  });
+});
+
+describe('decoderPool', () => {
+  // A results page draws an overview map per record, and a record can offer more than one COG. A
+  // pool each would be a page with a multiple of the pool size in workers on it.
+  it('is one pool for every COG on the page', () => {
+    expect(decoderPool()).toBe(decoderPool());
+  });
+});

--- a/src/lib/decoder.ts
+++ b/src/lib/decoder.ts
@@ -1,0 +1,193 @@
+import { DecoderPool, type DecodedPixels, type DecoderPoolOptions } from '@developmentseed/geotiff';
+
+import { DECODER_WORKER_SOURCE } from './decoder-worker-source';
+
+// How many workers decode tiles. deck.gl asks for a viewport's worth at once, so more than one is
+// worth having, but it also throttles itself to six tile requests at a time - so a pool much bigger
+// than that could never be busy. A fixed number rather than navigator.hardwareConcurrency, which is
+// what upstream's default pool uses: every worker is another copy of the decoders, wasm included, and
+// a machine reporting sixteen cores has no more COG in front of it than one reporting four.
+const POOL_SIZE = 4;
+
+// How long the first tile has to come back from a worker before the pool gives up on workers
+// altogether. Only ever waited out when something is wrong - a worker that runs at all answers in
+// milliseconds - so it is set to be unmistakable rather than tight. See FallbackDecoderPool.
+const FIRST_DECODE_TIMEOUT = 10_000;
+
+// The arguments and answer of a decode, taken from the pool itself rather than named here: the
+// compression is @cogeotiff/core's enum, which this library doesn't depend on directly.
+type DecodeArguments = Parameters<DecoderPool['decode']>;
+
+// Starts a decoder worker from source held in this bundle, rather than from a file of its own.
+//
+// A worker has to be same-origin, and this library is usually not: GeoBlacklight and sul-embed both
+// load it from a CDN through an importmap, so a worker built from a URL beside this module would be
+// refused outright (SecurityError, thrown by the constructor). A blob is same-origin wherever the
+// page is, which is how MapLibre and Allmaps already start their own workers in this bundle - so the
+// one Content-Security-Policy this needs, `worker-src blob:`, is one the viewer already needs.
+//
+// Inlining the source rather than fetching it from the CDN buys the rest: no CORS to satisfy, no
+// second chance for the network to fail long after the page loaded, and nothing for a consumer's
+// bundler to resolve - which is the other half of why the URL upstream builds is a problem (#186).
+//
+// Revoked immediately, as Vite's own inlined workers do: the constructor has already resolved the
+// URL by the time it returns, and holding it would keep a copy of the source alive per worker.
+function createDecoderWorker(source: string): Worker {
+  const url = decoderWorkerUrl(source);
+
+  try {
+    return new Worker(url, { type: 'module' });
+  } finally {
+    if (url.startsWith('blob:')) URL.revokeObjectURL(url);
+  }
+}
+
+// Where the worker's source is handed to the browser from. A blob, except in a document that has no
+// origin for one to inherit - a sandboxed iframe, which is how sul-embed is embedded - where Chromium
+// refuses a module worker from a blob URL however self-contained it is. A data: URL is allowed there,
+// so the blob URL naming a null origin is the signal to use one; Allmaps' worker in this same bundle
+// keeps that pair the other way round. Only worth the longer URL where the shorter one cannot work:
+// a policy is far likelier to allow blob: in worker-src than data:.
+function decoderWorkerUrl(source: string): string {
+  const url = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
+  if (!url.startsWith('blob:null')) return url;
+
+  URL.revokeObjectURL(url);
+  return `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`;
+}
+
+// A pool that decodes in place if its workers turn out not to work.
+//
+// The ways they can fail are narrow, since they are built from source that is already here: a policy
+// that refuses blob: workers refuses them in the constructor, and a browser with no Worker at all
+// never builds this pool. But narrow is not none, and the failure that isn't a thrown error is the
+// bad one - a worker that dies on load answers nothing, and DecoderPool's job never settles, so
+// every tile of that COG would sit unfinished with nothing said about why.
+//
+// So the first tile through the pool is raced against the workers reporting themselves broken and
+// against a deadline, and a race that doesn't come back takes the workers out of service. The tile
+// itself is still drawn, from the copy kept for that purpose. Once one tile has come back the copy
+// and the deadline are dropped: the workers have answered, and a pool that keeps second-guessing them
+// would be paying for a copy of every tile it ever decodes.
+//
+// Later tiles are given up on rather than retried, but they are still given up on: a worker that dies
+// mid-session - a decode that runs the tab out of memory - leaves the job it was given pending for
+// good, and deck.gl throttles its tile requests, so six unfinished ones and the layer stops asking
+// for tiles at all. Losing the tile a dead worker was decoding is the better end of that trade.
+class FallbackDecoderPool extends DecoderPool {
+  private proven = false;
+
+  // The decodes waiting on a worker right now. DecoderPool never settles the job a terminated worker
+  // was holding, so these are the promises that would hang; they are failed by hand instead. Held as
+  // a set so each one is dropped as it finishes, rather than accumulating for the life of the pool.
+  private readonly waiting = new Set<(error: unknown) => void>();
+
+  constructor(broken: Promise<never>, options: DecoderPoolOptions) {
+    super(options);
+    // However late the news arrives, and whether or not a tile is waiting on one right now
+    broken.catch(error => this.retire(error));
+  }
+
+  async decode(...args: DecodeArguments): Promise<DecodedPixels> {
+    if (!this.hasWorkers) return await super.decode(...args);
+    if (this.proven) return await this.decodeInWorker(args);
+
+    // The pool hands the compressed bytes to a worker by transferring them, which detaches the
+    // buffer here - so the copy has to be taken before the attempt, not after it fails.
+    const [bytes, ...rest] = args;
+    const retry = bytes.slice(0);
+
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    const expiry = new Promise<never>((_, reject) => {
+      deadline = setTimeout(() => reject(new Error(`No answer from a decoder worker in ${FIRST_DECODE_TIMEOUT}ms`)), FIRST_DECODE_TIMEOUT);
+    });
+
+    try {
+      const pixels = await Promise.race([this.decodeInWorker(args), expiry]);
+      this.proven = true;
+      return pixels;
+    } catch (error) {
+      this.retire(error);
+      return await super.decode(retry, ...rest);
+    } finally {
+      clearTimeout(deadline);
+    }
+  }
+
+  private async decodeInWorker(args: DecodeArguments): Promise<DecodedPixels> {
+    let abandon: (error: unknown) => void = () => {};
+    const abandoned = new Promise<never>((_, reject) => this.waiting.add((abandon = reject)));
+
+    try {
+      return await Promise.race([super.decode(...args), abandoned]);
+    } finally {
+      this.waiting.delete(abandon);
+    }
+  }
+
+  // Take the workers out of service, so every later tile decodes on the main thread: destroy() is
+  // what turns hasWorkers off, and the pool's own decode() reads that as "decode in place". Said
+  // once however many tiles were waiting on the same broken workers.
+  private retire(error: unknown) {
+    if (!this.hasWorkers) return;
+
+    console.warn('Could not decode COG tiles in a worker, so decoding them on the main thread instead:', error);
+    this.destroy();
+    this.waiting.forEach(abandon => abandon(error));
+  }
+}
+
+// Builds a pool that decodes off the main thread, or one that decodes on it when there is no way not
+// to: a build that didn't inline the worker (the unit tests, which read this module as written), or
+// an environment with no Worker at all (Node, and happy-dom - so the tests that load the built
+// output don't try to start one either).
+export function createDecoderPool(source: string = DECODER_WORKER_SOURCE, size: number = POOL_SIZE): DecoderPool {
+  if (!source || typeof Worker === 'undefined') return new DecoderPool({ createWorker: undefined });
+
+  // Rejects as soon as any worker reports it can't run, which is what takes the pool's workers out
+  // of service. Marked handled here as well as there, because a pool that couldn't be built at all is
+  // thrown away below - and a rejection nothing is listening to is reported as an unhandled one.
+  let reportBroken: (error: unknown) => void = () => {};
+  const broken = new Promise<never>((_, reject) => (reportBroken = reject));
+  broken.catch(() => {});
+
+  const started: Worker[] = [];
+  const createWorker = () => {
+    const worker = createDecoderWorker(source);
+    worker.addEventListener('error', event => reportBroken(new Error(`A decoder worker could not start: ${event.message || 'no reason given'}`)));
+    worker.addEventListener('messageerror', () => reportBroken(new Error('A decoder worker sent something that could not be read')));
+    started.push(worker);
+    return worker;
+  };
+
+  try {
+    return new FallbackDecoderPool(broken, { size, createWorker });
+  } catch (error) {
+    // The likeliest way a worker is refused, and the one FallbackDecoderPool can't help with: a
+    // Content-Security-Policy without `worker-src blob:` throws here rather than reporting an event,
+    // and it throws while the pool is being built - so with nothing caught, the whole preview would
+    // fail over a decoder that only makes it faster. Anything already started is stopped, since the
+    // pool that would have owned them is being thrown away.
+    started.forEach(worker => worker.terminate());
+    console.warn('Could not start the decoder workers, so COG tiles will be decoded on the main thread:', error);
+    return new DecoderPool({ createWorker: undefined });
+  }
+}
+
+// One pool for every COG drawn on the page, built the first time one is.
+//
+// Shared because the alternative is a pool per preview, and previews outlive their use: a record
+// change builds new ones without tearing the old ones down, and a page can hold more than one
+// <ogm-viewer>. Each would otherwise arrive with POOL_SIZE workers of its own and keep them.
+//
+// Never destroyed, which is also what upstream's default pool does. There is nowhere to do it from -
+// clearPreview() is only reached when an app swaps the previewer on a live <ogm-map>, not on the
+// <ogm-viewer> path - and nowhere it would be right to: destroy() strands whatever job its workers
+// were holding, and previews are attached again constantly, since every theme change rebuilds the
+// style document and draws each of them from scratch.
+let shared: DecoderPool | undefined;
+
+export function decoderPool(): DecoderPool {
+  shared ??= createDecoderPool();
+  return shared;
+}

--- a/src/lib/previewers/cog-deck.test.ts
+++ b/src/lib/previewers/cog-deck.test.ts
@@ -64,6 +64,11 @@ const FAKE_GEOTIFF = { crs: 'EPSG:4326' };
 // the real previewer
 class TestDeckCogPreviewer extends DeckCogPreviewer {
   overlay = new FakeOverlay();
+
+  get pool() {
+    return this.decoderPool;
+  }
+
   opened: string[] = [];
   refusal: Error | undefined;
 
@@ -189,6 +194,15 @@ describe('DeckCogPreviewer', () => {
       const ids = previewer.overlay.props.flatMap(p => (p.layers ?? []).map((l: any) => l.id));
       expect(new Set(ids).size).toEqual(1);
     });
+  });
+
+  // Every COG on the page decodes through the same workers: a pool each would put a multiple of the
+  // pool size in workers on a results page of overview maps. See src/lib/decoder.ts.
+  it('decodes through the pool shared with every other COG', () => {
+    const { previewer } = previewFor();
+    const { previewer: other } = previewFor();
+
+    expect(previewer.pool).toBe(other.pool);
   });
 
   // deck.gl's TileLayer has no getBoundingVolume for a globe view and logs an error for every frame

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -1,10 +1,11 @@
 import { MapboxOverlay as DeckOverlay } from '@deck.gl/mapbox';
 import { COGLayer } from '@developmentseed/deck.gl-geotiff';
-import { DecoderPool, type GeoTIFF } from '@developmentseed/geotiff';
+import type { DecoderPool, GeoTIFF } from '@developmentseed/geotiff';
 import type { AddLayerObject, LngLatBoundsLike } from 'maplibre-gl';
 
 import MapPreviewer from './map';
 import type CogResource from '../resources/cog';
+import { decoderPool } from '../decoder';
 import { openGeoTIFF } from '../geotiff';
 import { isLayerDrawn, type LayerState, type PreviewStyleLayer } from '../layers';
 import type { MapLibreStyle } from '../themes/maplibre';
@@ -34,7 +35,8 @@ export default class DeckCogPreviewer extends MapPreviewer {
   protected deckOverlay: DeckOverlay | undefined;
 
   // Built once and reused: recreating it on every opacity change would throw away the decoder
-  // workers along with it, and this layer is rebuilt on each of those.
+  // workers along with it, and this layer is rebuilt on each of those. Shared with every other COG
+  // on the page - see src/lib/decoder.ts.
   protected decoderPool: DecoderPool | undefined;
 
   // What the user has asked for, held because deck.gl takes visibility and opacity as layer props,
@@ -176,11 +178,11 @@ export default class DeckCogPreviewer extends MapPreviewer {
     this.onError?.(error);
   }
 
-  // Disable the web worker decoder pool; it appears to error because it can't find /worker.js.
+  // The pool every COG on the page decodes through, workers and all - see src/lib/decoder.ts. Asked
+  // for through a method of its own so a test can hand this previewer a pool instead.
   // See: https://developmentseed.org/deck.gl-raster/api/geotiff/type-aliases/DecoderPoolOptions/
-  // See also: https://github.com/developmentseed/deck.gl-raster/issues/364
   protected createDecoderPool(): DecoderPool {
-    return new DecoderPool({ createWorker: undefined });
+    return decoderPool();
   }
 
   // The record's own bounding box when it has one, since that needs no waiting. Otherwise the COG's,

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,7 +1,114 @@
 import { Config } from '@stencil/core';
 
+// The worker that decodes COG tiles off the main thread, and the module its bundled source is
+// inlined into - siblings, so the entry is found from whichever id Rollup hands us rather than from
+// anything relative to the working directory. See src/lib/decoder.ts for why the workers start from
+// a string rather than from a file beside this bundle. Ids are matched with their separators
+// normalized, so this holds on Windows too.
+const WORKER_SOURCE_MODULE = 'src/lib/decoder-worker-source.ts';
+const WORKER_ENTRY = 'decoder-worker.ts';
+
+// Upstream's own default pool builds a worker from a URL beside whichever chunk it lands in:
+//
+//   createWorker: () => new Worker(new URL("./worker.js", import.meta.url), { type: "module" })
+//
+// COGLayer reaches for that pool whenever it isn't handed one, so the expression is in the bundle
+// whether or not anything calls it - and no worker.js is published beside the chunks, so a consumer
+// on Vite can't build at all: its worker-import-meta-url plugin resolves the URL as a worker entry
+// while transforming the chunk and stops at a file that isn't there. Replacing the factory with
+// `undefined` leaves defaultDecoderPool() working, just on the main thread, and takes the URL out of
+// the published output. The pool this library actually uses is built in src/lib/decoder.ts.
+//
+// See: https://github.com/OpenGeoMetadata/ogm-viewer/issues/186
+// See: https://github.com/developmentseed/deck.gl-raster/issues/364
+const UPSTREAM_POOL_MODULE = '@developmentseed/geotiff/dist/pool/pool.js';
+const UPSTREAM_WORKER_FACTORY = 'createWorker: () => new Worker(new URL("./worker.js", import.meta.url), { type: "module" })';
+const MISSING_WORKER_URL = './worker.js';
+
+const normalize = (id: string) => id.replace(/\\/g, '/');
+
+// Bundled once per process and reused: every output target runs its own Rollup build, and there is
+// nothing in the worker to rebuild between them. A watch session that edits WORKER_ENTRY itself
+// needs restarting, which is a fair trade for a file that is one import.
+let bundledWorker: Promise<string> | undefined;
+
+// Bundle WORKER_ENTRY into one self-contained ES module, with its dynamically imported codecs
+// inlined: a worker started from a blob URL has no directory to resolve a sibling chunk against, so
+// anything left unbundled would be unreachable. ES rather than IIFE because
+// @developmentseed/lzw-tiff-decoder initializes its wasm with top-level await - see the note on the
+// output targets below - though Rolldown hoists that into the lazy initializer it wraps an inlined
+// dynamic import in, which is what lets a consumer's bundler re-bundle this file as an IIFE.
+async function bundleDecoderWorker(entry: string): Promise<string> {
+  const { rolldown } = await import('rolldown');
+
+  const bundle = await rolldown({
+    input: entry,
+    platform: 'browser',
+    // lerc reaches for node:module in the branch it takes outside a browser. Nothing evaluates it
+    // here, but left to resolve it Rolldown reports a module it couldn't find.
+    external: ['module'],
+    // @developmentseed/geotiff declares itself side-effect free, and the worker's message handler is
+    // nothing but a side effect: shaken, this bundle comes out empty, and every tile would then wait
+    // forever on a worker that registered no listener.
+    treeshake: { moduleSideEffects: () => true },
+  });
+
+  try {
+    const { output } = await bundle.generate({ format: 'esm', codeSplitting: false, minify: true });
+    // Named so devtools lists the worker by something other than its blob URL
+    return `${output[0].code}\n//# sourceURL=ogm-decoder-worker.js\n`;
+  } finally {
+    await bundle.close();
+  }
+}
+
+// Replaces the empty placeholder in WORKER_SOURCE_MODULE with the bundled worker
+const inlineDecoderWorker = () => ({
+  name: 'ogm-inline-decoder-worker',
+  async transform(_code: string, id: string) {
+    if (!normalize(id).endsWith(WORKER_SOURCE_MODULE)) return null;
+
+    bundledWorker ??= bundleDecoderWorker(normalize(id).replace(/[^/]+$/, WORKER_ENTRY));
+    return { code: `export const DECODER_WORKER_SOURCE = ${JSON.stringify(await bundledWorker)};`, map: { mappings: '' } };
+  },
+});
+
+// Takes upstream's worker URL out of the bundle; see UPSTREAM_POOL_MODULE above for why
+const stripUpstreamDecoderWorker = () => ({
+  name: 'ogm-strip-upstream-decoder-worker',
+  transform(code: string, id: string) {
+    if (!normalize(id).endsWith(UPSTREAM_POOL_MODULE)) return null;
+
+    // Loudly rather than quietly: a version of the package that words this differently would
+    // otherwise put the URL back in the published bundle and break every consumer on Vite again.
+    if (!code.includes(UPSTREAM_WORKER_FACTORY)) {
+      throw new Error(`${UPSTREAM_POOL_MODULE} no longer contains the worker factory this build replaces. Check whether it still needs replacing, and update stencil.config.ts.`);
+    }
+
+    return { code: code.replace(UPSTREAM_WORKER_FACTORY, 'createWorker: undefined'), map: { mappings: '' } };
+  },
+});
+
+// The other half of that: nothing may reach the published output asking for a worker.js beside it,
+// however it got there. Cheap enough to check on every build, and the failure it catches is one that
+// only shows up in someone else's build log.
+const verifyNoMissingWorker = () => ({
+  name: 'ogm-verify-no-missing-worker',
+  generateBundle(_options: unknown, bundle: Record<string, { type: string; code?: string }>) {
+    const referenced = Object.entries(bundle).filter(([, output]) => output.type === 'chunk' && output.code?.includes(MISSING_WORKER_URL));
+    if (referenced.length === 0) return;
+
+    throw new Error(
+      `${MISSING_WORKER_URL} is not published by this package, and is asked for by ${referenced.map(([fileName]) => fileName).join(', ')}. See https://github.com/OpenGeoMetadata/ogm-viewer/issues/186.`,
+    );
+  },
+});
+
 export const config: Config = {
   namespace: 'ogm-viewer',
+  rollupPlugins: {
+    before: [inlineDecoderWorker(), stripUpstreamDecoderWorker(), verifyNoMissingWorker()],
+  },
   // Off because the check wants package.json's `module`/`types` pointed at dist/components/index.js,
   // and for this output target that file is the Stencil runtime, not a barrel - importing it defines
   // no elements at all. The component entries are what register the library, so package.json names


### PR DESCRIPTION
Fixes #186, and enables the decoder pool that issue was about.

## The build failure

`@developmentseed/geotiff`'s default pool builds its worker from `new Worker(new URL("./worker.js", import.meta.url), { type: "module" })`, and `COGLayer` reaches for that pool whenever it isn't handed one — so the expression is in the published bundle whether or not anything evaluates it. No `worker.js` is published beside the chunks, so `npm i ogm-viewer` + `import 'ogm-viewer'` cannot be built by Vite at all.

**Shipping the file it asks for only moves the failure.** Vite bundles a worker entry as IIFE regardless of `{type:"module"}`, and `@developmentseed/lzw-tiff-decoder` initializes its wasm with top-level await, so a resolvable `worker.js` fails with `[UNSUPPORTED_FEATURE] Top-level await is currently not supported with the 'iife' output format` instead. Verified both ways.

So the build takes the URL out of the output instead — the issue's second suggestion. A `rollupPlugins.before` transform replaces the factory with `createWorker: undefined`, which leaves `defaultDecoderPool()` working (just on the main thread), and a `generateBundle` check fails the build if any chunk still asks for a `worker.js` we don't publish. Both guards are deliberately broken and confirmed to fail the build non-zero.

## The pool

With the URL gone, the pool the viewer uses is built in `src/lib/decoder.ts`, and it has real workers for the first time. The worker's source is bundled at build time (Rolldown, new devDependency) and inlined as a string, so a worker starts from a blob URL rather than a file. That is what makes it work everywhere:

- a worker must be same-origin, and GeoBlacklight and sul-embed both load the viewer cross-origin from a CDN through an importmap, where `new Worker(cdnUrl)` is a hard `SecurityError`;
- inlining means no CORS to satisfy, no second chance for the network to fail after page load, and nothing for a consumer's bundler to resolve;
- MapLibre and Allmaps already start their workers from a blob in this same bundle, so `worker-src blob:` is not a new requirement. In a document with an opaque origin — a sandboxed iframe, which is how sul-embed is embedded — Chromium refuses blob module workers, so a `blob:null` URL switches to a `data:` URL.

One pool of four workers is shared by every COG on the page, and it degrades rather than breaks: a policy that refuses blob workers throws during construction, a worker that dies answers nothing at all, and in either case the tiles are decoded in place and still drawn. `readme.md` gains a short CSP note.

## Verification

Against the built bundle in Chrome, drawing an LZW COG through the real `<ogm-viewer>`:

| scenario | result |
|---|---|
| same-origin script tag | 4 module workers, **46 jobs / 46 replies** |
| cross-origin CDN (both consumers' importmaps) | same, blob URLs on the page's origin |
| sandboxed iframe (`origin: null`) | 4 workers on `data:` URLs, 46 / 46 |
| Vite 8.2.2 (sul-embed's pin) and Vite 7.3.6, `build` and `dev` | all four build clean, 46 / 46 |
| workers refused, as a CSP would | 0 decoder workers, one console warning, **COG still drawn** |

`npm test` 993 passing (13 new), `npm run lint` clean, and the packed tarball has no reference to `./worker.js`.

## Performance, honestly

Decode gets **2.8–3.1× faster** in isolation across three fixtures (a 578 MB LZW scan, deck.gl-raster's own 1.36 GB Deflate land-cover COG, and a 32-bit float raster — the shape 44 of 44 sampled Stanford production COGs turn out to be). End to end it is **neutral**: 200 tiles at 0.52 ms is ~104 ms of decode inside a 3.7 s load, and the load is network-bound (44 s of range requests). No regression on any metric, including at a 4× CPU throttle. It starts to matter for JPEG/WebP COGs, a warm cache or CDN in front of the data, or several COGs on one page.

Two adjacent gaps found and deliberately left alone: `lerc-wasm.wasm` is not published, so LERC COGs cannot decode on either path (pre-existing); and a bundled consumer gets no theme or icon assets, because `init.ts` anchors them to `import.meta.url` (also pre-existing, and the remaining half of "one import gets you the whole viewer").

🤖 Generated with [Claude Code](https://claude.com/claude-code)