### PR TITLE
Render scalar COGs with a color ramp

### DIFF
--- a/assets/records.csv
+++ b/assets/records.csv
@@ -11,6 +11,7 @@
 "Countries Demo (Vector TileJSON)","https://gist.githubusercontent.com/thatbudakguy/2be84fa59dbf5e5b85b237903f80d18b/raw/b6ff324e6bab2cfc65af1159939c6a1cbec490a5/tilejson"
 "Tibet (Raster TileJSON over COG)","https://gist.githubusercontent.com/thatbudakguy/2be84fa59dbf5e5b85b237903f80d18b/raw/fb8f6e416af087a7a5c2a84094a0cfc421d8f41c/tilejson-raster"
 "Stanford Farm (EPSG:4326 COG)","https://gist.githubusercontent.com/thatbudakguy/d75a2a5916328be3f1597cab89fa79b4/raw/aad202cf8a31dca8c803191902d493b5edc50e7d/cog.json"
+"Groundwater Elevation (Float COG, Color Ramp)","https://raw.githubusercontent.com/OpenGeoMetadata/edu.stanford.purl/8f9ce62bdc4b60f821c80199aa6061d5bc4793fd/metadata-aardvark/xp/137/nw/4166/geoblacklight.json"
 "Finland 2G Coverage (COG, Restricted)","./build/assets/records/restricted-cog.json"
 "Ag Districts (TMS)","https://raw.githubusercontent.com/geoblacklight/geoblacklight/9f7dbb4c36dc0b8e88fb9be5282d7b1663858829/spec/fixtures/solr_documents/tms.json"
 "Faults (XYZ Tiles)","https://raw.githubusercontent.com/geoblacklight/geoblacklight/9f7dbb4c36dc0b8e88fb9be5282d7b1663858829/spec/fixtures/solr_documents/xyz.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@deck.gl/mapbox": "^9.3.1",
         "@deck.gl/mesh-layers": "^9.3.1",
         "@developmentseed/deck.gl-geotiff": "^0.7.0",
+        "@developmentseed/deck.gl-raster": "^0.7.0",
         "@developmentseed/geotiff": "^0.7.0",
         "@geomatico/maplibre-cog-protocol": "^0.9.0",
         "@iiif/presentation-2": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@deck.gl/mapbox": "^9.3.1",
     "@deck.gl/mesh-layers": "^9.3.1",
     "@developmentseed/deck.gl-geotiff": "^0.7.0",
+    "@developmentseed/deck.gl-raster": "^0.7.0",
     "@developmentseed/geotiff": "^0.7.0",
     "@geomatico/maplibre-cog-protocol": "^0.9.0",
     "@iiif/presentation-2": "^1.0.4",

--- a/scripts/inline-assets.mjs
+++ b/scripts/inline-assets.mjs
@@ -1,18 +1,21 @@
 /**
- * Writes src/lib/assets.generated.ts: the two things a component needs at runtime that used to be
- * files beside it - Web Awesome's default theme and our bootstrap-icons subset - as strings the
- * bundler carries with the rest of the library.
+ * Writes src/lib/assets.generated.ts: things a component needs at runtime that used to be files
+ * beside it - Web Awesome's default theme, our bootstrap-icons subset, and the colormap sprite
+ * scalar COGs are drawn through - as strings and base64 the bundler carries with the rest of the
+ * library.
  *
- * Both used to be fetched from a URL beside this package's own files, anchored to the module's
- * import.meta.url. That is right for a script tag and for a CDN importmap, and wrong for every app
- * that bundles us: a bundler copies the JavaScript it was asked for, and knows nothing about a
- * sibling directory of assets it was never pointed at. So `npm i ogm-viewer` and `import
- * 'ogm-viewer'` drew the map correctly and everything around it unstyled - serif fallback font, no
- * icons - with a handful of failed requests to explain it. Nothing a consumer can configure fixes
- * that; the files have to be inside the module graph, which is what this puts them there for.
+ * All three used to be (or, for the sprite, would otherwise be) fetched from a URL beside this
+ * package's own files, anchored to the module's import.meta.url. That is right for a script tag and
+ * for a CDN importmap, and wrong for every app that bundles us: a bundler copies the JavaScript it
+ * was asked for, and knows nothing about a sibling directory of assets it was never pointed at. So
+ * `npm i ogm-viewer` and `import 'ogm-viewer'` drew the map correctly and everything around it
+ * unstyled - serif fallback font, no icons - with a handful of failed requests to explain it.
+ * Nothing a consumer can configure fixes that; the files have to be inside the module graph, which
+ * is what this puts them there for.
  *
  * Run ahead of Stencil by `npm run build` and `npm start`, rather than checked in, so the tree can
- * never carry a copy of Web Awesome's CSS that disagrees with the version in package.json.
+ * never carry a copy of Web Awesome's CSS, or of a sprite from @developmentseed/deck.gl-raster, that
+ * disagrees with the version in package.json.
  *
  * A step ahead of the compiler rather than a Rollup transform like the decoder worker's in
  * stencil.config.ts, because the two fail differently: that source can be empty in a build that
@@ -23,6 +26,8 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import { COLORMAP_INDEX } from '@developmentseed/deck.gl-raster/gpu-modules';
+
 // The stylesheet every component used to link, resolved through Web Awesome's own exports rather
 // than from a path into node_modules, so this holds wherever the package manager hoisted it to.
 const THEME = '@awesome.me/webawesome/dist/styles/themes/default.css';
@@ -30,6 +35,13 @@ const THEME = '@awesome.me/webawesome/dist/styles/themes/default.css';
 // Our icons: the subset of bootstrap-icons checked in beside this repo's other assets. Whatever is
 // in that directory is what <wa-icon name="..."> can name - see registerIconLibrary in src/lib/init.ts.
 const ICONS = new URL('../assets/icons/', import.meta.url);
+
+// The 107 named color ramps a scalar COG can be drawn with, as one 256x107 RGBA sprite - see
+// src/lib/colormap.ts. Resolved the same way as THEME, so it holds wherever the package manager put
+// it, and small enough (16.4 KB) to compile in rather than publish as a copied file the way lerc's
+// wasm still is; see the note on the dist-custom-elements output target in stencil.config.ts for why
+// that one is different.
+const COLORMAP_SPRITE = '@developmentseed/deck.gl-raster/gpu-modules/colormaps.png';
 
 const OUTPUT = new URL('../src/lib/assets.generated.ts', import.meta.url);
 
@@ -63,6 +75,28 @@ const icons = readdirSync(ICONS)
 
 if (icons.length === 0) throw new Error(`No icons in ${ICONS.pathname}. Every wa-icon in the library resolves through that directory.`);
 
+const spritePath = import.meta.resolve(COLORMAP_SPRITE).replace('file://', '');
+const sprite = readFileSync(spritePath);
+
+// A PNG's width and height are the first two 4-byte big-endian fields of its IHDR chunk, which is
+// always the first chunk - right after the 8-byte signature every PNG opens with. Read rather than
+// trusted, because both numbers are load-bearing for what reads this sprite at runtime:
+// createColormapTexture (@developmentseed/deck.gl-raster) throws on anything but a 256-wide image,
+// and src/lib/colormap.ts indexes rows by COLORMAP_INDEX, which is only correct while there is
+// exactly one row per name that package exports.
+const spriteWidth = sprite.readUInt32BE(16);
+const spriteHeight = sprite.readUInt32BE(20);
+if (spriteWidth !== 256) {
+  throw new Error(
+    `${COLORMAP_SPRITE} is ${spriteWidth}px wide, not the 256 createColormapTexture requires. Check what changed upstream, and update src/lib/colormap.ts and this script.`,
+  );
+}
+if (spriteHeight !== Object.keys(COLORMAP_INDEX).length) {
+  throw new Error(
+    `${COLORMAP_SPRITE} has ${spriteHeight} rows, but COLORMAP_INDEX names ${Object.keys(COLORMAP_INDEX).length} ramps. The two have to agree on which row is which ramp - check what changed upstream, and update src/lib/colormap.ts and this script.`,
+  );
+}
+
 // JSON rather than template literals: both of these carry backticks and backslashes of their own.
 const entries = icons.map(([name, svg]) => `  ${JSON.stringify(name)}: ${JSON.stringify(svg)},`).join('\n');
 
@@ -78,7 +112,12 @@ export const webAwesomeThemeCss = ${JSON.stringify(css)};
 export const iconSvgs: Record<string, string> = {
 ${entries}
 };
+
+// ${COLORMAP_SPRITE}, base64-encoded. See src/lib/colormap.ts for how this is decoded and read.
+export const colormapSpriteBase64 = ${JSON.stringify(sprite.toString('base64'))};
 `,
 );
 
-console.log(`inline-assets: ${Math.round(css.length / 1024)} KB of CSS and ${icons.length} icons into src/lib/assets.generated.ts`);
+console.log(
+  `inline-assets: ${Math.round(css.length / 1024)} KB of CSS, ${icons.length} icons, and a ${Math.round(sprite.length / 1024)} KB colormap sprite into src/lib/assets.generated.ts`,
+);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,12 +10,14 @@ import { MapGeoJSONFeature } from "maplibre-gl";
 import { ResourceKind } from "./lib/resources/resource";
 import { RequestTransform } from "./lib/request";
 import { LayerControl } from "./lib/layers";
+import { ColorRampName } from "./lib/colormap";
 import { AnyPreviewer } from "./lib/previewers/factory";
 export { PreviewError } from "./lib/errors";
 export { MapGeoJSONFeature } from "maplibre-gl";
 export { ResourceKind } from "./lib/resources/resource";
 export { RequestTransform } from "./lib/request";
 export { LayerControl } from "./lib/layers";
+export { ColorRampName } from "./lib/colormap";
 export { AnyPreviewer } from "./lib/previewers/factory";
 export namespace Components {
     interface OgmAlerts {
@@ -45,6 +47,13 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmLayers {
+        /**
+          * @default []
+         */
+        "layers": LayerControl[];
+        "theme": 'light' | 'dark';
+    }
+    interface OgmLegend {
         /**
           * @default []
          */
@@ -236,6 +245,7 @@ declare global {
     interface HTMLOgmLayersElementEventMap {
         "layerVisibilityChange": { id: string; visible: boolean };
         "layerOpacityChange": { id: string; opacity: number };
+        "layerColorRampChange": { id: string; colorRamp: ColorRampName };
         "allLayersVisibilityChange": boolean;
     }
     interface HTMLOgmLayersElement extends Components.OgmLayers, HTMLStencilElement {
@@ -251,6 +261,12 @@ declare global {
     var HTMLOgmLayersElement: {
         prototype: HTMLOgmLayersElement;
         new (): HTMLOgmLayersElement;
+    };
+    interface HTMLOgmLegendElement extends Components.OgmLegend, HTMLStencilElement {
+    }
+    var HTMLOgmLegendElement: {
+        prototype: HTMLOgmLegendElement;
+        new (): HTMLOgmLegendElement;
     };
     interface HTMLOgmLocatorElement extends Components.OgmLocator, HTMLStencilElement {
     }
@@ -367,6 +383,7 @@ declare global {
         "ogm-attributes": HTMLOgmAttributesElement;
         "ogm-image": HTMLOgmImageElement;
         "ogm-layers": HTMLOgmLayersElement;
+        "ogm-legend": HTMLOgmLegendElement;
         "ogm-locator": HTMLOgmLocatorElement;
         "ogm-map": HTMLOgmMapElement;
         "ogm-menubar": HTMLOgmMenubarElement;
@@ -415,8 +432,16 @@ declare namespace LocalJSX {
          */
         "layers"?: LayerControl[];
         "onAllLayersVisibilityChange"?: (event: OgmLayersCustomEvent<boolean>) => void;
+        "onLayerColorRampChange"?: (event: OgmLayersCustomEvent<{ id: string; colorRamp: ColorRampName }>) => void;
         "onLayerOpacityChange"?: (event: OgmLayersCustomEvent<{ id: string; opacity: number }>) => void;
         "onLayerVisibilityChange"?: (event: OgmLayersCustomEvent<{ id: string; visible: boolean }>) => void;
+        "theme"?: 'light' | 'dark';
+    }
+    interface OgmLegend {
+        /**
+          * @default []
+         */
+        "layers"?: LayerControl[];
         "theme"?: 'light' | 'dark';
     }
     interface OgmLocator {
@@ -552,6 +577,9 @@ declare namespace LocalJSX {
     interface OgmLayersAttributes {
         "theme": 'light' | 'dark';
     }
+    interface OgmLegendAttributes {
+        "theme": 'light' | 'dark';
+    }
     interface OgmLocatorAttributes {
         "theme": 'light' | 'dark';
         "recordUrl": string;
@@ -598,6 +626,7 @@ declare namespace LocalJSX {
         "ogm-attributes": Omit<OgmAttributes, keyof OgmAttributesAttributes> & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes]?: OgmAttributes[K] } & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes as `attr:${K}`]?: OgmAttributesAttributes[K] } & { [K in keyof OgmAttributes & keyof OgmAttributesAttributes as `prop:${K}`]?: OgmAttributes[K] };
         "ogm-image": Omit<OgmImage, keyof OgmImageAttributes> & { [K in keyof OgmImage & keyof OgmImageAttributes]?: OgmImage[K] } & { [K in keyof OgmImage & keyof OgmImageAttributes as `attr:${K}`]?: OgmImageAttributes[K] } & { [K in keyof OgmImage & keyof OgmImageAttributes as `prop:${K}`]?: OgmImage[K] };
         "ogm-layers": Omit<OgmLayers, keyof OgmLayersAttributes> & { [K in keyof OgmLayers & keyof OgmLayersAttributes]?: OgmLayers[K] } & { [K in keyof OgmLayers & keyof OgmLayersAttributes as `attr:${K}`]?: OgmLayersAttributes[K] } & { [K in keyof OgmLayers & keyof OgmLayersAttributes as `prop:${K}`]?: OgmLayers[K] };
+        "ogm-legend": Omit<OgmLegend, keyof OgmLegendAttributes> & { [K in keyof OgmLegend & keyof OgmLegendAttributes]?: OgmLegend[K] } & { [K in keyof OgmLegend & keyof OgmLegendAttributes as `attr:${K}`]?: OgmLegendAttributes[K] } & { [K in keyof OgmLegend & keyof OgmLegendAttributes as `prop:${K}`]?: OgmLegend[K] };
         "ogm-locator": Omit<OgmLocator, keyof OgmLocatorAttributes> & { [K in keyof OgmLocator & keyof OgmLocatorAttributes]?: OgmLocator[K] } & { [K in keyof OgmLocator & keyof OgmLocatorAttributes as `attr:${K}`]?: OgmLocatorAttributes[K] } & { [K in keyof OgmLocator & keyof OgmLocatorAttributes as `prop:${K}`]?: OgmLocator[K] };
         "ogm-map": Omit<OgmMap, keyof OgmMapAttributes> & { [K in keyof OgmMap & keyof OgmMapAttributes]?: OgmMap[K] } & { [K in keyof OgmMap & keyof OgmMapAttributes as `attr:${K}`]?: OgmMapAttributes[K] } & { [K in keyof OgmMap & keyof OgmMapAttributes as `prop:${K}`]?: OgmMap[K] };
         "ogm-menubar": Omit<OgmMenubar, keyof OgmMenubarAttributes> & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes]?: OgmMenubar[K] } & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes as `attr:${K}`]?: OgmMenubarAttributes[K] } & { [K in keyof OgmMenubar & keyof OgmMenubarAttributes as `prop:${K}`]?: OgmMenubar[K] };
@@ -617,6 +646,7 @@ declare module "@stencil/core" {
             "ogm-attributes": LocalJSX.IntrinsicElements["ogm-attributes"] & JSXBase.HTMLAttributes<HTMLOgmAttributesElement>;
             "ogm-image": LocalJSX.IntrinsicElements["ogm-image"] & JSXBase.HTMLAttributes<HTMLOgmImageElement>;
             "ogm-layers": LocalJSX.IntrinsicElements["ogm-layers"] & JSXBase.HTMLAttributes<HTMLOgmLayersElement>;
+            "ogm-legend": LocalJSX.IntrinsicElements["ogm-legend"] & JSXBase.HTMLAttributes<HTMLOgmLegendElement>;
             "ogm-locator": LocalJSX.IntrinsicElements["ogm-locator"] & JSXBase.HTMLAttributes<HTMLOgmLocatorElement>;
             "ogm-map": LocalJSX.IntrinsicElements["ogm-map"] & JSXBase.HTMLAttributes<HTMLOgmMapElement>;
             "ogm-menubar": LocalJSX.IntrinsicElements["ogm-menubar"] & JSXBase.HTMLAttributes<HTMLOgmMenubarElement>;

--- a/src/components/ogm-layers/ogm-layers.css
+++ b/src/components/ogm-layers/ogm-layers.css
@@ -92,3 +92,56 @@
   min-width: 2.75rem;
   text-align: end;
 }
+
+/* The ramp picker's own row, unlike the two above it: every swatch wants equal width, which align
+   the row itself is a flex container the way .row (opacity, visibility) already is */
+.row:has(.ramps) {
+  align-items: stretch;
+}
+
+/* Twelve ramps at four per row fits the panel's own 13-18rem width without crowding a swatch below
+   a size it can still be told apart at. No <legend> - aria-label carries the name instead, since a
+   visible one would repeat the layer's own title immediately above it. */
+.ramps {
+  border: none;
+  display: grid;
+  gap: var(--wa-space-3xs);
+  grid-template-columns: repeat(4, 1fr);
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.swatch {
+  aspect-ratio: 2 / 1;
+  border-radius: var(--wa-border-radius-s, 0.125rem);
+  cursor: pointer;
+  display: block;
+  outline: var(--wa-panel-border-width) solid var(--wa-color-surface-border);
+  outline-offset: -1px;
+  /* Set from JS as an inline gradient once the sprite has decoded; a name-only fallback swatch
+     until then, or if it never does, still works as a picker - just without the preview. */
+  background-color: var(--wa-color-surface-lowered, var(--wa-color-surface-default));
+}
+
+/* Radio inputs carry the choice and the keyboard behavior (arrow keys move within the fieldset,
+   same group semantics a native radio group always has); their own box is never drawn, which is
+   why the swatch has to answer :focus-visible and :checked on their behalf. Not display:none or
+   visibility:hidden - either would also drop it from the accessibility tree and the tab order. */
+.swatch input {
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+.swatch:has(input:checked) {
+  outline: 2px solid var(--wa-color-brand-fill-loud, currentColor);
+  outline-offset: 0;
+}
+
+.swatch:has(input:focus-visible) {
+  outline: 2px solid var(--wa-color-brand-fill-loud, currentColor);
+  outline-offset: 1px;
+}

--- a/src/components/ogm-layers/ogm-layers.test.tsx
+++ b/src/components/ogm-layers/ogm-layers.test.tsx
@@ -7,6 +7,7 @@ const item = (id: string, title: string, overrides: Partial<LayerControl> = {}):
 
 const ONE = [item('districts', 'Districts', { opacity: 0.8 })];
 const TWO = [item('districts', 'Districts'), item('places', 'Places')];
+const RAMPED = [item('elevation', 'Groundwater Elevation', { colorRamp: 'viridis', colorRampRange: [-184.48, 607.27] })];
 
 const renderLayers = async (layers: LayerControl[]) => {
   const { root } = await render(<ogm-layers layers={layers}></ogm-layers>);
@@ -100,5 +101,74 @@ describe('ogm-layers', () => {
     expect(shadowRoot.querySelector('.panel')?.getAttribute('aria-label')).toEqual('Layer controls');
     expect(shadowRoot.querySelector('.layer .visibility')?.getAttribute('aria-label')).toEqual('Districts');
     expect(shadowRoot.querySelector('.opacity')?.getAttribute('aria-label')).toEqual('Opacity of Districts');
+  });
+
+  // A ramp picker is one more row in a layer's own <li>, not a control of its own - see
+  // src/lib/previewers/cog-pipeline.ts for what actually makes a layer rampable.
+  describe('a rampable layer', () => {
+    it('shows no ramp picker for an ordinary layer', async () => {
+      const shadowRoot = await renderLayers(ONE);
+      expect(shadowRoot.querySelector('.ramps')).toBeNull();
+    });
+
+    it('shows a swatch for every offered ramp', async () => {
+      const shadowRoot = await renderLayers(RAMPED);
+      // One label wrapping one radio input per ramp - see COLOR_RAMPS in src/lib/colormap.ts
+      expect(shadowRoot.querySelectorAll('.swatch')).toHaveLength(12);
+      expect(shadowRoot.querySelectorAll('.swatch input[type="radio"]')).toHaveLength(12);
+    });
+
+    it("marks the layer's current ramp as the checked swatch, and no other", async () => {
+      const shadowRoot = await renderLayers(RAMPED);
+      const checked = Array.from(shadowRoot.querySelectorAll<HTMLInputElement>('.swatch input')).filter(input => input.checked);
+
+      expect(checked).toHaveLength(1);
+      expect(checked[0].value).toEqual('viridis');
+    });
+
+    it('groups the swatches as one radio group per layer, not shared across layers', async () => {
+      const shadowRoot = await renderLayers([...RAMPED, item('other-cog', 'Other', { colorRamp: 'magma' })]);
+      const names = new Set(Array.from(shadowRoot.querySelectorAll<HTMLInputElement>('.swatch input')).map(input => input.name));
+
+      expect(names.size).toEqual(2);
+    });
+
+    it('reports when the user picks a different ramp', async () => {
+      const { root, waitForChanges } = await render(<ogm-layers layers={RAMPED}></ogm-layers>);
+      const changes: { id: string; colorRamp: string }[] = [];
+      root.addEventListener('layerColorRampChange', (event: Event) => changes.push((event as CustomEvent<{ id: string; colorRamp: string }>).detail));
+
+      const swatches = root.shadowRoot!.querySelectorAll<HTMLInputElement>('.swatch input');
+      const magma = Array.from(swatches).find(input => input.value === 'magma')!;
+      magma.checked = true;
+      magma.dispatchEvent(new Event('change', { bubbles: true }));
+      await waitForChanges();
+
+      expect(changes).toEqual([{ id: 'elevation', colorRamp: 'magma' }]);
+    });
+
+    // happy-dom, which this test renders into, has neither createImageBitmap nor OffscreenCanvas -
+    // decodeColormapSprite needs both, so componentWillLoad's sprite fetch genuinely fails here,
+    // exercising the same try/catch a real browser would only hit over a truly broken sprite. The
+    // gradient itself - what a *successful* decode draws each swatch in - is colormap.ts's own
+    // rampGradient(), already covered directly in colormap.test.ts with no DOM involved at all.
+    // What's worth proving here is narrower: that a decode failure costs the picker its gradients
+    // and nothing else.
+    it('still renders every swatch, without a gradient, when the sprite fails to decode', async () => {
+      const shadowRoot = await renderLayers(RAMPED);
+      const swatches = shadowRoot.querySelectorAll<HTMLElement>('.swatch');
+
+      expect(swatches).toHaveLength(12);
+      expect(Array.from(swatches).every(swatch => swatch.style.background === '')).toBe(true);
+      // Still fully working as a picker, sprite or no sprite
+      expect(shadowRoot.querySelector<HTMLInputElement>('.swatch input[value="viridis"]')?.checked).toBe(true);
+    });
+
+    it('names the picker and each swatch for assistive technology', async () => {
+      const shadowRoot = await renderLayers(RAMPED);
+
+      expect(shadowRoot.querySelector('.ramps')?.getAttribute('aria-label')).toEqual('Color ramp for Groundwater Elevation');
+      expect(shadowRoot.querySelector('.swatch input[value="viridis"]')?.getAttribute('aria-label')).toEqual('Viridis');
+    });
   });
 });

--- a/src/components/ogm-layers/ogm-layers.tsx
+++ b/src/components/ogm-layers/ogm-layers.tsx
@@ -1,5 +1,6 @@
-import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Prop, State } from '@stencil/core';
 
+import { COLOR_RAMPS, colormapSprite, rampGradient, type ColorRampName } from '../../lib/colormap';
 import type { LayerControl } from '../../lib/layers';
 
 // Panel for controlling visibility and opacity of MapLibre layers.
@@ -15,7 +16,23 @@ export class OgmLayers {
 
   @Event() layerVisibilityChange: EventEmitter<{ id: string; visible: boolean }>;
   @Event() layerOpacityChange: EventEmitter<{ id: string; opacity: number }>;
+  @Event() layerColorRampChange: EventEmitter<{ id: string; colorRamp: ColorRampName }>;
   @Event() allLayersVisibilityChange: EventEmitter<boolean>;
+
+  // The sprite every ramp swatch draws its gradient from - see colormapSprite(). Loaded before the
+  // first render rather than read synchronously, since decoding it needs no GPU device but does
+  // need a moment; Stencil holds componentWillLoad's own promise open for exactly this. Left
+  // undefined rather than thrown past if decoding fails for some reason, so a broken sprite costs
+  // this panel its gradients rather than the whole thing.
+  @State() private sprite: ImageData | undefined;
+
+  async componentWillLoad() {
+    try {
+      this.sprite = await colormapSprite();
+    } catch (error) {
+      console.warn('Could not decode the color ramp sprite, so ramp swatches will show as plain labels:', error);
+    }
+  }
 
   // Render a summary with its own checkbox, for multi-layered objects
   private get summarized(): boolean {
@@ -37,6 +54,10 @@ export class OgmLayers {
 
   private onOpacityInput(layer: LayerControl, event: Event) {
     this.layerOpacityChange.emit({ id: layer.id, opacity: Number((event.target as HTMLInputElement).value) / 100 });
+  }
+
+  private onColorRampInput(layer: LayerControl, event: Event) {
+    this.layerColorRampChange.emit({ id: layer.id, colorRamp: (event.target as HTMLInputElement).value as ColorRampName });
   }
 
   render() {
@@ -79,6 +100,24 @@ export class OgmLayers {
                   />
                   <span class="percent">{Math.round(layer.opacity * 100)}%</span>
                 </div>
+                {layer.colorRamp && (
+                  <div class="row">
+                    <fieldset class="ramps" aria-label={`Color ramp for ${layer.title}`}>
+                      {COLOR_RAMPS.map(({ key, label }) => (
+                        <label class="swatch" key={key} title={label} style={this.sprite && { background: rampGradient(this.sprite, key) }}>
+                          <input
+                            type="radio"
+                            name={`ramp-${layer.id}`}
+                            value={key}
+                            checked={layer.colorRamp === key}
+                            aria-label={label}
+                            onChange={event => this.onColorRampInput(layer, event)}
+                          />
+                        </label>
+                      ))}
+                    </fieldset>
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/src/components/ogm-legend/ogm-legend.css
+++ b/src/components/ogm-legend/ogm-legend.css
@@ -1,0 +1,53 @@
+:host {
+  display: block;
+}
+
+.panel {
+  background-color: var(--wa-color-surface-default);
+  border: var(--wa-panel-border-width) solid var(--wa-color-surface-border);
+  border-radius: var(--wa-border-radius-m, 0.25rem);
+  box-shadow: var(--wa-shadow-m);
+  color: var(--wa-color-text-normal);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--wa-font-family-body);
+  font-size: var(--wa-font-size-s);
+  gap: var(--wa-space-xs);
+  line-height: var(--wa-line-height-condensed);
+  max-width: 18rem;
+  min-width: 13rem;
+  padding: var(--wa-space-2xs);
+}
+
+.entry + .entry {
+  border-top: var(--wa-panel-border-width) solid var(--wa-color-surface-border);
+  margin-top: var(--wa-space-2xs);
+  padding-top: var(--wa-space-2xs);
+}
+
+.title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The gradient itself is an inline style, set from JS once the sprite has decoded - see
+   ogm-legend.tsx. This background is what a bar shows before that, or if it never does. */
+.bar {
+  background-color: var(--wa-color-surface-lowered, var(--wa-color-surface-default));
+  border-radius: var(--wa-border-radius-s, 0.125rem);
+  height: var(--wa-space-s, 0.75rem);
+  margin-top: var(--wa-space-3xs);
+  width: 100%;
+}
+
+/* Min at the start, max at the end - no midpoint label, matching how little space a bar this
+   narrow has to say anything more without crowding. */
+.labels {
+  display: flex;
+  font-variant-numeric: tabular-nums;
+  justify-content: space-between;
+  color: var(--wa-color-text-quiet);
+  margin-top: var(--wa-space-3xs);
+}

--- a/src/components/ogm-legend/ogm-legend.test.tsx
+++ b/src/components/ogm-legend/ogm-legend.test.tsx
@@ -1,0 +1,76 @@
+import { render, describe, it, expect, h } from '@stencil/vitest';
+
+import type { LayerControl } from '../../lib/layers';
+
+const item = (id: string, title: string, overrides: Partial<LayerControl> = {}): LayerControl => ({ id, title, visible: true, opacity: 1, ...overrides });
+
+const RAMPED = item('elevation', 'Groundwater Elevation', { colorRamp: 'viridis', colorRampRange: [-184.48, 607.27] });
+const VECTOR = item('districts', 'Districts');
+
+const renderLegend = async (layers: LayerControl[]) => {
+  const { root } = await render(<ogm-legend layers={layers}></ogm-legend>);
+  return root.shadowRoot as ShadowRoot;
+};
+
+describe('ogm-legend', () => {
+  it('shows nothing while nothing drawn has a ramp', async () => {
+    const shadowRoot = await renderLegend([VECTOR]);
+    expect(shadowRoot.querySelector('.panel')).toBeNull();
+  });
+
+  it('shows nothing for an empty layer list', async () => {
+    const shadowRoot = await renderLegend([]);
+    expect(shadowRoot.querySelector('.panel')).toBeNull();
+  });
+
+  it("labels an entry with the layer's own title", async () => {
+    const shadowRoot = await renderLegend([RAMPED]);
+    expect(shadowRoot.querySelector('.entry .title')?.textContent).toEqual('Groundwater Elevation');
+  });
+
+  // The gap between the labels is coarse enough here that formatValue rounds to whole numbers -
+  // see colormap.test.ts for formatValue itself; this only checks the legend hands it the right
+  // two numbers, in the right order.
+  it("labels the bar's ends with the layer's own value range", async () => {
+    const shadowRoot = await renderLegend([RAMPED]);
+    expect(shadowRoot.querySelector('.min')?.textContent).toEqual('-184');
+    expect(shadowRoot.querySelector('.max')?.textContent).toEqual('607');
+  });
+
+  it('lists only the rampable layers, in a mix with ordinary ones', async () => {
+    const shadowRoot = await renderLegend([VECTOR, RAMPED]);
+    expect(shadowRoot.querySelectorAll('.entry')).toHaveLength(1);
+    expect(shadowRoot.querySelector('.entry .title')?.textContent).toEqual('Groundwater Elevation');
+  });
+
+  // A layer hidden or faded to nothing has nothing on screen for a legend to explain
+  it('says nothing about a rampable layer that is not currently drawn', async () => {
+    const hidden = item('elevation', 'Groundwater Elevation', { visible: false, colorRamp: 'viridis', colorRampRange: [-184.48, 607.27] });
+    const shadowRoot = await renderLegend([hidden]);
+    expect(shadowRoot.querySelector('.panel')).toBeNull();
+  });
+
+  it('shows one entry per rampable layer, each with its own range', async () => {
+    const second = item('temperature', 'Temperature Anomaly', { colorRamp: 'rdbu', colorRampRange: [-5, 5] });
+    const shadowRoot = await renderLegend([RAMPED, second]);
+
+    expect(shadowRoot.querySelectorAll('.entry')).toHaveLength(2);
+    expect(Array.from(shadowRoot.querySelectorAll('.entry .title')).map(el => el.textContent)).toEqual(['Groundwater Elevation', 'Temperature Anomaly']);
+  });
+
+  // happy-dom has neither createImageBitmap nor OffscreenCanvas, which decodeColormapSprite needs,
+  // so this exercises the same fallback componentWillLoad's try/catch exists for in a real browser
+  // asked to draw a genuinely broken sprite. The gradient itself is rampGradient()'s own concern,
+  // covered directly and without a DOM in colormap.test.ts.
+  it('still labels the range when the sprite fails to decode, just without a gradient', async () => {
+    const shadowRoot = await renderLegend([RAMPED]);
+
+    expect(shadowRoot.querySelector<HTMLElement>('.bar')?.style.background).toEqual('');
+    expect(shadowRoot.querySelector('.min')?.textContent).toEqual('-184');
+  });
+
+  it('names the legend for assistive technology', async () => {
+    const shadowRoot = await renderLegend([RAMPED]);
+    expect(shadowRoot.querySelector('.panel')?.getAttribute('aria-label')).toEqual('Legend');
+  });
+});

--- a/src/components/ogm-legend/ogm-legend.tsx
+++ b/src/components/ogm-legend/ogm-legend.tsx
@@ -1,0 +1,75 @@
+import { Component, h, Host, Prop, State } from '@stencil/core';
+
+import { colormapSprite, formatValue, rampGradient } from '../../lib/colormap';
+import { rampedLayers, type LayerControl } from '../../lib/layers';
+
+// Reads a color ramp's ends for whichever drawn layers have one - a single-band COG of floats or
+// signed integers, drawn through src/lib/previewers/cog-pipeline.ts. Kept off the layers panel and
+// on the map instead: <ogm-layers> is unmounted while closed, and closing it is not asking to stop
+// being able to read the map, only to stop editing it. Native HTML elements, matching ogm-layers'
+// own reasoning for using them - easier to style and test than a Web Awesome component would be.
+//
+// <ogm-map> only mounts this when rampedLayers(this.layerControls) is non-empty - see its render()
+// - rather than mounting it unconditionally and relying on the render() below to return null. Both
+// would look right; only one of them is. A custom element that's always in the tree, with a
+// component that has its own async componentWillLoad, was found - in this one component tree,
+// under test - to delay a *different* component's own async lifecycle for reasons under Stencil's
+// hood rather than any logic of this component's own. Not mounting it when there's nothing to show
+// avoids the question rather than answering it.
+@Component({
+  tag: 'ogm-legend',
+  styleUrl: 'ogm-legend.css',
+  shadow: true,
+})
+export class OgmLegend {
+  @Prop() theme: 'light' | 'dark';
+  // Every layer control the panel would show, not a filtered list handed in from outside: which of
+  // them are rampable, and which of those are actually drawn right now, is this component's own
+  // question to answer, the same way ogm-layers decides for itself which row gets a ramp picker.
+  @Prop() layers: LayerControl[] = [];
+
+  // The sprite every entry's gradient bar is drawn from. See ogm-layers.tsx's own sprite field for
+  // why this is loaded in componentWillLoad rather than read synchronously, and why a decode
+  // failure is caught rather than left to fail the component: a legend with no gradients still
+  // labels its ends, which is most of what a legend is for.
+  @State() private sprite: ImageData | undefined;
+
+  async componentWillLoad() {
+    try {
+      this.sprite = await colormapSprite();
+    } catch (error) {
+      console.warn('Could not decode the color ramp sprite, so the legend will show no gradient:', error);
+    }
+  }
+
+  render() {
+    const entries = rampedLayers(this.layers);
+    if (!entries.length) return null;
+
+    return (
+      <Host class={this.theme && `wa-${this.theme}`}>
+        <div class="panel" role="group" aria-label="Legend">
+          {entries.map(layer => {
+            // Checked in `entries` above; asserted here rather than re-checked, since this is the
+            // one place their absence would otherwise be a type error rather than a filtered row.
+            const [min, max] = layer.colorRampRange!;
+            const step = max - min;
+
+            return (
+              <div class="entry" key={layer.id}>
+                <span class="title" title={layer.title}>
+                  {layer.title}
+                </span>
+                <div class="bar" style={this.sprite && { background: rampGradient(this.sprite, layer.colorRamp!) }}></div>
+                <div class="labels">
+                  <span class="min">{formatValue(min, step)}</span>
+                  <span class="max">{formatValue(max, step)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/ogm-map/ogm-map.css
+++ b/src/components/ogm-map/ogm-map.css
@@ -42,6 +42,19 @@ ogm-layers {
   display: flex;
 }
 
+/* Bottom-left, the one corner nothing else claims: the layer panel above is top-right, and
+   MapLibre's own attribution control defaults to bottom-right. Unlike the panel, this is never
+   toggled, so there's no button stack of its own to clear - just the same inset the panel keeps
+   from the map's own edge. */
+ogm-legend {
+  position: absolute;
+  inset-block-end: var(--ogm-control-inset);
+  inset-inline-start: var(--ogm-control-inset);
+  z-index: 3;
+  max-width: calc(100% - 2 * var(--ogm-control-inset));
+  display: flex;
+}
+
 /* Our own control button, drawn the way MapLibre draws its own: the glyph is a background image with
    its ink baked in at #333 rather than following currentColor, because the dark-mode rule below
    inverts the whole group - a themed glyph would turn near-white and then invert to black on black.

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -8,7 +8,7 @@ import { adoptWebAwesomeTheme, initialTheme, waScope } from '../../lib/init';
 import { dedupeFeatures } from '../../lib/features';
 import { mercatorBbox, type PixelWindow } from '../../lib/geometry';
 import { createMap, fitBounds, openingCamera, setBasemap, whenSized } from '../../lib/maps';
-import { isLayerDrawn, toLayerControlItems as getLayerControls, type LayerControl, type LayerState } from '../../lib/layers';
+import { isLayerDrawn, rampedLayers, resolveLayerState, toLayerControlItems as getLayerControls, type LayerControl, type LayerState } from '../../lib/layers';
 import LayersControl from '../../lib/layers-control';
 import InspectableRasterPreviewer from '../../lib/previewers/inspectable-raster';
 import type MapPreviewer from '../../lib/previewers/map';
@@ -396,6 +396,12 @@ export class OgmMap {
     this.setLayerState(event.detail.id, { opacity: event.detail.opacity });
   }
 
+  @Listen('layerColorRampChange')
+  handleLayerColorRampChange(event: CustomEvent<{ id: string; colorRamp: LayerState['colorRamp'] }>) {
+    event.stopPropagation();
+    this.setLayerState(event.detail.id, { colorRamp: event.detail.colorRamp });
+  }
+
   // Used when the user toggles the summary checkbox to show/hide all layers at once
   @Listen('allLayersVisibilityChange')
   handleAllLayersVisibilityChange(event: CustomEvent<boolean>) {
@@ -418,10 +424,16 @@ export class OgmMap {
 
   // Update the layer state for a layer; return true if it just changed
   // to hidden so we can clear popups/highlights
+  //
+  // The starting point for `current` has to be resolveLayerState's own, not a copy of the same two
+  // fields written out here by hand: that copy is how a ramp choice, once LayerState grew one,
+  // would have gone missing on the very next opacity change - `{...current, ...change}` merges the
+  // rest of `current` forward untouched, but only if `current` already had every field a layer
+  // might carry, which a hand-written `{ visible, opacity }` never will once a third one exists.
   private recordLayerState(id: string, change: Partial<LayerState>): boolean {
     const layer = this.previewer?.previewLayers.find(previewLayer => previewLayer.id === id);
     if (!layer) return false;
-    const current = this.layerState.get(id) ?? { visible: true, opacity: layer.defaultOpacity };
+    const current = this.layerState.get(id) ?? resolveLayerState(layer, this.layerState);
     const next = { ...current, ...change };
     this.layerState.set(id, next);
     return isLayerDrawn(current) && !isLayerDrawn(next);
@@ -628,22 +640,31 @@ export class OgmMap {
     return this.previewer?.visibleLayerIds || [];
   }
 
-  // The layer panel is a sibling of #map rather than a MapLibre control, even though the button that
-  // opens it is one. MapLibre owns the children of #map, so anything Stencil renders in there is
-  // fighting it for the same DOM - the reason ogm-attributes has to be built by hand.
+  // The layer panel and the legend are siblings of #map rather than MapLibre controls, even though
+  // the button that opens the panel is one. MapLibre owns the children of #map, so anything Stencil
+  // renders in there is fighting it for the same DOM - the reason ogm-attributes has to be built by
+  // hand.
   //
   // Everything is wrapped in .container because that is where the Web Awesome scope has to go: the
   // classes waScope() applies are matched by the theme adopted into this root, and a plain class
   // selector in a shadow root's stylesheet never matches the host of that root. On the Host alone
   // they would establish nothing, which is what a bare <ogm-map> used to draw with - every color
-  // empty. The panel needs them as much as the map does, and it isn't inside #map, so the scope goes
-  // above both.
+  // empty. The panel and the legend need them as much as the map does, and neither is inside #map,
+  // so the scope goes above all three.
+  //
+  // The legend is shown independently of the panel, unlike layersPanelOpen below: it exists to be
+  // read while looking at the map, which is exactly when the panel that would have opened it is
+  // closed. But it is gated the same way the panel is - mounted only when there's something for it
+  // to show, via rampedLayers(this.layerControls) rather than unconditionally with the component
+  // left to render null on its own. Both would look right to a reader; only one of them is - see
+  // the note on this at the top of ogm-legend.tsx.
   render() {
     return (
       <Host class={waScope(this.theme)}>
         <div class={`container ${waScope(this.theme)}`}>
           <div id="map"></div>
           {this.layersPanelOpen && <ogm-layers theme={this.theme} layers={this.layerControls}></ogm-layers>}
+          {rampedLayers(this.layerControls).length > 0 && <ogm-legend theme={this.theme} layers={this.layerControls}></ogm-legend>}
         </div>
       </Host>
     );

--- a/src/lib/colormap.test.ts
+++ b/src/lib/colormap.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { ColormapName } from '@developmentseed/deck.gl-raster/gpu-modules';
+
+import { formatValue, rampGradient, rampStops } from './colormap';
+
+// decodeColormapSprite needs createImageBitmap and OffscreenCanvas, which this project's node
+// environment doesn't have - so it's stubbed, and what's checked is only what colormapSprite() is
+// responsible for: decoding the right bytes, once. COLORMAP_INDEX and the ColormapName type pass
+// through from the real module, since rampStops needs the genuine row numbers.
+const { decodeColormapSprite } = vi.hoisted(() => ({
+  decodeColormapSprite: vi.fn(async (_bytes: Uint8Array) => ({ width: 256, height: 107, data: new Uint8ClampedArray(256 * 107 * 4) })),
+}));
+vi.mock('@developmentseed/deck.gl-raster/gpu-modules', async importOriginal => ({ ...(await importOriginal()), decodeColormapSprite }));
+
+// A sprite of the real dimensions, but with a color formula rather than the genuine ramps - a test
+// only has to tell "the right row" from "the wrong row" apart, not reproduce viridis.
+const SPRITE_WIDTH = 256;
+const SPRITE_HEIGHT = 107;
+const syntheticSprite = (): ImageData => {
+  const data = new Uint8ClampedArray(SPRITE_WIDTH * SPRITE_HEIGHT * 4);
+  for (let row = 0; row < SPRITE_HEIGHT; row++) {
+    for (let col = 0; col < SPRITE_WIDTH; col++) {
+      const offset = (row * SPRITE_WIDTH + col) * 4;
+      data.set([row, col, 255 - col, 255], offset);
+    }
+  }
+  return { width: SPRITE_WIDTH, height: SPRITE_HEIGHT, data, colorSpace: 'srgb' } as ImageData;
+};
+
+// colormapSprite() memoizes on a module-level promise, so a test asking whether it decoded once
+// needs a module nothing else has touched yet - the same reason src/lib/lerc.test.ts re-imports
+// after vi.resetModules() rather than sharing one import across the file.
+describe('colormapSprite', () => {
+  afterEach(() => {
+    vi.resetModules();
+    decodeColormapSprite.mockClear();
+  });
+
+  it('decodes the compiled-in sprite back to the original PNG bytes', async () => {
+    const { colormapSprite } = await import('./colormap');
+    await colormapSprite();
+
+    const bytes = decodeColormapSprite.mock.calls[0][0] as Uint8Array;
+    // The PNG signature every PNG opens with, and the width IHDR field
+    // scripts/inline-assets.mjs already checked before compiling this in.
+    expect([...bytes.slice(0, 8)]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(new DataView(bytes.buffer, bytes.byteOffset).getUint32(16)).toEqual(256);
+  });
+
+  it('decodes once however many times it is asked', async () => {
+    const { colormapSprite } = await import('./colormap');
+
+    await Promise.all([colormapSprite(), colormapSprite()]);
+
+    expect(decodeColormapSprite).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('rampStops', () => {
+  it("samples a named ramp's own row, evenly across its width", () => {
+    // row 100 is viridis's, per COLORMAP_INDEX - see the synthetic formula above for r/g/b
+    expect(rampStops(syntheticSprite(), 'viridis', 3)).toEqual(['rgb(100 0 255)', 'rgb(100 128 127)', 'rgb(100 255 0)']);
+  });
+
+  it("samples a different ramp's own row, not another one's", () => {
+    expect(rampStops(syntheticSprite(), 'greys', 1)).toEqual(['rgb(40 0 255)']);
+  });
+
+  // A ramp the sprite has no row for must not be quietly answered with some other ramp's colors
+  it('answers nothing for a name the sprite has no row for', () => {
+    expect(rampStops(syntheticSprite(), 'not-a-real-ramp' as ColormapName)).toEqual([]);
+  });
+});
+
+describe('rampGradient', () => {
+  it('builds a left-to-right CSS gradient from the same stops rampStops would give', () => {
+    expect(rampGradient(syntheticSprite(), 'greys')).toEqual(
+      'linear-gradient(90deg, rgb(40 0 255), rgb(40 51 204), rgb(40 102 153), rgb(40 153 102), rgb(40 204 51), rgb(40 255 0))',
+    );
+  });
+
+  it('is transparent for a ramp with no stops, rather than an empty gradient', () => {
+    expect(rampGradient(syntheticSprite(), 'not-a-real-ramp' as ColormapName)).toEqual('transparent');
+  });
+});
+
+describe('formatValue', () => {
+  // The case this exists for: a legend spanning hundreds of units, where a fixed two decimals would
+  // print "-184.48" and "607.27" - correct, but noisier than a legend needs to be
+  it('rounds to whole numbers when the gap between labels is that coarse', () => {
+    expect(formatValue(-184.48, 791.75)).toEqual('-184');
+    expect(formatValue(607.27, 791.75)).toEqual('607');
+  });
+
+  // A four-digit whole number reads as a year as often as a magnitude
+  it('leaves a four-digit whole number alone', () => {
+    expect(formatValue(5000)).toEqual('5,000');
+  });
+
+  it('abbreviates from ten thousand, and again from a million', () => {
+    expect(formatValue(50_000)).toEqual('50K');
+    expect(formatValue(1_500_000)).toEqual('1.5M');
+  });
+
+  // The case a fixed decimal count would fail: two labels a literal 0.0005 apart, which a legend
+  // with two decimal places would show as identical
+  it('falls back to exponential form when the gap between labels is that fine', () => {
+    expect(formatValue(0.0005, 0.0005)).toEqual('5.0e-4');
+  });
+
+  // Decimal count is read off the step between labels, not the value itself
+  it('gives a narrow range more decimals than a wide one', () => {
+    expect(formatValue(0.15, 0.3)).toEqual('0.15');
+    expect(formatValue(0.15, 3000)).toEqual('0');
+  });
+
+  it('treats zero as the whole number it is', () => {
+    expect(formatValue(0, 0)).toEqual('0');
+  });
+});

--- a/src/lib/colormap.ts
+++ b/src/lib/colormap.ts
@@ -1,0 +1,115 @@
+import { COLORMAP_INDEX, decodeColormapSprite, type ColormapName } from '@developmentseed/deck.gl-raster/gpu-modules';
+
+import { colormapSpriteBase64 } from './assets.generated';
+
+// The color ramps offered for a scalar COG - a single-band raster whose values are read off a ramp
+// rather than shown as-is; see src/lib/previewers/cog-pipeline.ts. Twelve of the 107
+// @developmentseed/deck.gl-raster ships, not all of them: perceptually-uniform ones first, since
+// those are the ones a value can be read off accurately, then a couple of diverging ramps for data
+// that has a meaningful zero (anomalies, elevation relative to sea level), then a few sequential
+// single-hue ones. `key` is upstream's own name, which flattens case in ways a label shouldn't
+// repeat - `rdylbu`, not `RdYlBu` - so every entry pairs it with one written for people.
+// `satisfies` rather than a `: readonly {...}[]` annotation, so this stays what it looks like: a
+// fixed list of literal strings, each checked against ColormapName without being widened back to
+// it. ColorRampName below is exactly those twelve, which is what lets a typo here - or a ramp
+// upstream drops - be a compile error instead of a swatch that's silently blank at runtime.
+export const COLOR_RAMPS = [
+  { key: 'viridis', label: 'Viridis' },
+  { key: 'magma', label: 'Magma' },
+  { key: 'inferno', label: 'Inferno' },
+  { key: 'plasma', label: 'Plasma' },
+  { key: 'cividis', label: 'Cividis' },
+  { key: 'terrain', label: 'Terrain' },
+  { key: 'gist_earth', label: 'Earth' },
+  { key: 'spectral', label: 'Spectral' },
+  { key: 'rdylbu', label: 'Red-Yellow-Blue' },
+  { key: 'rdbu', label: 'Red-Blue' },
+  { key: 'blues', label: 'Blues' },
+  { key: 'greys', label: 'Greys' },
+] as const satisfies readonly { key: ColormapName; label: string }[];
+
+export type ColorRampName = (typeof COLOR_RAMPS)[number]['key'];
+
+export const DEFAULT_COLOR_RAMP: ColorRampName = 'viridis';
+
+// Decoded once per realm and shared: every caller - the previewer building a GPU texture, the layers
+// panel drawing swatches, the legend drawing its gradient - wants the same pixels, and decoding needs
+// no GPU device, so there's nothing gained by putting it off until one exists. See lerc.ts's load()
+// for the same shape of memo.
+let sprite: Promise<ImageData> | undefined;
+
+// The sprite every named ramp is a row of - see scripts/inline-assets.mjs for how it gets here, and
+// stencil.config.ts's note on the dist-custom-elements target for why this one is compiled in rather
+// than published as a file the way lerc's wasm still is.
+export function colormapSprite(): Promise<ImageData> {
+  sprite ??= decodeColormapSprite(base64ToBytes(colormapSpriteBase64));
+  return sprite;
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// A handful of CSS colors sampled evenly across one ramp's row of the sprite, for a swatch or a
+// legend gradient - not the GPU path, which samples all 256 stops by indexing the sprite as a
+// texture directly (see Colormap in cog-pipeline.ts). Six is enough for a `linear-gradient()`, which
+// interpolates the rest; more would just be more stops of the same interpolation.
+//
+// Returns nothing for a name the sprite doesn't have a row for, rather than falling back to some
+// other ramp - a swatch that quietly became a different ramp would be a worse bug than a blank one.
+export function rampStops(image: ImageData, name: ColormapName, count = 6): string[] {
+  const row = COLORMAP_INDEX[name];
+  if (row === undefined) return [];
+
+  const stops: string[] = [];
+  for (let i = 0; i < count; i++) {
+    // Evenly spaced across all 256 columns, including both ends
+    const column = count > 1 ? Math.round((i * 255) / (count - 1)) : 0;
+    const offset = (row * image.width + column) * 4;
+    const [r, g, b] = image.data.subarray(offset, offset + 3);
+    stops.push(`rgb(${r} ${g} ${b})`);
+  }
+  return stops;
+}
+
+// A CSS `linear-gradient()` built from rampStops(), for anywhere a ramp needs to be shown rather than
+// drawn through - a swatch in the layers panel, the bar in the legend. `90deg` (left to right) reads
+// the way a legend's own min-to-max labels do; a caller drawing a legend the other way round is
+// responsible for turning the labels to match, not this.
+export function rampGradient(image: ImageData, name: ColormapName): string {
+  const stops = rampStops(image, name);
+  if (stops.length === 0) return 'transparent';
+  return `linear-gradient(90deg, ${stops.join(', ')})`;
+}
+
+// `step` is the spacing between adjacent labels on whatever axis value belongs to - a legend's own
+// (max - min), not the value being formatted. It decides two different things below, at opposite
+// ends of the range: whether a value near zero needs exponential form at all, and if not, how many
+// decimals a fractional one gets.
+//
+// Above ten thousand, values are abbreviated to K or M rather than ever shown in exponential form:
+// geo data commonly runs that high - population, precipitation in mm, elevation in mm - and "1.5M"
+// reads better than "1.5e6" ever would. Ten thousand rather than one thousand, because a four-digit
+// value is as often a year as a magnitude, and "5,000" is no harder to read at a glance than "5.0K"
+// is - the same reasoning apps/geolibre-desktop/src/lib/auto-legend.ts uses (MIT, opengeos/GeoLibre).
+//
+// Exponential form is reserved for the opposite end: a step under 0.001 is most of a Float32 range
+// centered near zero - an elevation anomaly, an NDVI band - where a fixed-point label would either
+// run long or round two adjacent ticks to the same "0.000". Derived from the step rather than the
+// value for the same reason apps/geolibre-desktop/src/lib/print-layout.ts derives decimal precision
+// from it (also GeoLibre, `formatColorbarTick`): two labels a literal 0.01 apart both round to "0.00"
+// at a fixed two decimals, which reads as a legend with no range at all.
+export function formatValue(value: number, step: number = Math.abs(value)): string {
+  const abs = Math.abs(value);
+
+  if (abs !== 0 && step > 0 && step < 0.001) return value.toExponential(1);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}M`;
+  if (abs >= 10_000) return `${(value / 1_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}K`;
+  if (Number.isInteger(value)) return value.toLocaleString();
+
+  const decimals = step > 0 ? Math.max(0, Math.min(8, Math.ceil(-Math.log10(step)) + 1)) : 2;
+  return value.toLocaleString(undefined, { maximumFractionDigits: decimals });
+}

--- a/src/lib/layers.test.ts
+++ b/src/lib/layers.test.ts
@@ -19,6 +19,15 @@ const vectorLayer: Layer = {
   ],
 };
 
+const scalarLayer: Layer = {
+  id: 'stanford-def456-cog',
+  title: 'Groundwater Elevation',
+  defaultOpacity: 0.8,
+  styleLayers: [{ id: 'stanford-def456-cog', type: 'custom' }],
+  defaultColorRamp: 'viridis',
+  colorRampRange: [-184.48, 607.27],
+};
+
 describe('humanizeLayerName', () => {
   it('turns a machine-written tileset name into a readable one', () => {
     expect(humanizeLayerName('landuse_overlay')).toEqual('Landuse overlay');
@@ -55,6 +64,23 @@ describe('resolveLayerState', () => {
     const states = new Map<string, LayerState>([[rasterLayer.id, { visible: false, opacity: 0.25 }]]);
     expect(resolveLayerState(vectorLayer, states)).toEqual({ visible: true, opacity: 0.8 });
   });
+
+  it("follows the layer's own ramp for a rampable row the user has not touched", () => {
+    expect(resolveLayerState(scalarLayer, new Map())).toEqual({ visible: true, opacity: 0.8, colorRamp: 'viridis' });
+  });
+
+  it('prefers the ramp the user chose', () => {
+    const states = new Map<string, LayerState>([[scalarLayer.id, { visible: true, opacity: 0.8, colorRamp: 'magma' }]]);
+    expect(resolveLayerState(scalarLayer, states).colorRamp).toEqual('magma');
+  });
+
+  // The case a whole-object fallback (states.get(id) ?? default) would get wrong: a state already
+  // on record from changing some other field - opacity, say - while the ramp went untouched, which
+  // carries no colorRamp key of its own rather than the layer's default under that key
+  it("falls back to the layer's own ramp when the state on record has none", () => {
+    const states = new Map<string, LayerState>([[scalarLayer.id, { visible: true, opacity: 0.4 }]]);
+    expect(resolveLayerState(scalarLayer, states).colorRamp).toEqual('viridis');
+  });
 });
 
 describe('isLayerDrawn', () => {
@@ -89,5 +115,16 @@ describe('toLayerControlItems', () => {
 
     expect(item.visible).toBe(false);
     expect(item.opacity).toEqual(0.4);
+  });
+
+  // A vector or raster layer's entry gains no colorRamp/colorRampRange keys at all, not even as
+  // undefined - most entries in this list are one of those, and there's no reason for them to carry
+  // two keys that never mean anything for them. The rampable layer's entry is the one that does.
+  it('carries a ramp and its range only for a layer that has one', () => {
+    const [scalar] = toLayerControlItems([scalarLayer], new Map());
+    expect(scalar).toEqual({ id: scalarLayer.id, title: 'Groundwater Elevation', visible: true, opacity: 0.8, colorRamp: 'viridis', colorRampRange: [-184.48, 607.27] });
+
+    const [vector] = toLayerControlItems([vectorLayer], new Map());
+    expect(Object.keys(vector).sort()).toEqual(['id', 'opacity', 'title', 'visible']);
   });
 });

--- a/src/lib/layers.ts
+++ b/src/lib/layers.ts
@@ -1,5 +1,7 @@
 import type { LayerSpecification as MapLibreLayerSpecification } from 'maplibre-gl';
 
+import type { ColorRampName } from './colormap';
+
 // A MapLibre style layer, one piece of a logical layer. Vector layers can have
 // multiple of these, e.g. to style fills, outlines, and labels separately.
 export type PreviewStyleLayer = {
@@ -21,24 +23,56 @@ export type Layer = {
   title: string;
   defaultOpacity: number;
   styleLayers: PreviewStyleLayer[];
+  // Present only for a layer whose values are read off a color ramp rather than shown as-is - a
+  // single-band COG of floats or signed integers; see src/lib/previewers/cog-pipeline.ts. Its
+  // presence is what marks a layer as rampable at all, both to the layers panel (which draws a ramp
+  // picker only for these layers) and to resolveLayerState below (which needs a ramp to default to).
+  defaultColorRamp?: ColorRampName;
+  // The values defaultColorRamp is stretched across, in the data's own units - what a legend labels
+  // its ends with. A fixed fact about the layer, not something the user chooses, so unlike the ramp
+  // itself it has no counterpart on LayerState; it travels with the layer the same way title does.
+  colorRampRange?: readonly [min: number, max: number];
 };
 
 // Attributes of a layer that the user can toggle in the control panel
-export type LayerState = { visible: boolean; opacity: number };
+export type LayerState = { visible: boolean; opacity: number; colorRamp?: ColorRampName };
 
 // Data for a single entry in the layers control panel
-export type LayerControl = { id: string; title: string } & LayerState;
+export type LayerControl = { id: string; title: string; colorRampRange?: Layer['colorRampRange'] } & LayerState;
 
-// Get the initial state for a layer
-export const resolveLayerState = (layer: Layer, states: ReadonlyMap<string, LayerState>): LayerState => states.get(layer.id) ?? { visible: true, opacity: layer.defaultOpacity };
+// Get the initial state for a layer. Field by field against the layer's own defaults, not the
+// stored state wholesale: a state already on record from before colorRamp existed - or from a
+// change to some other field, made while colorRamp was untouched - carries no colorRamp key of its
+// own, and that has to fall back to the layer's default rather than surface as undefined.
+export const resolveLayerState = (layer: Layer, states: ReadonlyMap<string, LayerState>): LayerState => {
+  const requested = states.get(layer.id);
+  return {
+    visible: requested?.visible ?? true,
+    opacity: requested?.opacity ?? layer.defaultOpacity,
+    colorRamp: requested?.colorRamp ?? layer.defaultColorRamp,
+  };
+};
 
 // Used to check if the layer should be inspectable; needs to be both toggled on and not fully faded
 export const isLayerDrawn = ({ visible, opacity }: LayerState): boolean => visible && opacity > 0;
 
+// Which of a panel's rows a legend has anything to say about: drawn, and carrying both halves of a
+// ramp - the color and the range it's stretched across. Shared between <ogm-map>, which uses this
+// to decide whether to mount <ogm-legend> at all, and <ogm-legend> itself, which uses it to decide
+// what to render - the same question asked twice would drift if answered twice. Mounting matters on
+// its own, separately from what gets rendered: an unconditionally-mounted custom element sibling has
+// been observed, in this component tree specifically, to perturb the timing of a *different*
+// component's own async lifecycle - see the note on this in ogm-map.tsx's render().
+export const rampedLayers = (layers: readonly LayerControl[]): LayerControl[] =>
+  layers.filter(layer => isLayerDrawn(layer) && layer.colorRamp !== undefined && layer.colorRampRange !== undefined);
+
 export const toLayerControlItems = (layers: readonly Layer[], states: ReadonlyMap<string, LayerState>): LayerControl[] =>
   layers.map(layer => {
-    const { visible, opacity } = resolveLayerState(layer, states);
-    return { id: layer.id, title: layer.title, visible, opacity };
+    const { visible, opacity, colorRamp } = resolveLayerState(layer, states);
+    // Left off a layer with no ramp of its own, rather than carried as undefined: ordinary vector
+    // and raster layers are most of what this list holds, and there is no reason for their entries
+    // to grow two keys that never mean anything for them.
+    return { id: layer.id, title: layer.title, visible, opacity, ...(colorRamp !== undefined && { colorRamp, colorRampRange: layer.colorRampRange }) };
   });
 
 // A tileset names its layers for machines ('landuse_overlay'); a WMTS <ows:Title> is already

--- a/src/lib/previewers/cog-deck.test.ts
+++ b/src/lib/previewers/cog-deck.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from '@stencil/vitest
 
 import DeckCogPreviewer from './cog-deck';
 import CogPreviewer from './cog';
+import { scalarGetTileData } from './cog-pipeline';
 import CogResource from '../resources/cog';
+import { DEFAULT_COLOR_RAMP } from '../colormap';
 import type { MapLibreStyle } from '../themes/maplibre';
 
 // Just enough of a MapLibre map to record what the previewer does. setPaintProperty and
@@ -60,6 +62,17 @@ class FakeOverlay {
 // hands it over - which is the whole of what these tests check about it.
 const FAKE_GEOTIFF = { crs: 'EPSG:4326' };
 
+// A single-band float COG - SampleFormat 3, one sample per pixel - with statistics already on
+// record, which is what most GDAL-written COGs carry. Read by isScalarSampleFormat and scalarRange
+// (see cog-pipeline.test.ts for both in isolation); statistics being present means scalarRange never
+// has to reach for fetchTile, so nothing here needs to answer one.
+const FAKE_SCALAR_GEOTIFF = {
+  crs: 'EPSG:4326',
+  cachedTags: { sampleFormat: [3], samplesPerPixel: 1 },
+  gdalMetadata: { bandStatistics: new Map([[1, { min: -184.48, max: 607.27, mean: null, std: null, validPercent: null }]]) },
+  overviews: [],
+};
+
 // Substitutes the fake overlay for deck.gl's and the fake COG for a real read, leaving everything else
 // the real previewer
 class TestDeckCogPreviewer extends DeckCogPreviewer {
@@ -71,6 +84,8 @@ class TestDeckCogPreviewer extends DeckCogPreviewer {
 
   opened: string[] = [];
   refusal: Error | undefined;
+  // What loadGeoTIFF hands back - FAKE_GEOTIFF unless a test needs a scalar one instead
+  geotiffToLoad: unknown = FAKE_GEOTIFF;
 
   protected getDeckOverlay() {
     return this.overlay as never;
@@ -79,7 +94,7 @@ class TestDeckCogPreviewer extends DeckCogPreviewer {
   protected async loadGeoTIFF() {
     if (this.refusal) throw this.refusal;
     this.opened.push(this.resource.url);
-    return FAKE_GEOTIFF as never;
+    return this.geotiffToLoad as never;
   }
 }
 
@@ -191,6 +206,85 @@ describe('DeckCogPreviewer', () => {
       await previewer.preview();
       previewer.applyLayerState(new Map([['stanford-vq494qx9344-cog', { visible: true, opacity: 0.5 }]]));
 
+      const ids = previewer.overlay.props.flatMap(p => (p.layers ?? []).map((l: any) => l.id));
+      expect(new Set(ids).size).toEqual(1);
+    });
+  });
+
+  // A scalar COG - single-band float or signed-integer data - draws through its own pipeline
+  // (src/lib/previewers/cog-pipeline.ts) rather than @developmentseed/deck.gl-geotiff's own, which
+  // refuses that data outright.
+  describe('a scalar COG', () => {
+    it("publishes the default ramp and the file's own value range on the layer", async () => {
+      const { previewer } = previewFor();
+      previewer.geotiffToLoad = FAKE_SCALAR_GEOTIFF;
+      await previewer.preview();
+
+      expect(previewer.previewLayers[0].defaultColorRamp).toEqual(DEFAULT_COLOR_RAMP);
+      expect(previewer.previewLayers[0].colorRampRange).toEqual([-184.48, 607.27]);
+    });
+
+    it('publishes no ramp at all for an ordinary COG', async () => {
+      const { previewer } = previewFor();
+      await previewer.preview();
+
+      expect(previewer.previewLayers[0].defaultColorRamp).toBeUndefined();
+      expect(previewer.previewLayers[0].colorRampRange).toBeUndefined();
+    });
+
+    it("draws through the scalar pipeline rather than deck.gl-geotiff's own", async () => {
+      const { previewer } = previewFor();
+      previewer.geotiffToLoad = FAKE_SCALAR_GEOTIFF;
+      await previewer.preview();
+
+      const { props } = previewer.overlay.lastLayers[0];
+      expect(props.getTileData).toBe(scalarGetTileData);
+      expect(props.renderTile).toBeInstanceOf(Function);
+    });
+
+    // getTileData and renderTile are unset either way - COGLayer's _parseGeoTIFF checks !this.props.getTileData
+    // || !this.props.renderTile to decide whether to infer a render pipeline itself, which either
+    // falsy value satisfies. deck.gl's own defaultProps happens to fill the two differently (null
+    // for one, plain undefined for the other); both are asserted so a change either way is caught.
+    it('leaves getTileData and renderTile unset for an ordinary COG, so its own pipeline is inferred', async () => {
+      const { previewer } = previewFor();
+      await previewer.preview();
+
+      const { props } = previewer.overlay.lastLayers[0];
+      expect(props.getTileData).toBeFalsy();
+      expect(props.renderTile).toBeFalsy();
+    });
+
+    it('draws in the default ramp until the user chooses one', async () => {
+      const { previewer } = previewFor();
+      previewer.geotiffToLoad = FAKE_SCALAR_GEOTIFF;
+      await previewer.preview();
+
+      expect(previewer.overlay.lastLayers[0].props.updateTriggers).toEqual({ renderTile: [DEFAULT_COLOR_RAMP, -184.48, 607.27] });
+    });
+
+    // The trap this test guards: drawDeckLayer rebuilds the layer object on every layer-state
+    // change, but deck.gl matches it by id and updates props in place rather than re-rendering from
+    // scratch - so without naming the ramp as a renderTile dependency, a swatch click would change
+    // nothing the user could see.
+    it('changes updateTriggers when the ramp changes, so deck.gl actually redraws it', async () => {
+      const { previewer } = previewFor();
+      previewer.geotiffToLoad = FAKE_SCALAR_GEOTIFF;
+      await previewer.preview();
+
+      previewer.applyLayerState(new Map([['stanford-vq494qx9344-cog', { visible: true, opacity: 0.8, colorRamp: 'magma' }]]));
+
+      expect(previewer.overlay.lastLayers[0].props.updateTriggers).toEqual({ renderTile: ['magma', -184.48, 607.27] });
+    });
+
+    it('keeps the COG open and the layer id stable across a ramp change, same as an opacity change', async () => {
+      const { previewer } = previewFor();
+      previewer.geotiffToLoad = FAKE_SCALAR_GEOTIFF;
+      await previewer.preview();
+
+      previewer.applyLayerState(new Map([['stanford-vq494qx9344-cog', { visible: true, opacity: 0.8, colorRamp: 'magma' }]]));
+
+      expect(previewer.opened).toEqual([COG_URL]);
       const ids = previewer.overlay.props.flatMap(p => (p.layers ?? []).map((l: any) => l.id));
       expect(new Set(ids).size).toEqual(1);
     });

--- a/src/lib/previewers/cog-deck.ts
+++ b/src/lib/previewers/cog-deck.ts
@@ -4,7 +4,9 @@ import type { DecoderPool, GeoTIFF } from '@developmentseed/geotiff';
 import type { AddLayerObject, LngLatBoundsLike } from 'maplibre-gl';
 
 import MapPreviewer from './map';
+import { isScalarSampleFormat, scalarGetTileData, scalarRange, scalarRenderTile, type ScalarRange, type ScalarTileData } from './cog-pipeline';
 import type CogResource from '../resources/cog';
+import { DEFAULT_COLOR_RAMP } from '../colormap';
 import { decoderPool } from '../decoder';
 import { openGeoTIFF } from '../geotiff';
 import { isLayerDrawn, type LayerState, type PreviewStyleLayer } from '../layers';
@@ -53,6 +55,13 @@ export default class DeckCogPreviewer extends MapPreviewer {
   // open file instead of reading its header again.
   protected geotiff: GeoTIFF | undefined;
 
+  // Set once per preview(), and only for a single-band COG of floats or signed integers - the kind
+  // @developmentseed/deck.gl-geotiff's own render pipeline refuses to draw at all. Its presence is
+  // what createLayers and createDeckLayer below both key off of to decide whether this COG draws
+  // through our own scalar pipeline (src/lib/previewers/cog-pipeline.ts) instead of upstream's;
+  // there is deliberately nowhere else that re-derives the same answer.
+  protected valueRange: ScalarRange | undefined;
+
   // Whether any tile of this COG has been drawn, which is what tells a COG that can't be drawn at
   // all from one tile of it that couldn't. Reset per attach, alongside everything else a fresh load
   // attempt starts over. See reportTileError.
@@ -82,6 +91,10 @@ export default class DeckCogPreviewer extends MapPreviewer {
       title: this.resource.label(),
       defaultOpacity: this.style.opacity,
       styleLayers: [{ id: this.getLayerId(), type: 'custom' }],
+      // Only present for a scalar COG - see valueRange above - which is what marks the layer as
+      // rampable to the panel and to resolveLayerState. this.valueRange is already known by the
+      // time this runs; see preview() for why the ordering has to be that way round.
+      ...(this.valueRange && { defaultColorRamp: DEFAULT_COLOR_RAMP, colorRampRange: this.valueRange }),
     });
 
     return [];
@@ -94,9 +107,16 @@ export default class DeckCogPreviewer extends MapPreviewer {
   // Opening the COG here rather than leaving deck.gl to do it is what lets a restricted one be drawn:
   // deck.gl only reads a URL with a plain fetch. It also means a COG that refuses to be read fails the
   // preview, so the alert names it, where before it only turned up in the console.
+  //
+  // Both reads happen before super.preview() now, not after: super.preview() is what calls
+  // createLayers(), and that needs to already know whether this COG is scalar - and its value range,
+  // if so - to publish the ramp defaults the layer starts with. A COG that fails to open still fails
+  // preview() the same way either order; the difference is that it no longer leaves a phantom layer
+  // registered for a COG that was never actually readable.
   async preview(): Promise<void> {
-    await super.preview();
     this.geotiff = await this.loadGeoTIFF();
+    this.valueRange = isScalarSampleFormat(this.geotiff.cachedTags) ? await scalarRange(this.geotiff, this.decoderPool) : undefined;
+    await super.preview();
     this.drawDeckLayer();
   }
 
@@ -108,6 +128,7 @@ export default class DeckCogPreviewer extends MapPreviewer {
     await super.clearPreview();
     this.deckOverlay?.setProps({ layers: [] });
     this.geotiff = undefined;
+    this.valueRange = undefined;
   }
 
   // MapLibre knows nothing about this layer, so the inherited version - which starts by looking it
@@ -125,8 +146,20 @@ export default class DeckCogPreviewer extends MapPreviewer {
     this.deckOverlay.setProps({ layers: [this.createDeckLayer(this.geotiff, this.drawnState)] });
   }
 
-  protected createDeckLayer(geotiff: GeoTIFF, state: LayerState): COGLayer {
-    return new COGLayer({
+  // COGLayer's own generic parameter tracks the shape getTileData/renderTile produce and consume,
+  // and the two branches below produce different shapes - so each is its own `new COGLayer(...)`
+  // rather than one call with the pair conditionally spread into its props. A single call can't be
+  // typed for both at once, and building the discriminated union COGLayerDataProps actually wants by
+  // hand would say the same thing this does, at more length.
+  protected createDeckLayer(geotiff: GeoTIFF, state: LayerState): COGLayer | COGLayer<ScalarTileData> {
+    // Not this.geotiff: the layer this becomes is drawn from whichever GeoTIFF the caller handed
+    // over, and drawDeckLayer's caller is always that same field - the distinction only matters for
+    // a test building a layer directly. this.valueRange is the field that matters, and is safe to
+    // read as-is: it's set from this same geotiff in preview(), and cleared with it in
+    // clearPreview(), so the two never point at different files.
+    const range = this.valueRange;
+
+    const shared = {
       id: this.getLayerId(),
       // The open COG, not a URL: handed one of those, deck.gl opens it with a plain fetch that no
       // transform can reach. (And never getMapLibreSourceUrl(), which prefixes the cog:// scheme the
@@ -134,7 +167,7 @@ export default class DeckCogPreviewer extends MapPreviewer {
       geotiff,
       visible: isLayerDrawn(state),
       opacity: state.opacity,
-      onGeoTIFFLoad: (_data, options) => {
+      onGeoTIFFLoad: (_data: GeoTIFF, options: { geographicBounds: { west: number; south: number; east: number; north: number } }) => {
         const { west, south, east, north } = options.geographicBounds;
         this.resolveGeotiffBounds([
           [west, south],
@@ -143,8 +176,24 @@ export default class DeckCogPreviewer extends MapPreviewer {
       },
       onTileLoad: () => this.reportTileDrawn(),
       onTileError: (error: unknown) => this.reportTileError(error),
-      parameters: { depthCompare: 'always', cullMode: 'back' },
+      parameters: { depthCompare: 'always' as const, cullMode: 'back' as const },
       pool: this.decoderPool,
+    };
+
+    if (!range) return new COGLayer(shared);
+
+    const ramp = state.colorRamp ?? DEFAULT_COLOR_RAMP;
+    return new COGLayer({
+      ...shared,
+      getTileData: scalarGetTileData,
+      renderTile: scalarRenderTile(ramp, range),
+      // Without this, a ramp swatch click would do nothing visible: drawDeckLayer rebuilds the
+      // layer object on every layer-state change, but deck.gl matches it by id and updates props in
+      // place rather than re-rendering from scratch, so the inner TileLayer keeps whichever shader
+      // pipeline it already rendered with unless told a dependency of renderTile changed. Naming
+      // renderTile's own dependencies here, rather than getTileData's: nothing about fetching or
+      // decoding a tile depends on the ramp, only on how the decoded value is drawn.
+      updateTriggers: { renderTile: [ramp, ...range] },
     });
   }
 

--- a/src/lib/previewers/cog-pipeline.test.ts
+++ b/src/lib/previewers/cog-pipeline.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { isScalarSampleFormat, scalarRange, scalarGetTileData, scalarRenderTile, DiscardNonFinite, type ScalarTileData } from './cog-pipeline';
+
+// colormapSprite() goes through decodeColormapSprite, which needs createImageBitmap and
+// OffscreenCanvas - absent in this project's node test environment, and beside the point here
+// anyway: what matters to cog-pipeline.ts is only that it gets an ImageData-shaped object back.
+// createColormapTexture is left real; it does nothing FakeDevice.createTexture can't stand in for.
+const FAKE_SPRITE = { width: 256, height: 107, data: new Uint8ClampedArray(256 * 107 * 4) } as ImageData;
+vi.mock('../colormap', async importOriginal => ({ ...(await importOriginal()), colormapSprite: vi.fn(async () => FAKE_SPRITE) }));
+
+// SampleFormat values, matching the ones cog-pipeline.ts hardcodes
+const UINT = 1;
+const INT = 2;
+const FLOAT = 3;
+
+const cachedTags = (sampleFormat: number[], samplesPerPixel: number) => ({ sampleFormat, samplesPerPixel }) as never;
+
+describe('isScalarSampleFormat', () => {
+  it('is false with nothing to read', () => {
+    expect(isScalarSampleFormat(undefined)).toBe(false);
+  });
+
+  // Ordinary RGB/RGBA imagery - already drawn by upstream's own pipeline
+  it('is false for more than one band, whatever the sample format', () => {
+    expect(isScalarSampleFormat(cachedTags([FLOAT], 3))).toBe(false);
+  });
+
+  // Unsigned integers are what inferRenderPipeline already handles - nothing for this pipeline to do
+  it('is false for a single unsigned-integer band', () => {
+    expect(isScalarSampleFormat(cachedTags([UINT], 1))).toBe(false);
+  });
+
+  it('is true for a single signed-integer band', () => {
+    expect(isScalarSampleFormat(cachedTags([INT], 1))).toBe(true);
+  });
+
+  it('is true for a single float band', () => {
+    expect(isScalarSampleFormat(cachedTags([FLOAT], 1))).toBe(true);
+  });
+});
+
+// Stands in for a GeoTIFF or Overview: fetchTile is the only method scalarRange and
+// scalarGetTileData call on it.
+const fakeImage = (array: Partial<ScalarTileData> & Record<string, unknown>) => ({
+  fetchTile: vi.fn(async () => ({ array })),
+});
+
+describe('scalarRange', () => {
+  it("reads the band's own statistics without fetching a tile", async () => {
+    const geotiff = {
+      gdalMetadata: { bandStatistics: new Map([[1, { min: -184.48, max: 607.27, mean: null, std: null, validPercent: null }]]) },
+      overviews: [fakeImage({})],
+      fetchTile: vi.fn(),
+    };
+
+    expect(await scalarRange(geotiff as never)).toEqual([-184.48, 607.27]);
+    expect(geotiff.overviews[0].fetchTile).not.toHaveBeenCalled();
+  });
+
+  it('samples the coarsest overview when the file has no statistics of its own', async () => {
+    const coarsest = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([1, 2, 3, 100]), nodata: null } as never);
+    const geotiff = { gdalMetadata: null, overviews: [fakeImage({}), coarsest], fetchTile: vi.fn() };
+
+    expect(await scalarRange(geotiff as never)).toEqual([1, 100]);
+    expect(coarsest.fetchTile).toHaveBeenCalledWith(0, 0, { boundless: false, pool: undefined });
+  });
+
+  it('falls back to the full-resolution image when there are no overviews at all', async () => {
+    const fetchTile = vi.fn(async () => ({ array: { layout: 'pixel-interleaved', data: Float32Array.from([5, 6]), nodata: null } }));
+    const geotiff = { gdalMetadata: null, overviews: [], fetchTile };
+
+    expect(await scalarRange(geotiff as never)).toEqual([5, 6]);
+    expect(fetchTile).toHaveBeenCalledWith(0, 0, { boundless: false, pool: undefined });
+  });
+
+  // The GeoLibre/Math.fround case: a sentinel whose decimal text parses to a float64 that never
+  // equals the pixel's own float32 value unless both are compared at float32 precision
+  it('excludes nodata written at less precision than the pixel it matches', async () => {
+    const trueSentinel = Math.fround(-3.4028235e38);
+    const coarsest = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([trueSentinel, 10, 20]), nodata: -3.4028235e38 } as never);
+    const geotiff = { gdalMetadata: null, overviews: [coarsest], fetchTile: vi.fn() };
+
+    expect(await scalarRange(geotiff as never)).toEqual([10, 20]);
+  });
+
+  it('excludes non-finite samples alongside nodata', async () => {
+    const coarsest = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([NaN, 3, 4, Infinity]), nodata: null } as never);
+    const geotiff = { gdalMetadata: null, overviews: [coarsest], fetchTile: vi.fn() };
+
+    expect(await scalarRange(geotiff as never)).toEqual([3, 4]);
+  });
+
+  // LinearRescale divides by (max - min); a flat raster would otherwise divide by zero
+  it('widens a flat range so the ramp has a span to stretch across', async () => {
+    const geotiff = { gdalMetadata: { bandStatistics: new Map([[1, { min: 42, max: 42, mean: null, std: null, validPercent: null }]]) }, overviews: [], fetchTile: vi.fn() };
+
+    expect(await scalarRange(geotiff as never)).toEqual([42, 43]);
+  });
+
+  it('answers a default range rather than an inverted one when every sample was excluded', async () => {
+    const coarsest = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([NaN, NaN]), nodata: null } as never);
+    const geotiff = { gdalMetadata: null, overviews: [coarsest], fetchTile: vi.fn() };
+
+    expect(await scalarRange(geotiff as never)).toEqual([0, 1]);
+  });
+});
+
+// Enough of a luma.gl Device for scalarGetTileData: it only calls createTexture and
+// isTextureFormatFilterable, and records what it was given.
+class FakeDevice {
+  filterable = true;
+  textures: { format: string; sampler: unknown; data: unknown }[] = [];
+
+  isTextureFormatFilterable() {
+    return this.filterable;
+  }
+
+  createTexture(options: { format: string; sampler: unknown; data: unknown }) {
+    const texture = { ...options };
+    this.textures.push(texture);
+    return texture;
+  }
+}
+
+describe('scalarGetTileData', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches the tile at the given coordinates through the given pool', async () => {
+    const device = new FakeDevice();
+    const pool = { decode: vi.fn() } as never;
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([1, 2]), width: 2, height: 1, nodata: null } as never);
+
+    await scalarGetTileData(image as never, { device: device as never, x: 3, y: 4, pool });
+
+    expect(image.fetchTile).toHaveBeenCalledWith(3, 4, { boundless: false, pool, signal: undefined });
+  });
+
+  it('uploads a band-separate tile as one r32float texture', async () => {
+    const device = new FakeDevice();
+    const image = fakeImage({ layout: 'band-separate', bands: [Float32Array.from([1, 2, 3, 4])], width: 2, height: 2, nodata: null } as never);
+
+    const data = await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+
+    // The tile's own texture, plus the shared colormap sprite texture created alongside it
+    expect(device.textures).toHaveLength(2);
+    expect(device.textures[0].format).toEqual('r32float');
+    expect([...(device.textures[0].data as Float32Array)]).toEqual([1, 2, 3, 4]);
+    expect(data.width).toEqual(2);
+    expect(data.height).toEqual(2);
+    expect(data.byteLength).toEqual(16);
+  });
+
+  it('rewrites nodata to NaN before it reaches the texture', async () => {
+    const device = new FakeDevice();
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([-9999, 5]), width: 2, height: 1, nodata: -9999 } as never);
+
+    await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+
+    const [first, second] = device.textures[0].data as Float32Array;
+    expect(first).toBeNaN();
+    expect(second).toEqual(5);
+  });
+
+  it('widens signed integer samples to float32', async () => {
+    const device = new FakeDevice();
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Int16Array.from([-32768, 32767]), width: 2, height: 1, nodata: null } as never);
+
+    await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+
+    expect(device.textures[0].data).toBeInstanceOf(Float32Array);
+    expect([...(device.textures[0].data as Float32Array)]).toEqual([-32768, 32767]);
+  });
+
+  it('filters linearly when the device supports it', async () => {
+    const device = new FakeDevice();
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([1]), width: 1, height: 1, nodata: null } as never);
+
+    await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+
+    expect(device.textures[0].sampler).toEqual({ minFilter: 'linear', magFilter: 'linear' });
+  });
+
+  // r32float is unfilterable-float without the device feature; sampling it as linear anyway reads
+  // as black rather than refusing to draw, so nearest is the fallback rather than a thrown error.
+  it('falls back to nearest filtering when the device does not', async () => {
+    const device = new FakeDevice();
+    device.filterable = false;
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([1]), width: 1, height: 1, nodata: null } as never);
+
+    await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+
+    expect(device.textures[0].sampler).toEqual({ minFilter: 'nearest', magFilter: 'nearest' });
+  });
+
+  it('shares one colormap texture across tiles decoded on the same device', async () => {
+    const device = new FakeDevice();
+    const image = fakeImage({ layout: 'pixel-interleaved', data: Float32Array.from([1]), width: 1, height: 1, nodata: null } as never);
+
+    const first = await scalarGetTileData(image as never, { device: device as never, x: 0, y: 0 });
+    const second = await scalarGetTileData(image as never, { device: device as never, x: 1, y: 0 });
+
+    expect(first.colormapTexture).toBe(second.colormapTexture);
+    // One for each tile's own data, plus exactly one for the shared colormap sprite
+    expect(device.textures).toHaveLength(3);
+  });
+});
+
+describe('scalarRenderTile', () => {
+  const data: ScalarTileData = { width: 1, height: 1, byteLength: 4, texture: { name: 'tile' } as never, colormapTexture: { name: 'sprite' } as never };
+
+  // scalarRenderTile(ramp, range) itself returns the renderTile function COGLayer wants, which
+  // takes a tile's ScalarTileData and only then produces a pipeline - so every test here has to
+  // call the result, not just build it.
+  const pipeline = (ramp: Parameters<typeof scalarRenderTile>[0], range: Parameters<typeof scalarRenderTile>[1]) => {
+    // Non-null: RenderTileResult is a union with an image-only branch that has no renderPipeline,
+    // but scalarRenderTile's own result is always the renderPipeline branch - that's the fact under
+    // test, and the whole reason to import RenderTileResult would be to re-widen away from it.
+    return scalarRenderTile(ramp, range)(data).renderPipeline!;
+  };
+
+  it('orders the pipeline: texture, discard, rescale, then colormap', () => {
+    const renderPipeline = pipeline('viridis', [0, 1]);
+
+    expect(renderPipeline.map(({ module }) => module.name)).toEqual(['create-texture-unorm', 'ogm-discard-non-finite', 'linearRescale', 'colormap']);
+  });
+
+  it('passes the tile texture and the shared colormap texture through unchanged', () => {
+    const [texture, , , colormap] = pipeline('viridis', [0, 1]);
+
+    expect(texture.props).toMatchObject({ textureName: data.texture });
+    expect(colormap.props).toMatchObject({ colormapTexture: data.colormapTexture });
+  });
+
+  it("resolves the ramp's own row in the sprite", () => {
+    const [, , , viridis] = pipeline('viridis', [0, 1]);
+    const [, , , greys] = pipeline('greys', [0, 1]);
+
+    expect(viridis.props).toMatchObject({ colormapIndex: 100 });
+    expect(greys.props).toMatchObject({ colormapIndex: 40 });
+  });
+
+  it('stretches the given range across 0-1', () => {
+    const [, , rescale] = pipeline('viridis', [-184.48, 607.27]);
+
+    expect(rescale.props).toMatchObject({ rescaleMin: -184.48, rescaleMax: 607.27 });
+  });
+});
+
+describe('DiscardNonFinite', () => {
+  // Not runnable GLSL in a unit test - this only guards against losing the substance of the
+  // module while editing around it.
+  it('discards both NaN and infinite values', () => {
+    const injected = DiscardNonFinite.inject['fs:DECKGL_FILTER_COLOR'];
+
+    expect(injected).toContain('isnan(color.r)');
+    expect(injected).toContain('isinf(color.r)');
+    expect(injected).toContain('discard');
+  });
+});

--- a/src/lib/previewers/cog-pipeline.ts
+++ b/src/lib/previewers/cog-pipeline.ts
@@ -1,0 +1,207 @@
+import type { CachedTags, DecoderPool, GeoTIFF, Overview, RasterArray, RasterTypedArray } from '@developmentseed/geotiff';
+import { Colormap, COLORMAP_INDEX, createColormapTexture, CreateTexture, LinearRescale } from '@developmentseed/deck.gl-raster/gpu-modules';
+import type { RenderTileResult } from '@developmentseed/deck.gl-raster';
+import type { Device, Texture } from '@luma.gl/core';
+
+import { colormapSprite, type ColorRampName } from '../colormap';
+
+// SampleFormat values, from @cogeotiff/core's enum - hardcoded rather than imported for the same
+// reason src/lib/lerc.ts hardcodes LERC's compression tag: this library doesn't depend on
+// @cogeotiff/core directly, and these two numbers are unlikely to move.
+const SAMPLE_FORMAT_INT = 2;
+const SAMPLE_FORMAT_FLOAT = 3;
+
+// Whether a GeoTIFF's samples are read off a color ramp rather than shown as-is: a single band of
+// signed integers or floats, which @developmentseed/deck.gl-geotiff's own inferRenderPipeline
+// refuses outright - "Inferring render pipeline for non-unsigned integers not yet supported" - and
+// which is what most non-imagery COGs actually are: elevation, temperature, an index like NDVI.
+// Multi-band data and unsigned integers (ordinary RGB/RGBA imagery, palette rasters) are left to
+// upstream's own pipeline, which already draws them.
+export function isScalarSampleFormat(cachedTags: CachedTags | undefined): boolean {
+  if (!cachedTags || cachedTags.samplesPerPixel !== 1) return false;
+  const [format] = cachedTags.sampleFormat;
+  return format === SAMPLE_FORMAT_INT || format === SAMPLE_FORMAT_FLOAT;
+}
+
+// The value range a scalar layer's ramp is stretched across - see scalarRange below for how it's
+// found. Read-only past this point: nothing here recomputes it per tile.
+export type ScalarRange = readonly [min: number, max: number];
+
+// The band's own pre-existing statistics when the file carries them (most COGs written by GDAL do),
+// or a value range sampled from the coarsest overview when it doesn't. Never the full resolution
+// image: a DEM the size of a state is exactly the case a fallback like this has to stay cheap for,
+// and the coarsest overview is already downsampled to a handful of tiles - one, for the COG this was
+// measured against, at 131ms including the network read.
+export async function scalarRange(geotiff: GeoTIFF, pool?: DecoderPool): Promise<ScalarRange> {
+  const stats = geotiff.gdalMetadata?.bandStatistics.get(1);
+  if (stats && stats.min !== null && stats.max !== null) return widen(stats.min, stats.max);
+
+  const coarsest = geotiff.overviews.at(-1) ?? geotiff;
+  const tile = await coarsest.fetchTile(0, 0, { boundless: false, pool });
+  const values = singleBand(tile.array);
+  const sentinel = tile.array.nodata === null ? null : Math.fround(tile.array.nodata);
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const value of values) {
+    if (sentinel !== null && Math.fround(value) === sentinel) continue;
+    if (!Number.isFinite(value)) continue;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+
+  // Every sampled pixel was nodata or non-finite - a mask that happens to blank the one tile this
+  // reads from, most likely. [0, 1] is as good a guess as any and, unlike leaving min > max, doesn't
+  // divide LinearRescale by a negative span.
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [0, 1];
+  return widen(min, max);
+}
+
+// A flat raster - every sampled pixel the same value - would otherwise hand LinearRescale a span of
+// zero, dividing by it in the shader for every pixel. Widened rather than left, so a single-valued
+// layer still draws in the ramp's first color instead of NaN.
+function widen(min: number, max: number): ScalarRange {
+  return max > min ? [min, max] : [min, min + 1];
+}
+
+// Everything a scalar tile needs GPU-side: the tile's own values, uploaded once as a texture no
+// ramp choice ever has to re-upload, and the ramp sprite every scalar layer on the page shares.
+export type ScalarTileData = {
+  width: number;
+  height: number;
+  byteLength: number;
+  texture: Texture;
+  colormapTexture: Texture;
+};
+
+// One colormap texture per Device, not per tile or per layer: the sprite is the same 107 ramps
+// whichever layer is asking, and re-uploading it on every tile would be paying GPU memory bandwidth
+// for a texture that never changes. A Device is not disposed of by anything in this library, so
+// nothing here has to be either.
+const colormapTextures = new WeakMap<Device, Texture>();
+
+async function colormapTexture(device: Device): Promise<Texture> {
+  const existing = colormapTextures.get(device);
+  if (existing) return existing;
+
+  const sprite = await colormapSprite();
+  const texture = createColormapTexture(device, sprite);
+  colormapTextures.set(device, texture);
+  return texture;
+}
+
+// Fetches, decodes and uploads one tile of a scalar COG - the getTileData half of the pair COGLayer
+// wants; see scalarRenderTile for the other half. Stable across every render a scalar layer goes
+// through: nothing it does depends on which ramp is currently selected, only on the tile itself, so
+// there is nothing to gain and tiles already decoded to lose by rebuilding this per ramp change. The
+// pool, the device and even the image (a GeoTIFF or one of its Overviews) all arrive as arguments -
+// COGLayer resolves which overview level a tile belongs to before calling this.
+export async function scalarGetTileData(
+  image: GeoTIFF | Overview,
+  options: { device: Device; x: number; y: number; signal?: AbortSignal; pool?: DecoderPool },
+): Promise<ScalarTileData> {
+  const { device, x, y, signal, pool } = options;
+  const tile = await image.fetchTile(x, y, { boundless: false, pool, signal });
+  const { array } = tile;
+  const values = toScalarValues(singleBand(array), array.nodata);
+  const filterable = device.isTextureFormatFilterable('r32float');
+  const texture = device.createTexture({
+    data: values,
+    format: 'r32float',
+    width: array.width,
+    height: array.height,
+    // r32float is not linearly filterable without the float32-filterable device feature (WebGL2's
+    // OES_texture_float_linear) - unfiltered, sampling it at a zoom between tile levels reads as
+    // block edges rather than a smooth gradient, so nearest is the fallback, not a refusal to draw.
+    sampler: filterable ? { minFilter: 'linear', magFilter: 'linear' } : { minFilter: 'nearest', magFilter: 'nearest' },
+  });
+
+  return {
+    width: array.width,
+    height: array.height,
+    byteLength: values.byteLength,
+    texture,
+    colormapTexture: await colormapTexture(device),
+  };
+}
+
+// A single band's samples, however the decoder answered: band-separate (LERC always does, and
+// PlanarConfiguration=2 does for any codec) or pixel-interleaved (everything else, and LERC's own
+// codec output for a one-band file is identical either way - there is only one band to separate).
+// @developmentseed/geotiff's own toBandSeparate() does this generally, for any band count, but isn't
+// part of its published API - only its own decoders reach for it - so this is the one-band case of
+// the same idea, small enough to own here.
+function singleBand(array: RasterArray) {
+  return array.layout === 'band-separate' ? array.bands[0] : array.data;
+}
+
+// Widens integer samples to float, and rewrites nodata to NaN so DiscardNonFinite below can drop it
+// on the GPU without a value comparison of its own - see that module for why an exact comparison in
+// the shader is the wrong tool. Left alone (same reference, no copy) when it's already Float32 with
+// no nodata to rewrite, which is the common case for a DEM: nothing here needs to touch memory that
+// doesn't need touching.
+//
+// Signed integers arrive here because @developmentseed/geotiff's decoders answer band-separate for
+// LERC regardless of layout, and there is no unsigned-texture format upstream's CreateTexture
+// declares a sampler for (that would need isampler2D/usampler2D) - so both scalar cases upload as
+// float, or not at all. Widening loses no precision for anything this pipeline draws: display, not
+// scientific recomputation, and the values involved are far inside float32's exactly-representable
+// integer range.
+function toScalarValues(raw: RasterTypedArray, nodata: number | null): Float32Array {
+  if (raw instanceof Float32Array && nodata === null) return raw;
+
+  const values = raw instanceof Float32Array ? raw.slice() : Float32Array.from(raw);
+  if (nodata === null) return values;
+
+  // Compared at float32 precision, not as the float64 `nodata` parses to: GDAL_NODATA is decimal
+  // text, and a sentinel written with too few digits parses to a float64 that never equals the
+  // float32 value the pixel actually holds once it's upconverted to a JS double - "-3.4028235e+38"
+  // reads as that exact float64, while the pixel's true value is -3.4028234663852886e+38. Comparing
+  // both at float32 makes them meet either way. (Credit: this exact failure mode, and this fix, are
+  // documented in packages/map/src/cog-dem-source.ts of opengeos/GeoLibre, MIT licensed.)
+  const sentinel = Math.fround(nodata);
+  for (let i = 0; i < values.length; i++) {
+    if (Math.fround(values[i]) === sentinel) values[i] = NaN;
+  }
+  return values;
+}
+
+// A shader module of our own, alongside the published ones in @developmentseed/deck.gl-raster: that
+// package ships FilterNoDataVal for this job, but it discards by an exact GPU `==` against a single
+// uniform, which is exactly the comparison toScalarValues above avoids doing on the CPU and for the
+// same reason - and `==` never matches NaN regardless, so it couldn't discard what toScalarValues
+// produces even if the precision problem didn't exist. Nodata is already NaN in the texture by the
+// time this runs; discarding is just noticing that.
+export const DiscardNonFinite = {
+  name: 'ogm-discard-non-finite',
+  inject: {
+    // isnan/isinf are GLSL ES 3.00 builtins, which this pipeline already requires: Colormap injects
+    // `precision highp sampler2DArray`, a type that doesn't exist below ES 3.00 (WebGL1). Nothing
+    // upstream produces Infinity - toScalarValues only ever writes finite samples or NaN - but a
+    // consumer's own values are read here too, and isinf costs nothing to also check for.
+    'fs:DECKGL_FILTER_COLOR': `
+    if (isnan(color.r) || isinf(color.r)) {
+      discard;
+    }
+    `,
+  },
+};
+
+// Builds the renderTile half of the pair COGLayer wants, closed over the one layer's current ramp
+// and value range - the two things a ramp change actually is. Rebuilt on every such change, unlike
+// scalarGetTileData: a fresh function here costs nothing tiles already decoded, because it never
+// touches the tile cache, only the shader pipeline drawn from it - see the note on updateTriggers
+// where this is called, in src/lib/previewers/cog-deck.ts.
+export function scalarRenderTile(ramp: ColorRampName, range: ScalarRange): (data: ScalarTileData) => RenderTileResult {
+  const colormapIndex = COLORMAP_INDEX[ramp];
+  const [rescaleMin, rescaleMax] = range;
+
+  return data => ({
+    renderPipeline: [
+      { module: CreateTexture, props: { textureName: data.texture } },
+      { module: DiscardNonFinite },
+      { module: LinearRescale, props: { rescaleMin, rescaleMax } },
+      { module: Colormap, props: { colormapTexture: data.colormapTexture, colormapIndex } },
+    ],
+  });
+}

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -8,6 +8,7 @@ import './dist/components/ogm-alerts.js';
 import './dist/components/ogm-attributes.js';
 import './dist/components/ogm-image.js';
 import './dist/components/ogm-layers.js';
+import './dist/components/ogm-legend.js';
 import './dist/components/ogm-locator.js';
 import './dist/components/ogm-map.js';
 import './dist/components/ogm-menubar.js';


### PR DESCRIPTION
## Summary

- Single-band COGs of floats or signed integers - elevation, temperature, an NDVI-style index - currently refuse to draw at all: `@developmentseed/deck.gl-geotiff`'s render pipeline throws `Inferring render pipeline for non-unsigned integers not yet supported`, and since that throw happens during layer construction rather than per tile, it never reaches `onTileError` - the preview just times out with nothing to explain why.
- Adds `src/lib/previewers/cog-pipeline.ts`, a render pipeline of our own assembled from `@developmentseed/deck.gl-raster`'s own published shader modules, so these COGs decode and draw through a `r32float` texture and a 256-color ramp sprite compiled into the bundle.
- Adds a ramp picker (12 of the 107 ramps deck.gl-raster ships) to the layers panel, and a new `<ogm-legend>` component reading the current ramp's ends on the map.
- Adds the real OpenGeoMetadata record for [Groundwater Elevation Color Ramp, California, Fall 2013](https://purl.stanford.edu/xp137nw4166) as a fixture, so this path has something to exercise it. The COG itself stays remote; nothing large is vendored in.

## Reviewer notes

- Nodata is handled on the CPU (compared at float32 precision, rewritten to `NaN`) rather than through the published `FilterNoDataVal` module, which discards by an exact GPU `==` that a `GDAL_NODATA` sentinel can silently fail depending on how many digits it was written with. This exact failure mode and fix are documented in `opengeos/GeoLibre`'s `cog-dem-source.ts` (MIT), credited in the code.
- `getTileData` is stable across every render a layer goes through - a ramp change never re-fetches or re-decodes a tile. Only `renderTile` is rebuilt, and `COGLayer` has to be told so via `updateTriggers`, or deck.gl's id-matched prop update leaves the old shader pipeline in place and a ramp change would silently do nothing visible.
- `<ogm-legend>` is mounted only when there's something for it to show, not unconditionally with the component left to render `null` on its own. In this component tree specifically, an always-mounted custom element with its own async lifecycle measurably delayed a *sibling* component's own `componentDidLoad` under Stencil's test harness - confirmed by elimination, not fully explained. Worth knowing if a future change wants to mount something else unconditionally near `<ogm-map>`.

## Test plan

- [x] `npm test` - 1073 tests pass
- [x] `npm run lint` - clean
- [x] `npm run build` - clean, including the new colormap-sprite compilation step in `scripts/inline-assets.mjs`
- [x] Verified in a real browser (Chromium via Playwright) against the actual Stanford record: the COG range-fetches and draws, the legend reads the file's own `-184`/`607`, the ramp picker shows all 12 swatches with `viridis` checked by default, and picking `magma` repaints the map, the legend, and the checked swatch with zero additional tile requests
- [x] Verified the new fixture is reachable and loads from the demo page's own record selector, not just by URL

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>