### PR TITLE
Support opening overview maps on configured bounds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -242,10 +242,16 @@ document.querySelector('ogm-overview').addEventListener('boundsChange', event =>
 });
 ```
 
-Set `bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it. It will accept an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
+Set `search-bounds` to the area a search is currently filtered to. It's drawn as a box and the camera frames it, with the same gap everything else on the map gets. It will accept an `ENVELOPE` string, or anything else MapLibre reads as bounds — and being a string, it can come from an attribute:
 
 ```html
-<ogm-overview bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
+<ogm-overview search-bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
+```
+
+Set `view-bounds` to where the map should open in place of the whole world, when there's no active search and no results of its own to frame - a catalog's home page, say. Given in the same form as `search-bounds`:
+
+```html
+<ogm-overview view-bounds="ENVELOPE(-124.41,-114.13,42.01,32.53)"></ogm-overview>
 ```
 
 ### Content Security Policy

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -114,10 +114,6 @@ export namespace Components {
      */
     interface OgmOverview {
         /**
-          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Leave it unset for a map that should look at whatever it has been given.
-         */
-        "bounds"?: maplibregl.LngLatBoundsLike | string;
-        /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
           * @default false
          */
@@ -129,6 +125,10 @@ export namespace Components {
         "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**
+          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Wins over `viewBounds` when both are given, an active filter being the stronger statement - though in practice a page states one or the other, never both. Leave it unset for a map that should look at whatever it has been given; see `viewBounds` for a default to open on instead of the whole world.
+         */
+        "searchBounds"?: maplibregl.LngLatBoundsLike | string;
+        /**
           * @default 'Shift + drag to search an area'
          */
         "searchHelpText": string;
@@ -136,6 +136,10 @@ export namespace Components {
           * @default initialTheme(this.el)
          */
         "theme": 'light' | 'dark';
+        /**
+          * Where to point the camera when there is nothing else to look at - no active search, no results - in place of the whole world. Given in the same form as `searchBounds` and read the same way, but nothing about it is drawn: no box, no marker, nothing on the map says it is there.  Framed exactly, with no padding and no ceiling on how far in the camera can zoom - unlike `searchBounds` and the extent of a set of results, which both keep the theme's gap because neither one is a promise about what should fill the frame. This one is: a page that sets it has already chosen the exact box the map should show, so nothing here second-guesses that choice.
+         */
+        "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
         "previewer": AnyPreviewer;
@@ -505,10 +509,6 @@ declare namespace LocalJSX {
      */
     interface OgmOverview {
         /**
-          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Leave it unset for a map that should look at whatever it has been given.
-         */
-        "bounds"?: maplibregl.LngLatBoundsLike | string;
-        /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
           * @default false
          */
@@ -525,6 +525,10 @@ declare namespace LocalJSX {
         "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**
+          * The area a search is currently filtered to, drawn as a box and framed by the camera. Given as the west, south, east, north degrees `boundsChange` reports, as an ENVELOPE string in the form `dcat_bbox` holds one, or as anything else MapLibre reads as bounds. A string is read from an attribute, so a page rendered by a server can say what its map is filtered to without any JavaScript at all.  It goes on holding: whenever what is drawn changes, the camera returns here rather than re-framing itself around the new set of results. Wins over `viewBounds` when both are given, an active filter being the stronger statement - though in practice a page states one or the other, never both. Leave it unset for a map that should look at whatever it has been given; see `viewBounds` for a default to open on instead of the whole world.
+         */
+        "searchBounds"?: maplibregl.LngLatBoundsLike | string;
+        /**
           * @default 'Shift + drag to search an area'
          */
         "searchHelpText"?: string;
@@ -532,6 +536,10 @@ declare namespace LocalJSX {
           * @default initialTheme(this.el)
          */
         "theme"?: 'light' | 'dark';
+        /**
+          * Where to point the camera when there is nothing else to look at - no active search, no results - in place of the whole world. Given in the same form as `searchBounds` and read the same way, but nothing about it is drawn: no box, no marker, nothing on the map says it is there.  Framed exactly, with no padding and no ceiling on how far in the camera can zoom - unlike `searchBounds` and the extent of a set of results, which both keep the theme's gap because neither one is a promise about what should fill the frame. This one is: a page that sets it has already chosen the exact box the map should show, so nothing here second-guesses that choice.
+         */
+        "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
         "previewer"?: AnyPreviewer;
@@ -611,7 +619,8 @@ declare namespace LocalJSX {
         "highlighted": string;
         "geosearch": boolean;
         "searchHelpText": string;
-        "bounds": maplibregl.LngLatBoundsLike | string;
+        "searchBounds": maplibregl.LngLatBoundsLike | string;
+        "viewBounds": maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreviewAttributes {
         "theme": 'light' | 'dark';

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -171,7 +171,8 @@ type Overview = HTMLElement & {
   projection: 'globe' | 'mercator';
   extents: unknown[];
   highlighted?: number | string;
-  bounds?: number[] | string;
+  searchBounds?: number[] | string;
+  viewBounds?: number[] | string;
   geosearch: boolean;
   searchHelpText: string;
   addControls: () => void;
@@ -184,7 +185,8 @@ type Overview = HTMLElement & {
   declaredExtents: () => unknown[];
   search: (start: Point, end: Point) => void;
   onRecordsChange: () => Promise<void>;
-  onBoundsChange: () => Promise<void>;
+  onSearchBoundsChange: () => Promise<void>;
+  onViewBoundsChange: () => Promise<void>;
   onHighlightedChange: () => void;
   onGeosearchChange: () => void;
   onSearchHelpTextChange: () => void;
@@ -545,8 +547,8 @@ describe('ogm-overview search filter', () => {
     el.records = [record('one', { dcat_bbox: ICELAND })];
     await el.load();
 
-    el.bounds = CALIFORNIA;
-    await el.onBoundsChange();
+    el.searchBounds = CALIFORNIA;
+    await el.onSearchBoundsChange();
 
     expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
     // Only the view of it changed; the results are still on the map, still numbered
@@ -556,7 +558,7 @@ describe('ogm-overview search filter', () => {
   it('draws the area being searched as a box under everything else', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: ICELAND })];
-    el.bounds = CALIFORNIA;
+    el.searchBounds = CALIFORNIA;
     await el.load();
 
     expect(layerIds(map)).toEqual(ALL_LAYERS);
@@ -565,11 +567,11 @@ describe('ogm-overview search filter', () => {
 
   it('takes the box away when the search filter is withdrawn', async () => {
     const { el, map } = await renderOverview();
-    el.bounds = CALIFORNIA;
+    el.searchBounds = CALIFORNIA;
     await el.load();
 
-    el.bounds = undefined;
-    await el.onBoundsChange();
+    el.searchBounds = undefined;
+    await el.onSearchBoundsChange();
 
     expect(drawnBox(map, SEARCH_BOUNDS)).toBe(false);
   });
@@ -578,7 +580,7 @@ describe('ogm-overview search filter', () => {
   // who searched one street shouldn't come back to a view of the city, so no zoom limit
   it('gives a search filter the same room it gives everything else', async () => {
     const { el, map } = await renderOverview();
-    el.bounds = CALIFORNIA;
+    el.searchBounds = CALIFORNIA;
     await el.load();
 
     const [, options] = framed(map);
@@ -588,7 +590,7 @@ describe('ogm-overview search filter', () => {
 
   it('returns to the search filter when what is drawn changes', async () => {
     const { el, map } = await renderOverview();
-    el.bounds = CALIFORNIA;
+    el.searchBounds = CALIFORNIA;
     el.records = [record('one', { dcat_bbox: ICELAND })];
     await el.load();
 
@@ -601,11 +603,11 @@ describe('ogm-overview search filter', () => {
   it('goes back to framing what it drew when the filter is withdrawn', async () => {
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: ICELAND })];
-    el.bounds = CALIFORNIA;
+    el.searchBounds = CALIFORNIA;
     await el.load();
 
-    el.bounds = undefined;
-    await el.onBoundsChange();
+    el.searchBounds = undefined;
+    await el.onSearchBoundsChange();
 
     expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
     expect(framed(map)[1].maxZoom).toEqual(12);
@@ -614,10 +616,10 @@ describe('ogm-overview search filter', () => {
   // Which is how a page rendered by a server says what its map is filtered to, without any JavaScript
   it('takes a filter from an attribute', async () => {
     const { el, map } = await renderOverview();
-    el.setAttribute('bounds', CALIFORNIA);
+    el.setAttribute('search-bounds', CALIFORNIA);
 
-    expect(el.bounds).toEqual(CALIFORNIA);
-    await el.onBoundsChange();
+    expect(el.searchBounds).toEqual(CALIFORNIA);
+    await el.onSearchBoundsChange();
 
     expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
     expect(drawnBox(map, SEARCH_BOUNDS)).toBe(true);
@@ -627,15 +629,113 @@ describe('ogm-overview search filter', () => {
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { el, map } = await renderOverview();
     el.records = [record('one', { dcat_bbox: ICELAND })];
-    el.bounds = 'somewhere nice';
+    el.searchBounds = 'somewhere nice';
     // Whatever the watcher said about it on the way in; what is under test is the load below
     consoleWarn.mockClear();
     await el.load();
 
-    expect(consoleWarn).toHaveBeenCalledWith('Could not read bounds:', 'somewhere nice');
+    expect(consoleWarn).toHaveBeenCalledWith('Could not read searchBounds:', 'somewhere nice');
     // Once per load, rather than once for the box and again for the camera
     expect(consoleWarn).toHaveBeenCalledTimes(1);
     expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('ogm-overview default view', () => {
+  it('points the camera there when there is nothing else to look at', async () => {
+    const { el, map } = await renderOverview();
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  // The whole point of it: a page states where the map should open, not what it should say is there
+  it('draws nothing for it', async () => {
+    const { el, map } = await renderOverview();
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    expect(drawnBox(map, SEARCH_BOUNDS)).toBe(false);
+    expect(layerIds(map)).toEqual(ALL_LAYERS);
+  });
+
+  // An active filter is a stronger statement than a default opening point - though in practice a
+  // page never states both at once
+  it('loses to a search filter when both are given', async () => {
+    const { el, map } = await renderOverview();
+    el.searchBounds = ICELAND;
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+  });
+
+  it('loses to what it drew when both are given', async () => {
+    const { el, map } = await renderOverview();
+    el.records = [record('one', { dcat_bbox: ICELAND })];
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    expect(frameOf(map)).toEqual([-24.55, 63.39, -13.49, 66.57]);
+  });
+
+  // Unlike everything else this frames: a page that set this has already chosen the exact box the
+  // map should show, so nothing here pads it or holds it back from zooming in past city scale
+  it('is framed exactly, with no gap and no ceiling on how far in it can zoom', async () => {
+    const { el, map } = await renderOverview();
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    const [, options] = framed(map);
+    expect(options.padding).toEqual(0);
+    expect(options.maxZoom).toBeUndefined();
+  });
+
+  it('moves the camera when it changes', async () => {
+    const { el, map } = await renderOverview();
+    await el.load();
+
+    el.viewBounds = CALIFORNIA;
+    await el.onViewBoundsChange();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  it('goes back to the whole world when it is withdrawn and there is nothing else to show', async () => {
+    const { el, map } = await renderOverview();
+    el.viewBounds = CALIFORNIA;
+    await el.load();
+
+    el.viewBounds = undefined;
+    await el.onViewBoundsChange();
+
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
+  });
+
+  // Which is how a page rendered by a server says where its map should default to, without any
+  // JavaScript at all
+  it('is read from an attribute', async () => {
+    const { el, map } = await renderOverview();
+    el.setAttribute('view-bounds', CALIFORNIA);
+
+    expect(el.viewBounds).toEqual(CALIFORNIA);
+    await el.onViewBoundsChange();
+
+    expect(frameOf(map)).toEqual([-124.41, 32.53, -114.13, 42.01]);
+  });
+
+  it('says so, and opens on the whole world, when it cannot read the default it was given', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { el, map } = await renderOverview();
+    el.viewBounds = 'somewhere nice';
+    consoleWarn.mockClear();
+    await el.load();
+
+    expect(consoleWarn).toHaveBeenCalledWith('Could not read viewBounds:', 'somewhere nice');
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(frameOf(map)).toEqual([-90, -85, 90, 85]);
     consoleWarn.mockRestore();
   });
 });

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -84,10 +84,24 @@ export class OgmOverview {
    * JavaScript at all.
    *
    * It goes on holding: whenever what is drawn changes, the camera returns here rather than
-   * re-framing itself around the new set of results. Leave it unset for a map that should look at
-   * whatever it has been given.
+   * re-framing itself around the new set of results. Wins over `viewBounds` when both are given,
+   * an active filter being the stronger statement - though in practice a page states one or the
+   * other, never both. Leave it unset for a map that should look at whatever it has been given; see
+   * `viewBounds` for a default to open on instead of the whole world.
    */
-  @Prop() bounds?: maplibregl.LngLatBoundsLike | string;
+  @Prop() searchBounds?: maplibregl.LngLatBoundsLike | string;
+
+  /**
+   * Where to point the camera when there is nothing else to look at - no active search, no results -
+   * in place of the whole world. Given in the same form as `searchBounds` and read the same way, but
+   * nothing about it is drawn: no box, no marker, nothing on the map says it is there.
+   *
+   * Framed exactly, with no padding and no ceiling on how far in the camera can zoom - unlike
+   * `searchBounds` and the extent of a set of results, which both keep the theme's gap because
+   * neither one is a promise about what should fill the frame. This one is: a page that sets it has
+   * already chosen the exact box the map should show, so nothing here second-guesses that choice.
+   */
+  @Prop() viewBounds?: maplibregl.LngLatBoundsLike | string;
 
   // Where the reader has asked to search, as the west, south, east, north degrees a query states -
   // see boundsToBbox. Nothing here answers it: what a new area means is the embedding page's to say.
@@ -130,6 +144,11 @@ export class OgmOverview {
   // twice would report an unreadable one twice as well.
   private searchFilter?: maplibregl.LngLatBounds;
 
+  // Where to open when nothing else says where to look, as this map can read it. Held for the same
+  // reason searchFilter is, even though nothing here draws it: reading it twice would warn about an
+  // unreadable one twice as well.
+  private viewFilter?: maplibregl.LngLatBounds;
+
   // Which result the reader's pointer is over, as its place in the list counted from one. Ours rather
   // than the page's: nothing outside can see a pointer land on a number drawn inside this shadow root.
   private hovered?: number;
@@ -157,6 +176,7 @@ export class OgmOverview {
 
     // What the camera should be looking at, worked out before there is a camera
     this.readSearchFilter();
+    this.readViewFilter();
     this.extents = this.declaredExtents();
 
     this.map = createMap(container, this.mapTheme, {
@@ -372,10 +392,19 @@ export class OgmOverview {
 
   // The area being searched has changed. The box that says where it is changes with it, but nothing
   // about the results has moved, so nobody is asked for their extent a second time.
-  @Watch('bounds')
-  protected async onBoundsChange() {
+  @Watch('searchBounds')
+  protected async onSearchBoundsChange() {
     this.readSearchFilter();
     this.draw();
+    await this.frame();
+  }
+
+  // Where to open by default has changed. Nothing is drawn for it, so there is nothing to redraw -
+  // only the camera has anywhere new to go, and only when nothing stronger (an active search, a set
+  // of results) is already holding it elsewhere.
+  @Watch('viewBounds')
+  protected async onViewBoundsChange() {
+    this.readViewFilter();
     await this.frame();
   }
 
@@ -410,6 +439,7 @@ export class OgmOverview {
   // what goes on the map, and then where the camera looks.
   private async load() {
     this.readSearchFilter();
+    this.readViewFilter();
     await this.measure();
     this.draw();
     await this.frame();
@@ -418,8 +448,15 @@ export class OgmOverview {
   // The area a search is filtered to, if this map can read what it was given. Read once per load
   // rather than at each of the two places that want it, so an unreadable one is reported once.
   private readSearchFilter() {
-    this.searchFilter = this.bounds === undefined ? undefined : readBounds(this.bounds);
-    if (this.bounds !== undefined && !this.searchFilter) console.warn('Could not read bounds:', this.bounds);
+    this.searchFilter = this.searchBounds === undefined ? undefined : readBounds(this.searchBounds);
+    if (this.searchBounds !== undefined && !this.searchFilter) console.warn('Could not read searchBounds:', this.searchBounds);
+  }
+
+  // Where to open by default, if this map can read what it was given. Read alongside
+  // readSearchFilter, and for the same reason: once per load rather than at each place that wants it.
+  private readViewFilter() {
+    this.viewFilter = this.viewBounds === undefined ? undefined : readBounds(this.viewBounds);
+    if (this.viewBounds !== undefined && !this.viewFilter) console.warn('Could not read viewBounds:', this.viewBounds);
   }
 
   // Where every result is, and what each of them is called.
@@ -471,9 +508,10 @@ export class OgmOverview {
     await frameLocation(this.map, this.mapTheme, this.target(), this.globe(), this.camera());
   }
 
-  // Where to point: the area a search is filtered to, or everywhere the results cover
+  // Where to point: the area a search is filtered to, or everywhere the results cover, or the
+  // default a page opened on in place of the whole world
   private target(): maplibregl.LngLatBoundsLike {
-    return this.searchFilter ?? unionBounds(this.extents) ?? WORLD;
+    return this.searchFilter ?? unionBounds(this.extents) ?? this.viewFilter ?? WORLD;
   }
 
   // Whether the camera is pointing at a sphere, which is what decides whether what it is pointed at
@@ -490,12 +528,18 @@ export class OgmOverview {
   // a page of results any closer by. An area a search is filtered to gets none: a reader who searched
   // a single street shouldn't come back to a view of the city.
   //
+  // A default view gets neither the limit nor frameLocation's own gap: a page that set one has
+  // already chosen the exact box the map should show, and asking for padding of zero here is what
+  // overrides the gap frameLocation would otherwise fill in around it.
+  //
   // Animated here, unlike the plain fitBounds an <ogm-map> drives: this camera moves itself, in
   // response to a search or a highlighted row, while a reader's attention is elsewhere on the page,
   // so a cut would be a jump they didn't ask for. An <ogm-map> only refits when told to by a caller
   // who's watching the map already.
   private camera(): maplibregl.FitBoundsOptions {
-    return this.searchFilter ? { animate: true } : { animate: true, maxZoom: LOCATION_MAX_ZOOM };
+    if (this.searchFilter) return { animate: true };
+    if (!unionBounds(this.extents) && this.viewFilter) return { animate: true, padding: 0 };
+    return { animate: true, maxZoom: LOCATION_MAX_ZOOM };
   }
 
   // Every result to draw as highlighted, counted from one: the one the page named and the one the

--- a/src/index.html
+++ b/src/index.html
@@ -308,7 +308,7 @@
 
         const setFilter = bounds => {
           filter = bounds;
-          overview.bounds = bounds;
+          overview.searchBounds = bounds;
           boundsOut.textContent = bounds ? bounds.map(degrees => degrees.toFixed(3)).join(' ') : '';
           applyFilter();
         };


### PR DESCRIPTION
GeoBlacklight uses this to set the homepage map's focus
without searching anything.
