### PR TITLE
Support configuring the basemap for each mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,22 @@ To programmatically control dark mode, you can use the `theme` attribute with a 
 <ogm-viewer record-url="https://example.com/record.json" theme="dark"></ogm-viewer>
 ```
 
+### Basemaps
+
+By default, the viewer draws on one of [CARTO](https://carto.com/basemaps)'s basemaps: Dark Matter in dark mode, Positron in light mode. To use a different one for either mode, set `dark-basemap` and/or `light-basemap` to one of CARTO's own style names (`positron`, `dark-matter`, `voyager`, or any of those with `-nolabels`):
+
+```html
+<ogm-viewer record-url="https://example.com/record.json" dark-basemap="voyager" light-basemap="voyager"></ogm-viewer>
+```
+
+Or set either to a URL, for a basemap of your own from CARTO or anywhere else that serves a [MapLibre style document](https://maplibre.org/maplibre-style-spec/):
+
+```html
+<ogm-viewer record-url="https://example.com/record.json" light-basemap="https://api.maptiler.com/maps/basic-v2/style.json?key=your-key"></ogm-viewer>
+```
+
+Both attributes are also DOM properties, so they can be set from JavaScript the same way `theme` can. They're supported everywhere `theme` is - `<ogm-viewer>`, `<ogm-preview>`, `<ogm-previews>`, `<ogm-map>`, `<ogm-locator>`, and `<ogm-overview>` - and GeoBlacklight uses them to let a site configure its own basemaps.
+
 ### Colors
 
 You can style the viewer's colors by setting CSS custom properties on its element.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -67,6 +67,8 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmLocator {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "previewer"?: LocationPreviewer;
         "record"?: OgmRecord;
         "recordUrl"?: string;
@@ -76,7 +78,9 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmMap {
+        "darkBasemap"?: string;
         "easeMapTo": (options: maplibregl.EaseToOptions) => Promise<maplibregl.Map>;
+        "lightBasemap"?: string;
         /**
           * @default 0
          */
@@ -113,6 +117,7 @@ export namespace Components {
      * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        "darkBasemap"?: string;
         /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
           * @default false
@@ -122,6 +127,7 @@ export namespace Components {
           * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.  A reader's pointer over a number does the same thing without being asked, so both can be true at once - of two different results, if a page names one while the pointer is over another. Each is a way of saying the same thing about a row, so each gets the same drawing; see draw.
          */
         "highlighted"?: number | string;
+        "lightBasemap"?: string;
         "previewers"?: (LocationPreviewer | undefined)[];
         "records"?: OgmRecord[];
         /**
@@ -142,6 +148,8 @@ export namespace Components {
         "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "previewer": AnyPreviewer;
         "sidebarPadding": number;
         /**
@@ -150,6 +158,8 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmPreviews {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "previewers"?: AnyPreviewer[];
         "record"?: OgmRecord;
         "requestTransform"?: RequestTransform;
@@ -168,10 +178,12 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmViewer {
+        "darkBasemap"?: string;
         /**
           * @default false
          */
         "hideTitle": boolean;
+        "lightBasemap"?: string;
         "loadRecord": (record: OgmRecord) => Promise<void>;
         "recordUrl": string;
         "requestTransform"?: RequestTransform;
@@ -459,6 +471,8 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmLocator {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "previewer"?: LocationPreviewer;
         "record"?: OgmRecord;
         "recordUrl"?: string;
@@ -468,6 +482,8 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmMap {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "onMapIdle"?: (event: OgmMapCustomEvent<void>) => void;
         "onMapLoading"?: (event: OgmMapCustomEvent<void>) => void;
         "onPreviewError"?: (event: OgmMapCustomEvent<PreviewError>) => void;
@@ -508,6 +524,7 @@ declare namespace LocalJSX {
      * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        "darkBasemap"?: string;
         /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
           * @default false
@@ -517,6 +534,7 @@ declare namespace LocalJSX {
           * Which result to bring forward, as either its place in the list counted from one or the id of the record - or of the resource a previewer draws - that it came from. An attribute hands over a string for either, since an attribute is always one.  The marker changes color and comes to the front, and the result's own extent is drawn around it. The camera doesn't move: something on the page has said which result matters, not where to look.  A reader's pointer over a number does the same thing without being asked, so both can be true at once - of two different results, if a page names one while the pointer is over another. Each is a way of saying the same thing about a row, so each gets the same drawing; see draw.
          */
         "highlighted"?: number | string;
+        "lightBasemap"?: string;
         "onBoundsChange"?: (event: OgmOverviewCustomEvent<[number, number, number, number]>) => void;
         /**
           * Which result the reader's pointer is over: its place in the list counted from one, and the id of the record - or of the resource a previewer draws - it came from. Null once the pointer has left every number.  Both terms, because a page holds its results in one or the other, and either is enough to light up the row the reader is pointing at - which is the whole of what this is for:    overview.addEventListener('highlightChange', event => mark(event.detail?.id));  The reader's own pointer only. Setting `highlighted` doesn't come back out: a page that has said which result matters already knows, and reporting it would be a loop waiting to be wired.
@@ -542,6 +560,8 @@ declare namespace LocalJSX {
         "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "previewer"?: AnyPreviewer;
         "sidebarPadding"?: number;
         /**
@@ -550,6 +570,8 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmPreviews {
+        "darkBasemap"?: string;
+        "lightBasemap"?: string;
         "onPreviewsLoaded"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "onPreviewsLoading"?: (event: OgmPreviewsCustomEvent<void>) => void;
         "previewers"?: AnyPreviewer[];
@@ -570,10 +592,12 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmViewer {
+        "darkBasemap"?: string;
         /**
           * @default false
          */
         "hideTitle"?: boolean;
+        "lightBasemap"?: string;
         "recordUrl"?: string;
         "requestTransform"?: RequestTransform;
         /**
@@ -600,10 +624,14 @@ declare namespace LocalJSX {
     }
     interface OgmLocatorAttributes {
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "recordUrl": string;
     }
     interface OgmMapAttributes {
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "padding": number;
     }
     interface OgmMenubarAttributes {
@@ -616,6 +644,8 @@ declare namespace LocalJSX {
     }
     interface OgmOverviewAttributes {
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "highlighted": string;
         "geosearch": boolean;
         "searchHelpText": string;
@@ -624,10 +654,14 @@ declare namespace LocalJSX {
     }
     interface OgmPreviewAttributes {
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "sidebarPadding": number;
     }
     interface OgmPreviewsAttributes {
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "sidebarPadding": number;
     }
     interface OgmSidebarAttributes {
@@ -637,6 +671,8 @@ declare namespace LocalJSX {
     interface OgmViewerAttributes {
         "recordUrl": string;
         "theme": 'light' | 'dark';
+        "darkBasemap": string;
+        "lightBasemap": string;
         "hideTitle": boolean;
     }
 

--- a/src/components/ogm-locator/ogm-locator.test.tsx
+++ b/src/components/ogm-locator/ogm-locator.test.tsx
@@ -12,7 +12,7 @@ import { adoptWebAwesomeTheme } from '../../lib/init';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
+import MapLibreTheme, { darkBasemapStyle, resolveBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw one location on, to be pointed at it, and to hang the three
 // controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
@@ -128,6 +128,8 @@ type Locator = HTMLElement & {
   previewer?: LocationPreviewer;
   recordUrl?: string;
   theme: 'light' | 'dark';
+  darkBasemap?: string;
+  lightBasemap?: string;
   map: FakeMap;
   mapTheme: MapLibreTheme;
   mapStyleLoaded: boolean;
@@ -430,6 +432,20 @@ describe('ogm-locator', () => {
     await el.handleStyleLoad();
 
     expect(drawn(map)).toEqual(['one-location-fill', 'one-location-outline']);
+  });
+
+  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to any
+  // style document - and each mode's override is independent of the other's.
+  it('swaps in a caller’s own basemap for the mode it names one for', async () => {
+    const { el, map } = await renderLocator();
+
+    el.theme = 'dark';
+    el.darkBasemap = 'voyager';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    expect(map.setStyle).toHaveBeenCalledWith(resolveBasemapStyle('voyager'));
   });
 
   it('takes its map down with it', async () => {

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -33,6 +33,10 @@ import MapLibreTheme from '../../lib/themes/maplibre';
 export class OgmLocator {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() record?: OgmRecord;
   @Prop() previewer?: LocationPreviewer; // Overrides record if passed
 
@@ -72,7 +76,7 @@ export class OgmLocator {
     // Taken back off the page while we waited, so there is nothing left to build a map in
     if (!this.el.isConnected) return;
 
-    this.mapTheme = new MapLibreTheme(container, this.theme);
+    this.mapTheme = new MapLibreTheme(container, this.theme, { darkBasemap: this.darkBasemap, lightBasemap: this.lightBasemap });
     this.map = createMap(container, this.mapTheme, {
       ...LOCATION_MAP,
       // We handle this on our own so we can start it collapsed
@@ -158,12 +162,16 @@ export class OgmLocator {
     }
   }
 
-  // When the theme changes, swap the basemap to match, then draw the same location into the style
-  // document the swap just emptied.
+  // When the theme or a basemap prop changes, swap the basemap to match, then draw the same location
+  // into the style document the swap just emptied.
   @Watch('theme')
+  @Watch('darkBasemap')
+  @Watch('lightBasemap')
   protected async onThemeChange() {
     if (!this.map) return;
     this.mapTheme.theme = this.theme;
+    this.mapTheme.darkBasemap = this.darkBasemap;
+    this.mapTheme.lightBasemap = this.lightBasemap;
 
     // Read now, while the map still knows: the document replacing this one names its own projection
     // and neither basemap names anything, so the map comes back flat unless it is put back.

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -176,6 +176,22 @@ describe('ogm-map', () => {
     expect(scope.querySelector('#map')).toBeTruthy();
   });
 
+  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to
+  // any style document - and componentDidLoad runs far enough to build the theme even though it never
+  // gets as far as a map here; see the note on renderMap above.
+  it('builds its theme with the caller’s own basemaps', async () => {
+    const container = document.createElement('div');
+    containers.push(container);
+    document.body.appendChild(container);
+    await stencilRender(<ogm-map darkBasemap="voyager" lightBasemap="https://example.com/style.json"></ogm-map>, container);
+    const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown>; mapTheme?: { darkBasemap?: string; lightBasemap?: string } };
+    await el.componentOnReady?.();
+    consoleError.mockClear();
+
+    expect(el.mapTheme?.darkBasemap).toBe('voyager');
+    expect(el.mapTheme?.lightBasemap).toBe('https://example.com/style.json');
+  });
+
   // Left to itself MapLibre fits bounds to the very edges of the canvas, which puts a record's own
   // edges - an index map's outermost sheets, a bounding box's corners - half off the map
   it('keeps the theme’s gap between the bounds it fits and the edge of the map', async () => {

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -32,6 +32,10 @@ export class OgmMap {
   @Element() el!: HTMLElement;
   @Prop() previewer: MapPreviewer;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() padding: number = 0;
   @Event() mapIdle: EventEmitter<void>;
   @Event() mapLoading: EventEmitter<void>;
@@ -86,7 +90,7 @@ export class OgmMap {
     // for why the host has no colors on it to read. Everything MapLibre draws is inside this element,
     // so an --ogm-* override set on the host or on the embedding page still reaches it by inheritance.
     const scope = getElement(this.el, '.container');
-    this.mapTheme = new MapLibreTheme(scope, this.theme);
+    this.mapTheme = new MapLibreTheme(scope, this.theme, { darkBasemap: this.darkBasemap, lightBasemap: this.lightBasemap });
 
     // Keep attributes outside Stencil render pipeline so that MapLibre can
     // use the HTML directly for the popup content
@@ -262,11 +266,15 @@ export class OgmMap {
     }
   }
 
-  // When the theme changes, swap the basemap to match.
+  // When the theme or a basemap prop changes, swap the basemap to match.
   @Watch('theme')
+  @Watch('darkBasemap')
+  @Watch('lightBasemap')
   async onThemeChange() {
     if (!this.map) return;
     this.mapTheme.theme = this.theme;
+    this.mapTheme.darkBasemap = this.darkBasemap;
+    this.mapTheme.lightBasemap = this.lightBasemap;
     // The popup reads from sources setStyle is about to drop, so it goes first
     this.destroyPopup();
     // The panel is still on screen over the window this opens, and a layer can't be styled inside it

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -14,7 +14,7 @@ import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
 import { HIGHLIGHT_BOUNDS, markerImageId, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
-import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
+import MapLibreTheme, { darkBasemapStyle, resolveBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
 // controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
@@ -165,6 +165,8 @@ type Overview = HTMLElement & {
   records?: OgmRecord[];
   previewers?: (LocationPreviewer | undefined)[];
   theme: 'light' | 'dark';
+  darkBasemap?: string;
+  lightBasemap?: string;
   map: FakeMap;
   mapTheme: MapLibreTheme;
   mapStyleLoaded: boolean;
@@ -1288,6 +1290,20 @@ describe('ogm-overview theme', () => {
     await el.handleStyleLoad();
 
     expect(layerIds(map)).toEqual(ALL_LAYERS);
+  });
+
+  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to any
+  // style document - and each mode's override is independent of the other's.
+  it('swaps in a caller’s own basemap for the mode it names one for', async () => {
+    const { el, map } = await renderOverview();
+
+    el.theme = 'dark';
+    el.darkBasemap = 'voyager';
+    const swapped = el.onThemeChange();
+    map.fire('style.load');
+    await swapped;
+
+    expect(map.setStyle).toHaveBeenCalledWith(resolveBasemapStyle('voyager'));
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -47,6 +47,10 @@ const MIN_SEARCH_DRAG = 3;
 export class OgmOverview {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() records?: OgmRecord[];
 
   // Holes and all, because that is what `locationsFor` hands back: a record with nothing to place it
@@ -172,7 +176,7 @@ export class OgmOverview {
     // Taken back off the page while we waited, so there is nothing left to build a map in
     if (!this.el.isConnected) return;
 
-    this.mapTheme = new MapLibreTheme(container, this.theme);
+    this.mapTheme = new MapLibreTheme(container, this.theme, { darkBasemap: this.darkBasemap, lightBasemap: this.lightBasemap });
 
     // What the camera should be looking at, worked out before there is a camera
     this.readSearchFilter();
@@ -418,12 +422,16 @@ export class OgmOverview {
     this.draw();
   }
 
-  // When the theme changes, swap the basemap to match, then draw the same results into the style
-  // document the swap just emptied.
+  // When the theme or a basemap prop changes, swap the basemap to match, then draw the same results
+  // into the style document the swap just emptied.
   @Watch('theme')
+  @Watch('darkBasemap')
+  @Watch('lightBasemap')
   protected async onThemeChange() {
     if (!this.map) return;
     this.mapTheme.theme = this.theme;
+    this.mapTheme.darkBasemap = this.darkBasemap;
+    this.mapTheme.lightBasemap = this.lightBasemap;
 
     // Read now, while the map still knows: the document replacing this one names its own projection
     // and neither basemap names anything, so the map comes back flat unless it is put back.

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -13,6 +13,11 @@ import type { PreviewError } from '../../lib/errors';
 export class OgmPreview {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // Only reaches the map preview below - an image preview has no basemap to apply it to.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() previewer: AnyPreviewer;
   @Prop() sidebarPadding: number;
   @State() error?: PreviewError;
@@ -40,7 +45,7 @@ export class OgmPreview {
     if (this.previewer.renderer === 'image') {
       return <ogm-image theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-image>;
     }
-    return <ogm-map theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-map>;
+    return <ogm-map theme={this.theme} darkBasemap={this.darkBasemap} lightBasemap={this.lightBasemap} previewer={this.previewer} padding={this.sidebarPadding}></ogm-map>;
   }
 
   // No scope on an element of our own, unlike the components below: nothing we draw reads a color -

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -18,6 +18,10 @@ import type { RequestTransform } from '../../lib/request';
 export class OgmPreviews {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() record?: OgmRecord;
   // Previews to show, for an application that builds its own rather than handing over a record - the
   // tab strip is worth having either way. Takes the place of `record`, which is then not read at all.
@@ -102,7 +106,13 @@ export class OgmPreviews {
           ))}
           {tabs.map((previewer, idx) => (
             <wa-tab-panel key={`panel-${previewer.previewId}`} name={previewer.previewId} active={idx === 0}>
-              <ogm-preview theme={this.theme} previewer={previewer} sidebar-padding={this.sidebarPadding}></ogm-preview>
+              <ogm-preview
+                theme={this.theme}
+                darkBasemap={this.darkBasemap}
+                lightBasemap={this.lightBasemap}
+                previewer={previewer}
+                sidebar-padding={this.sidebarPadding}
+              ></ogm-preview>
             </wa-tab-panel>
           ))}
         </wa-tab-group>

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -14,6 +14,10 @@ export class OgmViewer {
   @Element() el!: HTMLElement;
   @Prop() recordUrl: string;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
+  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
+  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  @Prop() darkBasemap?: string;
+  @Prop() lightBasemap?: string;
   @Prop() hideTitle: boolean = false;
   // Applied to the record fetch itself, and passed down to every resource built from it - see
   // Resource.requestTransform. A DOM property, like previewer on <ogm-preview>: set it before or
@@ -104,7 +108,14 @@ export class OgmViewer {
             {this.error ? (
               <ogm-alerts theme={this.theme} error={this.error}></ogm-alerts>
             ) : (
-              <ogm-previews theme={this.theme} record={this.record} requestTransform={this.requestTransform} sidebar-padding={this.sidebarPadding}></ogm-previews>
+              <ogm-previews
+                theme={this.theme}
+                darkBasemap={this.darkBasemap}
+                lightBasemap={this.lightBasemap}
+                record={this.record}
+                requestTransform={this.requestTransform}
+                sidebar-padding={this.sidebarPadding}
+              ></ogm-previews>
             )}
           </div>
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export { default as WmtsPreviewer } from './lib/previewers/wmts';
 
 // What a preview is drawn with, and what a failed one reports
 export { default as Theme } from './lib/themes/theme';
-export { default as MapLibreTheme, darkBasemapStyle, lightBasemapStyle, type MapLibreStyle } from './lib/themes/maplibre';
+export { default as MapLibreTheme, darkBasemapStyle, lightBasemapStyle, resolveBasemapStyle, type MapLibreStyle } from './lib/themes/maplibre';
 export { isLayerDrawn, resolveLayerState, type Layer, type LayerControl, type LayerState, type PreviewStyleLayer } from './lib/layers';
 export type { LegendEntry } from './lib/legend';
 

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@stencil/vitest';
 
 import { atLightness, contrastColor, shiftLightness } from './color';
-import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle } from './maplibre';
+import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle, resolveBasemapStyle } from './maplibre';
 
 // A theme reading from an element carrying the given custom properties.
 //
@@ -9,11 +9,11 @@ import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle } from './maplibre';
 // custom property declared on the element itself but does not inherit one down the tree. Reaching in
 // from an ancestor - which is how an embedding app actually sets these - is CSS inheritance doing its
 // job, so it belongs in a browser rather than here.
-const themed = (theme: 'light' | 'dark' | undefined, tokens: Record<string, string> = {}) => {
+const themed = (theme: 'light' | 'dark' | undefined, tokens: Record<string, string> = {}, basemaps?: { darkBasemap?: string; lightBasemap?: string }) => {
   const el = document.createElement('div');
   Object.entries(tokens).forEach(([name, value]) => el.style.setProperty(name, value));
   document.body.appendChild(el);
-  return new MapLibreTheme(el, theme);
+  return new MapLibreTheme(el, theme, basemaps);
 };
 
 describe('MapLibreTheme', () => {
@@ -243,6 +243,36 @@ describe('MapLibreTheme', () => {
 
       expect(new MapLibreTheme(el).getBaseMapStyle()).toBe(darkBasemapStyle);
       expect(new MapLibreTheme(document.createElement('div')).getBaseMapStyle()).toBe(lightBasemapStyle);
+    });
+
+    // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to
+    // any style document. Each mode takes its override independently, the same as an --ogm-* color.
+    it('prefers an app’s own basemap for the mode it named one for', () => {
+      const custom = themed('dark', {}, { darkBasemap: 'voyager', lightBasemap: 'https://example.com/light.json' });
+      expect(custom.getBaseMapStyle()).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json');
+
+      custom.theme = 'light';
+      expect(custom.getBaseMapStyle()).toBe('https://example.com/light.json');
+    });
+
+    it('falls back to our own default for a mode nothing was named for', () => {
+      const custom = themed('dark', {}, { lightBasemap: 'voyager' });
+
+      expect(custom.getBaseMapStyle()).toBe(darkBasemapStyle);
+    });
+  });
+
+  describe('resolveBasemapStyle', () => {
+    it('expands a bare CARTO name to that style’s URL', () => {
+      expect(resolveBasemapStyle('voyager')).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json');
+      expect(resolveBasemapStyle('dark-matter-nolabels')).toBe('https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json');
+    });
+
+    // A caller who already has a URL - CARTO's own or anyone else's - gets it back untouched, rather
+    // than having it read as a name and rewritten into something else.
+    it('passes a URL through untouched', () => {
+      expect(resolveBasemapStyle(lightBasemapStyle)).toBe(lightBasemapStyle);
+      expect(resolveBasemapStyle('https://api.maptiler.com/maps/basic-v2/style.json?key=abc123')).toBe('https://api.maptiler.com/maps/basic-v2/style.json?key=abc123');
     });
   });
 });

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -37,9 +37,27 @@ export type MapLibreStyle = {
   overviewPadding: number;
 };
 
-// URLs to MapLibre style documents for basemaps
-export const darkBasemapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
-export const lightBasemapStyle = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+// A CARTO basemap name ('positron', 'dark-matter', 'voyager', or either with '-nolabels'), turned
+// into the GL style URL it's short for.
+const cartoBasemapStyle = (name: string): string => `https://basemaps.cartocdn.com/gl/${name}-gl-style/style.json`;
+
+// URLs to MapLibre style documents for our own default basemaps
+export const darkBasemapStyle = cartoBasemapStyle('dark-matter');
+export const lightBasemapStyle = cartoBasemapStyle('positron');
+
+// A bare basemap name looks like this - lowercase letters and hyphens, none of what a URL would
+// have to have: a scheme, a slash, a dot. See resolveBasemapStyle.
+const CARTO_NAME = /^[a-z][a-z-]*$/;
+
+/**
+ * What an app handed us for a basemap - one of CARTO's own style names, or a URL to any MapLibre
+ * style document - turned into whatever a map's `style` can be set to.
+ *
+ * Only something that reads as a bare name is expanded; anything else, including a URL that happens
+ * to point at one of CARTO's own styles, is passed through untouched. A caller who already has the
+ * full URL - CARTO's or anyone else's - never has it rewritten under them.
+ */
+export const resolveBasemapStyle = (basemap: string): string => (CARTO_NAME.test(basemap) ? cartoBasemapStyle(basemap) : basemap);
 
 // What a result's number is drawn in when neither an app nor the palette has said. A CSS font stack,
 // unlike the glyph name below: the numbers are drawn into an image of our own rather than handed to
@@ -83,6 +101,19 @@ const textColorLight = '#101219';
 
 // Style properties common to all MapLibre-based previewers
 export default class MapLibreTheme extends Theme {
+  // An app's own basemap for this mode - a CARTO name or a URL, read the same way resolveBasemapStyle
+  // reads them - or undefined to keep this library's own CARTO default. Mutable for the same reason
+  // `theme` is: a component whose basemap prop changes writes straight back in, rather than
+  // rebuilding the theme from scratch.
+  darkBasemap?: string;
+  lightBasemap?: string;
+
+  constructor(element: Element, theme?: 'light' | 'dark', basemaps: { darkBasemap?: string; lightBasemap?: string } = {}) {
+    super(element, theme);
+    this.darkBasemap = basemaps.darkBasemap;
+    this.lightBasemap = basemaps.lightBasemap;
+  }
+
   /**
    * How previewed data is drawn. Every value here can be overridden by setting the matching
    * `--ogm-*` custom property on the component or anything above it - custom properties inherit
@@ -139,9 +170,12 @@ export default class MapLibreTheme extends Theme {
     return this.readCssNumber('--ogm-overview-padding', defaultOverviewPadding);
   }
 
-  // Get the appropriate basemap style URL based on dark mode
+  // The basemap style URL for the current mode: an app's own, if it named one for this mode - see
+  // resolveBasemapStyle - or our own CARTO default.
   getBaseMapStyle(): string {
-    return this.darkMode() ? darkBasemapStyle : lightBasemapStyle;
+    const darkMode = this.darkMode();
+    const override = darkMode ? this.darkBasemap : this.lightBasemap;
+    return override ? resolveBasemapStyle(override) : darkMode ? darkBasemapStyle : lightBasemapStyle;
   }
 
   // The outline for a color, unless an app named one. Derived rather than themed, because the


### PR DESCRIPTION
## Summary

- Adds `darkBasemap`/`lightBasemap` props (`dark-basemap`/`light-basemap` attributes) for customizing the basemap used in each mode, as requested in [#196](https://github.com/OpenGeoMetadata/ogm-viewer/issues/196).
- Each accepts either a CARTO style name for convenience (`positron`, `dark-matter`, `voyager`, or any of those with `-nolabels`) or a URL to any MapLibre style document.
- `MapLibreTheme` gained a `resolveBasemapStyle()` helper and constructor overrides for this; the prop is threaded through every component that builds a `MapLibreTheme` - `ogm-map`, `ogm-locator`, and `ogm-overview` - and through `ogm-viewer` → `ogm-previews` → `ogm-preview` so it can be set once at the top of the chain. Each component's existing theme-swap watcher now also fires on a basemap change, so setting it after the map is already up still restyles it live.
- Documented in the readme under a new "Basemaps" section.

## Test plan

- [x] `npm run lint` (tsc + prettier) passes
- [x] `npm test` passes (1092 tests, including new/updated coverage in `maplibre.test.tsx`, `ogm-map.test.tsx`, `ogm-locator.test.tsx`, `ogm-overview.test.tsx`)
- [x] Verified live in a browser via the dev server: swapped `<ogm-viewer>`'s basemap between a CARTO name and a full CARTO URL in both light and dark mode, and confirmed `<ogm-overview>` picks up the same prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)