### PR TITLE
Allow users to supply a CARTO API key for basemaps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,17 +58,23 @@ To programmatically control dark mode, you can use the `theme` attribute with a 
 
 ### Basemaps
 
-By default, the viewer draws on one of [CARTO](https://carto.com/basemaps)'s basemaps: Dark Matter in dark mode, Positron in light mode. To use a different one for either mode, set `dark-basemap` and/or `light-basemap` to one of CARTO's own style names (`positron`, `dark-matter`, `voyager`, or any of those with `-nolabels`):
-
-```html
-<ogm-viewer record-url="https://example.com/record.json" dark-basemap="voyager" light-basemap="voyager"></ogm-viewer>
-```
-
-Or set either to a URL, for a basemap of your own from CARTO or anywhere else that serves a [MapLibre style document](https://maplibre.org/maplibre-style-spec/):
+By default, the viewer draws on one of [CARTO](https://carto.com/basemaps)'s basemaps: Dark Matter in dark mode, Positron in light mode. To use a different one for either mode, set `dark-basemap` and/or `light-basemap` to a URL for a [MapLibre style document](https://maplibre.org/maplibre-style-spec/), from CARTO or anywhere else:
 
 ```html
 <ogm-viewer record-url="https://example.com/record.json" light-basemap="https://api.maptiler.com/maps/basic-v2/style.json?key=your-key"></ogm-viewer>
 ```
+
+CARTO watermarks a basemap requested without an API key. If you have [your own CARTO API key](https://carto.com/basemaps/apikey/), build the full style URL yourself and pass that:
+
+```html
+<ogm-viewer
+  record-url="https://example.com/record.json"
+  dark-basemap="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json?key=your-key"
+  light-basemap="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json?key=your-key"
+></ogm-viewer>
+```
+
+You can find basemaps that don't require an API key to use offered by [OpenFreeMap](https://openfreemap.org/quick_start/).
 
 Both attributes are also DOM properties, so they can be set from JavaScript the same way `theme` can. They're supported everywhere `theme` is - `<ogm-viewer>`, `<ogm-preview>`, `<ogm-previews>`, `<ogm-map>`, `<ogm-locator>`, and `<ogm-overview>` - and GeoBlacklight uses them to let a site configure its own basemaps.
 

--- a/src/components/ogm-locator/ogm-locator.test.tsx
+++ b/src/components/ogm-locator/ogm-locator.test.tsx
@@ -12,7 +12,7 @@ import { adoptWebAwesomeTheme } from '../../lib/init';
 import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
-import MapLibreTheme, { darkBasemapStyle, resolveBasemapStyle } from '../../lib/themes/maplibre';
+import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw one location on, to be pointed at it, and to hang the three
 // controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
@@ -439,18 +439,18 @@ describe('ogm-locator', () => {
     expect(drawn(map)).toEqual(['one-location-fill', 'one-location-outline']);
   });
 
-  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to any
-  // style document - and each mode's override is independent of the other's.
+  // GeoBlacklight hands over its own basemap this way - a URL to any style document - and each
+  // mode's override is independent of the other's.
   it('swaps in a caller’s own basemap for the mode it names one for', async () => {
     const { el, map } = await renderLocator();
 
     el.theme = 'dark';
-    el.darkBasemap = 'voyager';
+    el.darkBasemap = 'https://example.com/dark.json';
     const swapped = el.onThemeChange();
     map.fire('style.load');
     await swapped;
 
-    expect(map.setStyle).toHaveBeenCalledWith(resolveBasemapStyle('voyager'));
+    expect(map.setStyle).toHaveBeenCalledWith('https://example.com/dark.json');
   });
 
   it('takes its map down with it', async () => {

--- a/src/components/ogm-locator/ogm-locator.tsx
+++ b/src/components/ogm-locator/ogm-locator.tsx
@@ -33,8 +33,8 @@ import MapLibreTheme from '../../lib/themes/maplibre';
 export class OgmLocator {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() record?: OgmRecord;

--- a/src/components/ogm-map/ogm-map.test.tsx
+++ b/src/components/ogm-map/ogm-map.test.tsx
@@ -176,20 +176,23 @@ describe('ogm-map', () => {
     expect(scope.querySelector('#map')).toBeTruthy();
   });
 
-  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to
-  // any style document - and componentDidLoad runs far enough to build the theme even though it never
-  // gets as far as a map here; see the note on renderMap above.
+  // GeoBlacklight hands over its own basemap this way - a URL to a style document for each mode -
+  // and componentDidLoad runs far enough to build the theme even though it never gets as far as a
+  // map here; see the note on renderMap above.
   it('builds its theme with the caller’s own basemaps', async () => {
     const container = document.createElement('div');
     containers.push(container);
     document.body.appendChild(container);
-    await stencilRender(<ogm-map darkBasemap="voyager" lightBasemap="https://example.com/style.json"></ogm-map>, container);
-    const el = container.firstElementChild as HTMLElement & { componentOnReady?: () => Promise<unknown>; mapTheme?: { darkBasemap?: string; lightBasemap?: string } };
+    await stencilRender(<ogm-map darkBasemap="https://example.com/dark.json" lightBasemap="https://example.com/light.json"></ogm-map>, container);
+    const el = container.firstElementChild as HTMLElement & {
+      componentOnReady?: () => Promise<unknown>;
+      mapTheme?: { darkBasemap?: string; lightBasemap?: string };
+    };
     await el.componentOnReady?.();
     consoleError.mockClear();
 
-    expect(el.mapTheme?.darkBasemap).toBe('voyager');
-    expect(el.mapTheme?.lightBasemap).toBe('https://example.com/style.json');
+    expect(el.mapTheme?.darkBasemap).toBe('https://example.com/dark.json');
+    expect(el.mapTheme?.lightBasemap).toBe('https://example.com/light.json');
   });
 
   // Left to itself MapLibre fits bounds to the very edges of the canvas, which puts a record's own

--- a/src/components/ogm-map/ogm-map.tsx
+++ b/src/components/ogm-map/ogm-map.tsx
@@ -32,8 +32,8 @@ export class OgmMap {
   @Element() el!: HTMLElement;
   @Prop() previewer: MapPreviewer;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() padding: number = 0;

--- a/src/components/ogm-overview/ogm-overview.test.tsx
+++ b/src/components/ogm-overview/ogm-overview.test.tsx
@@ -14,7 +14,7 @@ import LocationPreviewer from '../../lib/previewers/location';
 import OgmRecord, { type GeoBlacklightSchemaAardvark } from '../../lib/record';
 import LocationResource from '../../lib/resources/location';
 import { HIGHLIGHT_BOUNDS, markerImageId, RESULT_MARKERS, RESULT_NUMBERS, SEARCH_BOUNDS } from '../../lib/results';
-import MapLibreTheme, { darkBasemapStyle, resolveBasemapStyle } from '../../lib/themes/maplibre';
+import MapLibreTheme, { darkBasemapStyle } from '../../lib/themes/maplibre';
 
 // Enough of a MapLibre map to draw numbered results on, to be pointed at them, and to hang the
 // controls off. MapLibre's own controls read a good deal of this as they are added - the titles to
@@ -1320,18 +1320,18 @@ describe('ogm-overview theme', () => {
     expect(layerIds(map)).toEqual(ALL_LAYERS);
   });
 
-  // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to any
-  // style document - and each mode's override is independent of the other's.
+  // GeoBlacklight hands over its own basemap this way - a URL to any style document - and each
+  // mode's override is independent of the other's.
   it('swaps in a caller’s own basemap for the mode it names one for', async () => {
     const { el, map } = await renderOverview();
 
     el.theme = 'dark';
-    el.darkBasemap = 'voyager';
+    el.darkBasemap = 'https://example.com/dark.json';
     const swapped = el.onThemeChange();
     map.fire('style.load');
     await swapped;
 
-    expect(map.setStyle).toHaveBeenCalledWith(resolveBasemapStyle('voyager'));
+    expect(map.setStyle).toHaveBeenCalledWith('https://example.com/dark.json');
   });
 });
 

--- a/src/components/ogm-overview/ogm-overview.tsx
+++ b/src/components/ogm-overview/ogm-overview.tsx
@@ -47,8 +47,8 @@ const MIN_SEARCH_DRAG = 3;
 export class OgmOverview {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() records?: OgmRecord[];

--- a/src/components/ogm-preview/ogm-preview.tsx
+++ b/src/components/ogm-preview/ogm-preview.tsx
@@ -13,9 +13,9 @@ import type { PreviewError } from '../../lib/errors';
 export class OgmPreview {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
-  // Only reaches the map preview below - an image preview has no basemap to apply it to.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default. Only reaches the map
+  // preview below - an image preview has no basemap to apply it to.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() previewer: AnyPreviewer;

--- a/src/components/ogm-previews/ogm-previews.tsx
+++ b/src/components/ogm-previews/ogm-previews.tsx
@@ -18,8 +18,8 @@ import type { RequestTransform } from '../../lib/request';
 export class OgmPreviews {
   @Element() el!: HTMLElement;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() record?: OgmRecord;

--- a/src/components/ogm-viewer/ogm-viewer.tsx
+++ b/src/components/ogm-viewer/ogm-viewer.tsx
@@ -14,8 +14,8 @@ export class OgmViewer {
   @Element() el!: HTMLElement;
   @Prop() recordUrl: string;
   @Prop() theme: 'light' | 'dark' = initialTheme(this.el);
-  // A caller's own basemap for each mode, as a CARTO name (e.g. 'positron') or a URL to a MapLibre
-  // style document; see MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
+  // A caller's own basemap for each mode, as a URL to a MapLibre style document; see
+  // MapLibreTheme.getBaseMapStyle. Undefined keeps this library's own default.
   @Prop() darkBasemap?: string;
   @Prop() lightBasemap?: string;
   @Prop() hideTitle: boolean = false;

--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,7 @@
       }
 
       #recordUrl,
+      #basemapUrl,
       select {
         max-width: 300px;
       }
@@ -244,6 +245,24 @@
           await loadRecords([]);
         });
 
+        // Basemap URL override. Each mode remembers its own choice - matching dark-basemap/
+        // light-basemap themselves - so switching theme below shows whichever URL this mode was
+        // last given, and an empty box means this mode is still drawing the library's own default.
+        const basemapUrlInput = document.getElementById('basemapUrl');
+        const loadBasemapButton = document.getElementById('loadBasemap');
+        const basemapPerTheme = { light: undefined, dark: undefined };
+        const applyBasemaps = () => {
+          [viewer, overview, locator].forEach(el => {
+            el.lightBasemap = basemapPerTheme.light;
+            el.darkBasemap = basemapPerTheme.dark;
+          });
+        };
+
+        loadBasemapButton.addEventListener('click', () => {
+          basemapPerTheme[viewer.theme] = basemapUrlInput.value.trim() || undefined;
+          applyBasemaps();
+        });
+
         // Toggle theme button
         const toggleThemeButton = document.getElementById('toggleTheme');
         toggleThemeButton.addEventListener('click', () => {
@@ -251,6 +270,7 @@
           viewer.theme = theme;
           overview.theme = theme;
           locator.theme = theme;
+          basemapUrlInput.value = basemapPerTheme[theme] ?? '';
         });
 
         // Hide title checkbox
@@ -371,7 +391,6 @@
         <button id="clearRecord">Clear</button>
       </div>
       <div class="props">
-        <button id="toggleTheme">Toggle Theme</button>
         <button id="switch-overview">Switch to overview</button>
         <button id="switch-locator">Switch to locator</button>
         <button id="switch-viewer" style="display: none">Switch to viewer</button>
@@ -382,6 +401,11 @@
           <code id="boundsOut"></code>
           <button id="clearFilter">Clear filter</button>
         </span>
+      </div>
+      <div class="props">
+        <button id="toggleTheme">Toggle Theme</button>
+        <input type="text" id="basemapUrl" size="45" placeholder="Enter a MapLibre style document URL" />
+        <button id="loadBasemap">Load Basemap</button>
       </div>
     </div>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export { default as WmtsPreviewer } from './lib/previewers/wmts';
 
 // What a preview is drawn with, and what a failed one reports
 export { default as Theme } from './lib/themes/theme';
-export { default as MapLibreTheme, darkBasemapStyle, lightBasemapStyle, resolveBasemapStyle, type MapLibreStyle } from './lib/themes/maplibre';
+export { default as MapLibreTheme, darkBasemapStyle, lightBasemapStyle, type MapLibreStyle } from './lib/themes/maplibre';
 export { isLayerDrawn, resolveLayerState, type Layer, type LayerControl, type LayerState, type PreviewStyleLayer } from './lib/layers';
 export type { LegendEntry } from './lib/legend';
 

--- a/src/lib/themes/maplibre.test.tsx
+++ b/src/lib/themes/maplibre.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@stencil/vitest';
 
 import { atLightness, contrastColor, shiftLightness } from './color';
-import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle, resolveBasemapStyle } from './maplibre';
+import MapLibreTheme, { darkBasemapStyle, lightBasemapStyle } from './maplibre';
 
 // A theme reading from an element carrying the given custom properties.
 //
@@ -245,34 +245,20 @@ describe('MapLibreTheme', () => {
       expect(new MapLibreTheme(document.createElement('div')).getBaseMapStyle()).toBe(lightBasemapStyle);
     });
 
-    // GeoBlacklight hands over its own basemap this way - a CARTO name for convenience, or a URL to
-    // any style document. Each mode takes its override independently, the same as an --ogm-* color.
+    // GeoBlacklight hands over its own basemap this way - a URL to any style document. Each mode
+    // takes its override independently, the same as an --ogm-* color.
     it('prefers an app’s own basemap for the mode it named one for', () => {
-      const custom = themed('dark', {}, { darkBasemap: 'voyager', lightBasemap: 'https://example.com/light.json' });
-      expect(custom.getBaseMapStyle()).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json');
+      const custom = themed('dark', {}, { darkBasemap: 'https://example.com/dark.json', lightBasemap: 'https://example.com/light.json' });
+      expect(custom.getBaseMapStyle()).toBe('https://example.com/dark.json');
 
       custom.theme = 'light';
       expect(custom.getBaseMapStyle()).toBe('https://example.com/light.json');
     });
 
     it('falls back to our own default for a mode nothing was named for', () => {
-      const custom = themed('dark', {}, { lightBasemap: 'voyager' });
+      const custom = themed('dark', {}, { lightBasemap: 'https://example.com/light.json' });
 
       expect(custom.getBaseMapStyle()).toBe(darkBasemapStyle);
-    });
-  });
-
-  describe('resolveBasemapStyle', () => {
-    it('expands a bare CARTO name to that style’s URL', () => {
-      expect(resolveBasemapStyle('voyager')).toBe('https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json');
-      expect(resolveBasemapStyle('dark-matter-nolabels')).toBe('https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json');
-    });
-
-    // A caller who already has a URL - CARTO's own or anyone else's - gets it back untouched, rather
-    // than having it read as a name and rewritten into something else.
-    it('passes a URL through untouched', () => {
-      expect(resolveBasemapStyle(lightBasemapStyle)).toBe(lightBasemapStyle);
-      expect(resolveBasemapStyle('https://api.maptiler.com/maps/basic-v2/style.json?key=abc123')).toBe('https://api.maptiler.com/maps/basic-v2/style.json?key=abc123');
     });
   });
 });

--- a/src/lib/themes/maplibre.ts
+++ b/src/lib/themes/maplibre.ts
@@ -37,27 +37,9 @@ export type MapLibreStyle = {
   overviewPadding: number;
 };
 
-// A CARTO basemap name ('positron', 'dark-matter', 'voyager', or either with '-nolabels'), turned
-// into the GL style URL it's short for.
-const cartoBasemapStyle = (name: string): string => `https://basemaps.cartocdn.com/gl/${name}-gl-style/style.json`;
-
 // URLs to MapLibre style documents for our own default basemaps
-export const darkBasemapStyle = cartoBasemapStyle('dark-matter');
-export const lightBasemapStyle = cartoBasemapStyle('positron');
-
-// A bare basemap name looks like this - lowercase letters and hyphens, none of what a URL would
-// have to have: a scheme, a slash, a dot. See resolveBasemapStyle.
-const CARTO_NAME = /^[a-z][a-z-]*$/;
-
-/**
- * What an app handed us for a basemap - one of CARTO's own style names, or a URL to any MapLibre
- * style document - turned into whatever a map's `style` can be set to.
- *
- * Only something that reads as a bare name is expanded; anything else, including a URL that happens
- * to point at one of CARTO's own styles, is passed through untouched. A caller who already has the
- * full URL - CARTO's or anyone else's - never has it rewritten under them.
- */
-export const resolveBasemapStyle = (basemap: string): string => (CARTO_NAME.test(basemap) ? cartoBasemapStyle(basemap) : basemap);
+export const darkBasemapStyle = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+export const lightBasemapStyle = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
 
 // What a result's number is drawn in when neither an app nor the palette has said. A CSS font stack,
 // unlike the glyph name below: the numbers are drawn into an image of our own rather than handed to
@@ -101,10 +83,9 @@ const textColorLight = '#101219';
 
 // Style properties common to all MapLibre-based previewers
 export default class MapLibreTheme extends Theme {
-  // An app's own basemap for this mode - a CARTO name or a URL, read the same way resolveBasemapStyle
-  // reads them - or undefined to keep this library's own CARTO default. Mutable for the same reason
-  // `theme` is: a component whose basemap prop changes writes straight back in, rather than
-  // rebuilding the theme from scratch.
+  // An app's own basemap for this mode - a URL to a MapLibre style document - or undefined to keep
+  // this library's own CARTO default. Mutable for the same reason `theme` is: a component whose
+  // basemap prop changes writes straight back in, rather than rebuilding the theme from scratch.
   darkBasemap?: string;
   lightBasemap?: string;
 
@@ -170,12 +151,11 @@ export default class MapLibreTheme extends Theme {
     return this.readCssNumber('--ogm-overview-padding', defaultOverviewPadding);
   }
 
-  // The basemap style URL for the current mode: an app's own, if it named one for this mode - see
-  // resolveBasemapStyle - or our own CARTO default.
+  // The basemap style URL for the current mode: an app's own, if it named one for this mode, or our
+  // own CARTO default.
   getBaseMapStyle(): string {
     const darkMode = this.darkMode();
-    const override = darkMode ? this.darkBasemap : this.lightBasemap;
-    return override ? resolveBasemapStyle(override) : darkMode ? darkBasemapStyle : lightBasemapStyle;
+    return (darkMode ? this.darkBasemap : this.lightBasemap) ?? (darkMode ? darkBasemapStyle : lightBasemapStyle);
   }
 
   // The outline for a color, unless an app named one. Derived rather than themed, because the


### PR DESCRIPTION
This changes how basemaps are supplied to make it mandatory to supply a full URL, so you can just include an API key as the `key=` param if you have one.