### PR TITLE
Make cooperative gestures configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,14 @@ document.querySelector('ogm-previews').previewers = [new GeoJsonPreviewer(geoJso
 
 `record` and `previewers` are DOM properties too. Neither component has an intrinsic size, so the embedding page should set it via CSS.
 
+#### Cooperative gestures
+
+`<ogm-preview>`, `<ogm-locator>`, and `<ogm-overview>` all require a reader to hold Ctrl (⌘ on a Mac) to zoom the map with the scroll wheel, and a second finger to pan it on a touchscreen, so that a map sitting inside a page doesn't steal the scroll a reader meant for the page around it. Set `cooperative-gestures` to `false` on any of them to turn this off and answer to the wheel and a single touch right away:
+
+```html
+<ogm-locator record-url="https://example.com/record.json" cooperative-gestures="false"></ogm-locator>
+```
+
 #### Locator maps
 
 To show where a single record is on earth, you can use the `<ogm-locator>` component. Give it a `record-url` and it fetches and draws that record's full geometry (`locn_geometry`) or its bounding box (`dcat_bbox`) if there's no geometry available - the same URL and format `<ogm-viewer>` takes:

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -67,6 +67,11 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmLocator {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures": boolean;
         "darkBasemap"?: string;
         "lightBasemap"?: string;
         "previewer"?: LocationPreviewer;
@@ -78,6 +83,11 @@ export namespace Components {
         "theme": 'light' | 'dark';
     }
     interface OgmMap {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures": boolean;
         "darkBasemap"?: string;
         "easeMapTo": (options: maplibregl.EaseToOptions) => Promise<maplibregl.Map>;
         "lightBasemap"?: string;
@@ -117,6 +127,11 @@ export namespace Components {
      * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures": boolean;
         "darkBasemap"?: string;
         /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
@@ -148,6 +163,10 @@ export namespace Components {
         "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
+        /**
+          * @default true
+         */
+        "cooperativeGestures": boolean;
         "darkBasemap"?: string;
         "lightBasemap"?: string;
         "previewer": AnyPreviewer;
@@ -471,6 +490,11 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmLocator {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures"?: boolean;
         "darkBasemap"?: string;
         "lightBasemap"?: string;
         "previewer"?: LocationPreviewer;
@@ -482,6 +506,11 @@ declare namespace LocalJSX {
         "theme"?: 'light' | 'dark';
     }
     interface OgmMap {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures"?: boolean;
         "darkBasemap"?: string;
         "lightBasemap"?: string;
         "onMapIdle"?: (event: OgmMapCustomEvent<void>) => void;
@@ -524,6 +553,11 @@ declare namespace LocalJSX {
      * pointed at actually is. For a single record on a map of its own, see <ogm-locator>.
      */
     interface OgmOverview {
+        /**
+          * Whether a wheel needs the command key, and a touch drag needs a second finger, before either reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map embedded in a page must not eat the scroll a reader meant for the page around it. A page that gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+          * @default true
+         */
+        "cooperativeGestures"?: boolean;
         "darkBasemap"?: string;
         /**
           * Whether a reader can search the map by holding shift and dragging a box over it. The area they drew is reported through `boundsChange`; nothing here answers it, because what a new area means is the embedding page's to say. The help text is a prop because GeoBlacklight runs the strings for the control this replaces through Rails I18n.
@@ -560,6 +594,10 @@ declare namespace LocalJSX {
         "viewBounds"?: maplibregl.LngLatBoundsLike | string;
     }
     interface OgmPreview {
+        /**
+          * @default true
+         */
+        "cooperativeGestures"?: boolean;
         "darkBasemap"?: string;
         "lightBasemap"?: string;
         "previewer"?: AnyPreviewer;
@@ -627,12 +665,14 @@ declare namespace LocalJSX {
         "darkBasemap": string;
         "lightBasemap": string;
         "recordUrl": string;
+        "cooperativeGestures": boolean;
     }
     interface OgmMapAttributes {
         "theme": 'light' | 'dark';
         "darkBasemap": string;
         "lightBasemap": string;
         "padding": number;
+        "cooperativeGestures": boolean;
     }
     interface OgmMenubarAttributes {
         "theme": 'light' | 'dark';
@@ -651,12 +691,14 @@ declare namespace LocalJSX {
         "searchHelpText": string;
         "searchBounds": maplibregl.LngLatBoundsLike | string;
         "viewBounds": maplibregl.LngLatBoundsLike | string;
+        "cooperativeGestures": boolean;
     }
     interface OgmPreviewAttributes {
         "theme": 'light' | 'dark';
         "darkBasemap": string;
         "lightBasemap": string;
         "sidebarPadding": number;
+        "cooperativeGestures": boolean;
     }
     interface OgmPreviewsAttributes {
         "theme": 'light' | 'dark';

--- a/src/components/ogm-locator/ogm-locator.test.tsx
+++ b/src/components/ogm-locator/ogm-locator.test.tsx
@@ -28,6 +28,9 @@ class FakeMap {
   style = { stylesheet: undefined as unknown, tileManagers: {} as Record<string, unknown> };
   keyboard = { disableRotation: vi.fn() };
   touchZoomRotate = { disableRotation: vi.fn() };
+
+  // Enough of the cooperative-gestures handler to be switched on and off
+  cooperativeGestures = { enable: vi.fn(), disable: vi.fn() };
   controls: { control: any; position?: string; element: HTMLElement }[] = [];
   listeners: Record<string, ((event: unknown) => void)[]> = {};
   onceListeners: Record<string, ((event: unknown) => void)[]> = {};
@@ -130,6 +133,7 @@ type Locator = HTMLElement & {
   theme: 'light' | 'dark';
   darkBasemap?: string;
   lightBasemap?: string;
+  cooperativeGestures: boolean;
   map: FakeMap;
   mapTheme: MapLibreTheme;
   mapStyleLoaded: boolean;
@@ -142,6 +146,7 @@ type Locator = HTMLElement & {
   opening: () => maplibregl.LngLatBoundsLike;
   onRecordChange: () => Promise<void>;
   onThemeChange: () => Promise<void>;
+  onCooperativeGesturesChange: () => void;
   componentDidLoad: () => Promise<void>;
 };
 
@@ -560,6 +565,29 @@ describe('ogm-locator controls', () => {
     expect(attribution.element.classList.contains('maplibregl-compact')).toBe(true);
     expect(attribution.element.classList.contains('maplibregl-compact-show')).toBe(false);
     expect(attribution.element.textContent).toContain('CARTO');
+  });
+});
+
+describe('ogm-locator cooperative gestures', () => {
+  it('is on by default', async () => {
+    const { el } = await renderLocator();
+    expect(el.cooperativeGestures).toBe(true);
+  });
+
+  it('answers a wheel or a single touch right away only once turned off', async () => {
+    const { el, map } = await renderLocator();
+    el.cooperativeGestures = false;
+    el.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.disable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.enable).not.toHaveBeenCalled();
+
+    map.cooperativeGestures.disable.mockClear();
+    el.cooperativeGestures = true;
+    el.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.enable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.disable).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -43,6 +43,14 @@ export class OgmLocator {
   // A URL to fetch an Aardvark record from - the same one <ogm-viewer> takes. Sets `record`.
   @Prop() recordUrl?: string;
 
+  /**
+   * Whether a wheel needs the command key, and a touch drag needs a second finger, before either
+   * reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map
+   * embedded in a page must not eat the scroll a reader meant for the page around it. A page that
+   * gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+   */
+  @Prop() cooperativeGestures: boolean = true;
+
   private map: maplibregl.Map;
   private mapTheme: MapLibreTheme;
 
@@ -79,6 +87,7 @@ export class OgmLocator {
     this.mapTheme = new MapLibreTheme(container, this.theme, { darkBasemap: this.darkBasemap, lightBasemap: this.lightBasemap });
     this.map = createMap(container, this.mapTheme, {
       ...LOCATION_MAP,
+      cooperativeGestures: this.cooperativeGestures,
       // We handle this on our own so we can start it collapsed
       attributionControl: false,
       // Already looking at the record, rather than at the world
@@ -181,6 +190,15 @@ export class OgmLocator {
     await setBasemap(this.map, this.mapTheme);
     // style.load has already fired by the time this resolves, and it draws - so there is nothing
     // to do here but let it. Kept as an await so a caller can wait for the swap to finish.
+  }
+
+  // A reader gets the changed answer from here on; the handler needs nothing rebuilt to give it, so
+  // there's no draw or frame to redo the way a theme swap needs.
+  @Watch('cooperativeGestures')
+  protected onCooperativeGesturesChange() {
+    if (!this.map) return;
+    if (this.cooperativeGestures) this.map.cooperativeGestures.enable();
+    else this.map.cooperativeGestures.disable();
   }
 
   // Put the record's location on the map, and point the map at it

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -267,4 +267,29 @@ describe('ogm-map', () => {
 
     expect(consoleError).not.toHaveBeenCalled();
   });
+
+  it('holds cooperative gestures on by default', async () => {
+    const { el } = await renderMap();
+    expect((el as unknown as { cooperativeGestures: boolean }).cooperativeGestures).toBe(true);
+  });
+
+  it('answers a wheel or a single touch right away only once turned off', async () => {
+    const { el } = await renderMap();
+    const map = { cooperativeGestures: { enable: vi.fn(), disable: vi.fn() }, remove: vi.fn() };
+    Object.assign(el, { map });
+    const withCooperativeGestures = el as unknown as { cooperativeGestures: boolean; onCooperativeGesturesChange: () => void };
+
+    withCooperativeGestures.cooperativeGestures = false;
+    withCooperativeGestures.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.disable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.enable).not.toHaveBeenCalled();
+
+    map.cooperativeGestures.disable.mockClear();
+    withCooperativeGestures.cooperativeGestures = true;
+    withCooperativeGestures.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.enable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.disable).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -37,6 +37,15 @@ export class OgmMap {
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() padding: number = 0;
+
+  /**
+   * Whether a wheel needs the command key, and a touch drag needs a second finger, before either
+   * reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map
+   * embedded in a page must not eat the scroll a reader meant for the page around it. A page that
+   * gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+   */
+  @Prop() cooperativeGestures: boolean = true;
+
   @Event() mapIdle: EventEmitter<void>;
   @Event() mapLoading: EventEmitter<void>;
   @Event() previewError: EventEmitter<PreviewError>;
@@ -107,7 +116,7 @@ export class OgmMap {
 
     this.map = createMap(container, this.mapTheme, {
       minZoom: 1,
-      cooperativeGestures: true,
+      cooperativeGestures: this.cooperativeGestures,
       // Read fresh on every request rather than captured once, so it always reflects whichever
       // previewer is currently attached - including across onPreviewerChange, with no watcher of
       // our own needed. Applies to the basemap's own style/glyphs/sprites too, not just this
@@ -282,6 +291,15 @@ export class OgmMap {
     await setBasemap(this.map, this.mapTheme);
     // The same preview, drawn again into the style document the swap just emptied
     await this.loadPreview();
+  }
+
+  // A reader gets the changed answer from here on; the handler needs nothing rebuilt to give it, so
+  // there's no draw or frame to redo the way a theme swap needs.
+  @Watch('cooperativeGestures')
+  onCooperativeGesturesChange() {
+    if (!this.map) return;
+    if (this.cooperativeGestures) this.map.cooperativeGestures.enable();
+    else this.map.cooperativeGestures.disable();
   }
 
   // Surface MapLibre errors tied to the current preview, skipping the noise from basemap/glyph/

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -37,6 +37,9 @@ class FakeMap {
   // Enough of the box-zoom handler to be switched on and off, and to have been caught mid-gesture
   boxZoom = { enable: vi.fn(), disable: vi.fn(), isEnabled: vi.fn(() => true), isActive: vi.fn(() => false), reset: vi.fn() };
 
+  // Enough of the cooperative-gestures handler to be switched on and off
+  cooperativeGestures = { enable: vi.fn(), disable: vi.fn() };
+
   // Written and read back, rather than recorded: which projection the map is in is what decides
   // whether the camera clamps, and the globe button's own state is read straight off it
   projection: { type: string } | undefined = undefined;
@@ -177,6 +180,7 @@ type Overview = HTMLElement & {
   viewBounds?: number[] | string;
   geosearch: boolean;
   searchHelpText: string;
+  cooperativeGestures: boolean;
   addControls: () => void;
   followPointer: () => void;
   handleStyleLoad: () => Promise<void>;
@@ -192,6 +196,7 @@ type Overview = HTMLElement & {
   onHighlightedChange: () => void;
   onGeosearchChange: () => void;
   onSearchHelpTextChange: () => void;
+  onCooperativeGesturesChange: () => void;
   onThemeChange: () => Promise<void>;
   componentDidLoad: () => Promise<void>;
 };
@@ -1268,6 +1273,29 @@ describe('ogm-overview geosearch', () => {
     expect(areas).toEqual([]);
     expect(consoleWarn).toHaveBeenCalled();
     consoleWarn.mockRestore();
+  });
+});
+
+describe('ogm-overview cooperative gestures', () => {
+  it('is on by default', async () => {
+    const { el } = await renderOverview();
+    expect(el.cooperativeGestures).toBe(true);
+  });
+
+  it('answers a wheel or a single touch right away only once turned off', async () => {
+    const { el, map } = await renderOverview();
+    el.cooperativeGestures = false;
+    el.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.disable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.enable).not.toHaveBeenCalled();
+
+    map.cooperativeGestures.disable.mockClear();
+    el.cooperativeGestures = true;
+    el.onCooperativeGesturesChange();
+
+    expect(map.cooperativeGestures.enable).toHaveBeenCalled();
+    expect(map.cooperativeGestures.disable).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -107,6 +107,14 @@ export class OgmOverview {
    */
   @Prop() viewBounds?: maplibregl.LngLatBoundsLike | string;
 
+  /**
+   * Whether a wheel needs the command key, and a touch drag needs a second finger, before either
+   * reaches the map - see MapLibre's CooperativeGesturesHandler. On by default, since a small map
+   * embedded in a page must not eat the scroll a reader meant for the page around it. A page that
+   * gives the map the whole screen, or has its own way of keeping the two apart, can turn it off.
+   */
+  @Prop() cooperativeGestures: boolean = true;
+
   // Where the reader has asked to search, as the west, south, east, north degrees a query states -
   // see boundsToBbox. Nothing here answers it: what a new area means is the embedding page's to say.
   @Event() boundsChange: EventEmitter<[number, number, number, number]>;
@@ -185,6 +193,7 @@ export class OgmOverview {
 
     this.map = createMap(container, this.mapTheme, {
       ...LOCATION_MAP,
+      cooperativeGestures: this.cooperativeGestures,
       boxZoom: { boxZoomEnd: (_map, start, end) => this.search(start, end) },
       minZoom: 1,
       ...openingLocation(container, this.mapTheme, this.target(), this.projection === 'globe', this.camera()),
@@ -441,6 +450,15 @@ export class OgmOverview {
     await setBasemap(this.map, this.mapTheme);
     // style.load has already fired by the time this resolves, and it draws - so there is nothing
     // to do here but let it. Kept as an await so a caller can wait for the swap to finish.
+  }
+
+  // A reader gets the changed answer from here on; the handler needs nothing rebuilt to give it, so
+  // there's no draw or frame to redo the way a theme swap needs.
+  @Watch('cooperativeGestures')
+  protected onCooperativeGesturesChange() {
+    if (!this.map) return;
+    if (this.cooperativeGestures) this.map.cooperativeGestures.enable();
+    else this.map.cooperativeGestures.disable();
   }
 
   // Everything, in the order it has to happen: what area is being searched, where the results are,

--- a/src/components/ogm-preview/ogm-preview.test.tsx
+++ b/src/components/ogm-preview/ogm-preview.test.tsx
@@ -58,6 +58,21 @@ describe('ogm-preview', () => {
     expect(shadowRoot.querySelector('ogm-map')).toBeNull();
   });
 
+  it('passes cooperative gestures on to the map, on by default', async () => {
+    const el = await renderPreview(mapPreviewer());
+    const map = (el.shadowRoot as ShadowRoot).querySelector('ogm-map') as HTMLElement & { cooperativeGestures: boolean };
+    expect(map.cooperativeGestures).toBe(true);
+  });
+
+  it('turns the map’s cooperative gestures off when asked to', async () => {
+    const el = await renderPreview(mapPreviewer());
+    (el as unknown as { cooperativeGestures: boolean }).cooperativeGestures = false;
+    await flush();
+
+    const map = (el.shadowRoot as ShadowRoot).querySelector('ogm-map') as HTMLElement & { cooperativeGestures: boolean };
+    expect(map.cooperativeGestures).toBe(false);
+  });
+
   it('shows the error over the preview when a previewError is reported', async () => {
     const el = await renderPreview(mapPreviewer());
     const error = referenceError(new TypeError('Failed to fetch'), 'GeoJSON', 'http://example.com/data.json');

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -20,6 +20,7 @@ export class OgmPreview {
   @Prop() lightBasemap?: string;
   @Prop() previewer: AnyPreviewer;
   @Prop() sidebarPadding: number;
+  @Prop() cooperativeGestures: boolean = true;
   @State() error?: PreviewError;
 
   // Before the first frame, so nothing paints unstyled
@@ -45,7 +46,16 @@ export class OgmPreview {
     if (this.previewer.renderer === 'image') {
       return <ogm-image theme={this.theme} previewer={this.previewer} padding={this.sidebarPadding}></ogm-image>;
     }
-    return <ogm-map theme={this.theme} darkBasemap={this.darkBasemap} lightBasemap={this.lightBasemap} previewer={this.previewer} padding={this.sidebarPadding}></ogm-map>;
+    return (
+      <ogm-map
+        theme={this.theme}
+        darkBasemap={this.darkBasemap}
+        lightBasemap={this.lightBasemap}
+        previewer={this.previewer}
+        padding={this.sidebarPadding}
+        cooperativeGestures={this.cooperativeGestures}
+      ></ogm-map>
+    );
   }
 
   // No scope on an element of our own, unlike the components below: nothing we draw reads a color -

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -240,14 +240,15 @@ const cameraForBounds = (map: maplibregl.Map, bounds: maplibregl.LngLatBoundsLik
  *
  * Both of them take exactly this - a locator's one record and an overview's several - so a reader can
  * pan and zoom and nothing else. These maps are read at a glance, and one that has been turned or
- * tilted can't be compared with the next one, so neither is offered. Cooperative gestures because a
- * small map inside a page must not eat the page's scroll, which is also why both of them carry zoom
- * buttons: a wheel needs the command key once this is on. And below createMap's own floor of 2,
- * because one record can cover the world, and an extent that wide framed with a gap around it inside
- * a container this small wants a camera further out than a map of data ever does.
+ * tilted can't be compared with the next one, so neither is offered. And below createMap's own floor
+ * of 2, because one record can cover the world, and an extent that wide framed with a gap around it
+ * inside a container this small wants a camera further out than a map of data ever does.
+ *
+ * Cooperative gestures isn't in here even though both callers want it on by default: each of them
+ * offers it as a prop, so each has to be able to pass its own answer through rather than have this
+ * override it.
  */
 export const LOCATION_MAP: MapExtras = {
-  cooperativeGestures: true,
   dragRotate: false,
   touchPitch: false,
   minZoom: 1,


### PR DESCRIPTION
## Summary
- Adds a `cooperativeGestures` prop (default `true`, matching current behavior) to `<ogm-preview>`, `<ogm-overview>`, and `<ogm-locator>` — and to `<ogm-map>`, which `<ogm-preview>` delegates to for map-based previews.
- Each map reacts live to the prop via MapLibre's `cooperativeGestures.enable()`/`disable()`, the same pattern already used for `<ogm-overview>`'s `geosearch` prop.
- Documents the new prop in the readme.

Closes #168 — makes the modifier-key requirement for scroll-to-zoom configurable instead of always-on, per the discussion on that issue.

## Test plan
- [x] `npm run lint` (tsc + prettier)
- [x] `npm run build`
- [x] `npm test` (1102 tests)
- [x] Manually verified in a running dev server: by default, an unmodified scroll wheel over `<ogm-locator>`/`<ogm-overview>` is blocked and shows MapLibre's hint overlay; setting `cooperative-gestures="false"` lets the scroll wheel zoom immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)